### PR TITLE
Scale testing of Android Targets to just Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,47 +12,47 @@ jobs:
   strategy:
     matrix:
       QT 5.11.3 mac desktop clang_64:
-        HOST: mac
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.11.3
-        ARCHDIR: clang_64
+        HOST: mac
         TARGET: desktop
         ARCH: clang_64
-        PYTHON_VERSION: '3.7'
-      QT 5.13.0 mac android android_x86:
-        HOST: mac
-        QT_VERSION: 5.13.0
-        ARCHDIR: android_x86
-        TARGET: android
-        ARCH: android_x86
-        PYTHON_VERSION: '3.7'
-      QT 5.13.0 mac android android_armv7:
-        HOST: mac
-        QT_VERSION: 5.13.0
-        ARCHDIR: android_armv7
-        TARGET: android
-        ARCH: android_armv7
-        PYTHON_VERSION: '3.7'
+        ARCHDIR: clang_64
       QT 5.12.3 mac desktop clang_64:
-        HOST: mac
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.12.3
-        ARCHDIR: clang_64
+        HOST: mac
         TARGET: desktop
         ARCH: clang_64
-        PYTHON_VERSION: '3.7'
+        ARCHDIR: clang_64
       QT 5.13.0 mac desktop clang_64:
-        HOST: mac
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.13.0
-        ARCHDIR: clang_64
+        HOST: mac
         TARGET: desktop
         ARCH: clang_64
-        PYTHON_VERSION: '3.7'
+        ARCHDIR: clang_64
       QT 5.13.0 mac ios ios:
-        HOST: mac
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.13.0
-        ARCHDIR: ios
+        HOST: mac
         TARGET: ios
         ARCH: ios
+        ARCHDIR: ios
+      QT 5.13.0 mac android android_x86:
         PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.13.0
+        HOST: mac
+        TARGET: android
+        ARCH: android_x86
+        ARCHDIR: android_x86
+      QT 5.13.0 mac android android_armv7:
+        PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.13.0
+        HOST: mac
+        TARGET: android
+        ARCH: android_armv7
+        ARCHDIR: android_armv7
 - job: Windows
   pool:
     vmImage: vs2017-win2016
@@ -60,83 +60,83 @@ jobs:
   - template: ci/steps.yml
   strategy:
     matrix:
-      QT 5.13.0 windows desktop win64_msvc2017_64:
+      QT 5.11.3 windows desktop win64_msvc2017_64:
+        PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.11.3
         HOST: windows
-        QT_VERSION: 5.13.0
-        ARCHDIR: msvc2017_64
         TARGET: desktop
         ARCH: win64_msvc2017_64
-        PYTHON_VERSION: '3.7'
+        ARCHDIR: msvc2017_64
       QT 5.11.3 windows desktop win32_msvc2015:
-        HOST: windows
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.11.3
-        ARCHDIR: msvc2015
+        HOST: windows
         TARGET: desktop
         ARCH: win32_msvc2015
-        PYTHON_VERSION: '3.7'
-      QT 5.13.0 windows desktop win32_mingw73:
-        HOST: windows
-        QT_VERSION: 5.13.0
-        ARCHDIR: mingw73_32
-        TARGET: desktop
-        ARCH: win32_mingw73
-        PYTHON_VERSION: '3.7'
-      QT 5.13.0 windows android android_armv7:
-        HOST: windows
-        QT_VERSION: 5.13.0
-        ARCHDIR: android_armv7
-        TARGET: android
-        ARCH: android_armv7
-        PYTHON_VERSION: '3.7'
+        ARCHDIR: msvc2015
       QT 5.12.3 windows desktop win64_msvc2017_64:
-        HOST: windows
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.12.3
-        ARCHDIR: msvc2017_64
+        HOST: windows
         TARGET: desktop
         ARCH: win64_msvc2017_64
+        ARCHDIR: msvc2017_64
+      QT 5.12.3 windows desktop win32_msvc2017:
         PYTHON_VERSION: '3.7'
-      QT 5.13.0 windows desktop win32_msvc2017:
+        QT_VERSION: 5.12.3
         HOST: windows
-        QT_VERSION: 5.13.0
-        ARCHDIR: msvc2017
         TARGET: desktop
         ARCH: win32_msvc2017
+        ARCHDIR: msvc2017
+      QT 5.13.0 windows desktop win64_msvc2017_64:
         PYTHON_VERSION: '3.7'
