### PR TITLE
No more os.chdir()

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -58,7 +58,6 @@ class QtInstaller:
     def retrieve_archive(self, package: QtPackage):
         archive = package.archive
         url = package.url
-        cwd = os.getcwd()
         self.logger.info("Downloading {}...".format(url))
         try:
             r = requests.get(url, allow_redirects=False, stream=True)
@@ -85,8 +84,6 @@ class QtInstaller:
             else:
                 if self.command is not None:
                     self.extract_archive_ext(archive)
-        # work around for extractor bug that may change current working directory
-        os.chdir(cwd)
         os.unlink(archive)
         self.logger.info("Finish installation of {} in {}".format(archive, time.process_time()))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 install_requires =
     requests
     wheel
-    py7zr>=0.6b4,<0.7
+    py7zr>=0.6b5,<0.7
     packaging
 setup_requires =
     setuptools-scm[toml]>=3.3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 install_requires =
     requests
     wheel
-    py7zr>=0.6b5,<0.7
+    py7zr>=0.5.3,<0.7
     packaging
 setup_requires =
     setuptools-scm[toml]>=3.3.3


### PR DESCRIPTION
WIP for:
- [x] requiring fixed release version of py7zr
- [x] Testing together in CI
- [x] ~~May as well update for the pywin32 dep of py7zr as well when there's a (beta) release~~
  - This should happen before releasing aqtinstall but isn't related to this PR...
  - Well, other than this PR failing so, sure, depends on preference, but it needs to happen regardless