### PR TITLE
Fix installation of Qt5.7 which use LZMA1+BCJ

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     importlib-metadata;python_version<"3.8"
     requests
     wheel
-    py7zr>=0.7.0,<0.8.0
+    py7zr>=0.9.0
     packaging
 setup_requires =
     setuptools-scm[toml]>=3.3.3


### PR DESCRIPTION
Update dependency to v0.9.0 and later.
Fix for #149