-      QT 5.13.0 windows desktop win64_mingw73:
-        HOST: windows
         QT_VERSION: 5.13.0
-        ARCHDIR: mingw73_64
+        HOST: windows
         TARGET: desktop
-        ARCH: win64_mingw73
-        PYTHON_VERSION: '3.7'
-      QT 5.13.0 windows android android_x86:
-        HOST: windows
-        QT_VERSION: 5.13.0
-        ARCHDIR: android_x86
-        TARGET: android
-        ARCH: android_x86
-        PYTHON_VERSION: '3.7'
+        ARCH: win64_msvc2017_64
+        ARCHDIR: msvc2017_64
       QT 5.13.0 windows desktop win64_msvc2015_64:
-        HOST: windows
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.13.0
-        ARCHDIR: msvc2015_64
+        HOST: windows
         TARGET: desktop
         ARCH: win64_msvc2015_64
+        ARCHDIR: msvc2015_64
+      QT 5.13.0 windows desktop win64_mingw73:
         PYTHON_VERSION: '3.7'
-      QT 5.12.3 windows desktop win32_msvc2017:
+        QT_VERSION: 5.13.0
         HOST: windows
-        QT_VERSION: 5.12.3
-        ARCHDIR: msvc2017
+        TARGET: desktop
+        ARCH: win64_mingw73
+        ARCHDIR: mingw73_64
+      QT 5.13.0 windows desktop win32_msvc2017:
+        PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.13.0
+        HOST: windows
         TARGET: desktop
         ARCH: win32_msvc2017
+        ARCHDIR: msvc2017
+      QT 5.13.0 windows desktop win32_mingw73:
         PYTHON_VERSION: '3.7'
-      QT 5.11.3 windows desktop win64_msvc2017_64:
+        QT_VERSION: 5.13.0
         HOST: windows
-        QT_VERSION: 5.11.3
-        ARCHDIR: msvc2017_64
         TARGET: desktop
-        ARCH: win64_msvc2017_64
+        ARCH: win32_mingw73
+        ARCHDIR: mingw73_32
+      QT 5.13.0 windows android android_x86:
         PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.13.0
+        HOST: windows
+        TARGET: android
+        ARCH: android_x86
+        ARCHDIR: android_x86
+      QT 5.13.0 windows android android_armv7:
+        PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.13.0
+        HOST: windows
+        TARGET: android
+        ARCH: android_armv7
+        ARCHDIR: android_armv7
 - job: Linux
   pool:
     vmImage: ubuntu-16.04
@@ -144,38 +144,38 @@ jobs:
   - template: ci/steps.yml
   strategy:
     matrix:
-      QT 5.13.0 linux desktop gcc_64:
+      QT 5.11.3 linux desktop gcc_64:
+        PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.11.3
         HOST: linux
-        QT_VERSION: 5.13.0
-        ARCHDIR: gcc_64
         TARGET: desktop
         ARCH: gcc_64
+        ARCHDIR: gcc_64
+      QT 5.12.3 linux desktop gcc_64:
         PYTHON_VERSION: '3.7'
-      QT 5.13.0 linux android android_x86:
+        QT_VERSION: 5.12.3
         HOST: linux
+        TARGET: desktop
+        ARCH: gcc_64
+        ARCHDIR: gcc_64
+      QT 5.13.0 linux desktop gcc_64:
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.13.0
-        ARCHDIR: android_x86
+        HOST: linux
+        TARGET: desktop
+        ARCH: gcc_64
+        ARCHDIR: gcc_64
+      QT 5.13.0 linux android android_x86:
+        PYTHON_VERSION: '3.7'
+        QT_VERSION: 5.13.0
+        HOST: linux
         TARGET: android
         ARCH: android_x86
-        PYTHON_VERSION: '3.7'
+        ARCHDIR: android_x86
       QT 5.13.0 linux android android_armv7:
-        HOST: linux
+        PYTHON_VERSION: '3.7'
         QT_VERSION: 5.13.0
-        ARCHDIR: android_armv7
+        HOST: linux
         TARGET: android
         ARCH: android_armv7
