### PR TITLE
Simplify steps by using powershell on both platforms to install built package.

### DIFF
--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -18,16 +18,10 @@ steps:
     displayName: build package
   #
   # Install aqtinstall
-  - bash: |
-      export AQT_VERSION=$(python $(Build.SourcesDirectory)/setup.py --version)
-      pip install $(Build.SourcesDirectory)/dist/aqtinstall-${AQT_VERSION}-py2.py3-none-any.whl
-    condition: or( eq( variables['Agent.OS'], 'Linux' ), eq( variables['Agent.OS'], 'Darwin' ))
-    displayName: install package on MacOS and Linux
   - powershell: |
       $aqtVersion = & python $(Build.SourcesDirectory)/setup.py --version | Out-String -Stream
       pip install $(Build.SourcesDirectory)/dist/aqtinstall-$aqtVersion-py2.py3-none-any.whl
-    condition: eq( variables['Agent.OS'], 'Windows_NT' )
-    displayName: install package on Windows
+    displayName: install package
   #
   # Run Aqt
   - task: PythonScript@0


### PR DESCRIPTION
Pro:

1 step instead of 2 for all platforms. Very consistent. The steps file is getting a bit bloated.

Con:

People don't usually use Powershell as their shell on macOS and Linux. The fact it is preinstalled on all Azure Pipeline runners on all the platforms is quite unusual. 


I don't know what decision to make. It's something I noticed.