### PR TITLE
No need for yaml modification library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ pytest
 pytest-pep8
 pytest-cov
 flake8
-ruamel.yaml==0.15.94
 wheel
 twine


### PR DESCRIPTION
The ruamel.yaml library was used for the original matrix generation script. It is not required inside aqtinstall's development/ci/cd environment.