-        PYTHON_VERSION: '3.7'
-      QT 5.11.3 linux desktop gcc_64:
-        HOST: linux
-        QT_VERSION: 5.11.3
-        ARCHDIR: gcc_64
-        TARGET: desktop
-        ARCH: gcc_64
-        PYTHON_VERSION: '3.7'
-      QT 5.12.3 linux desktop gcc_64:
-        HOST: linux
-        QT_VERSION: 5.12.3
-        ARCHDIR: gcc_64
-        TARGET: desktop
-        ARCH: gcc_64
-        PYTHON_VERSION: '3.7'
+        ARCHDIR: android_armv7

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,20 +39,6 @@ jobs:
         TARGET: ios
         ARCH: ios
         ARCHDIR: ios
-      QT 5.13.0 mac android android_x86:
-        PYTHON_VERSION: '3.7'
-        QT_VERSION: 5.13.0
-        HOST: mac
-        TARGET: android
-        ARCH: android_x86
-        ARCHDIR: android_x86
-      QT 5.13.0 mac android android_armv7:
-        PYTHON_VERSION: '3.7'
-        QT_VERSION: 5.13.0
-        HOST: mac
-        TARGET: android
-        ARCH: android_armv7
-        ARCHDIR: android_armv7
 - job: Windows
   pool:
     vmImage: vs2017-win2016
@@ -123,20 +109,6 @@ jobs:
         TARGET: desktop
         ARCH: win32_mingw73
         ARCHDIR: mingw73_32
-      QT 5.13.0 windows android android_x86:
-        PYTHON_VERSION: '3.7'
-        QT_VERSION: 5.13.0
-        HOST: windows
-        TARGET: android
-        ARCH: android_x86
-        ARCHDIR: android_x86
-      QT 5.13.0 windows android android_armv7:
-        PYTHON_VERSION: '3.7'
-        QT_VERSION: 5.13.0
-        HOST: windows
-        TARGET: android
-        ARCH: android_armv7
-        ARCHDIR: android_armv7
 - job: Linux
   pool:
     vmImage: ubuntu-16.04

--- a/generate_azure_pipelines_yml.py
+++ b/generate_azure_pipelines_yml.py
@@ -1,10 +1,12 @@
 """
 This generates a matrix of QT versions to test downloading against
 """
-
-from itertools import product
+import collections
 import os
+from itertools import product
+
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
 
 
 class BuildJob:
@@ -97,9 +99,9 @@ for android_arch in [ 'android_x86', 'android_armv7', ]:
 matrices = {}
 
 for platform_build_job in all_platform_build_jobs:
-    yaml_dictionary = {
-        'matrix': {}
-    }
+    yaml_dictionary = collections.OrderedDict({
+        'matrix':  CommentedMap()
+    })
     for build_job, python_version in product(platform_build_job.build_jobs, python_versions):
         key = 'QT {} {} {} {}'.format(build_job.qt_version, build_job.host, build_job.target,
                                                 build_job.arch)
@@ -112,7 +114,9 @@ for platform_build_job in all_platform_build_jobs:
                 'ARCH': build_job.arch,
                 'ARCHDIR': build_job.archdir,
             }
-    matrices[platform_build_job.platform.capitalize()] = yaml_dictionary
+
+    # CommentedMap wraps yaml_dictionary to suppress the !!omap annotation
+    matrices[platform_build_job.platform.capitalize()] = CommentedMap(yaml_dictionary)
 
 root_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/generate_azure_pipelines_yml.py
+++ b/generate_azure_pipelines_yml.py
@@ -88,13 +88,15 @@ windows_build_jobs.extend(
     ]
 )
 
-# All Androids for all platforms
+# Androids for Linux platforms
+# aqt is for CI/CD systems!
+# Users might develop on Win/Mac, but are most likely to use Linux for CI/CD with
+# the Android ecosystem.
 
-for android_arch in [ 'android_x86', 'android_armv7', ]:
-    for platform_build_jobs in all_platform_build_jobs:
-        platform_build_jobs.build_jobs.append(
-            BuildJob('5.13.0', platform_build_jobs.platform, 'android', android_arch, android_arch)
-        )
+for android_arch in ['android_x86', 'android_armv7']:
+    linux_build_jobs.append(
+        BuildJob('5.13.0', 'linux', 'android', android_arch, android_arch)
+    )
 
 matrices = {}
 


### PR DESCRIPTION
AQT is for CI/CD. Users might develop Android Apps on Mac/Windows but
they are far more likely to choose the most available platform for CI/CD
of their apps: Linux.