### PR TITLE
update py7zr dependent version and  test target versions

### DIFF
--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -14,6 +14,10 @@ jobs:
           - os: ubuntu-20.04
             py: 3.8
             qtver: 6.0.0
+        exclude:
+          - os: windows-latest
+            py: 3.6
+            qtver: 5.15.1
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -9,7 +9,11 @@ jobs:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
         py: [3.6, 3.8]
-        qtver: [5.7, 5.14.1, 5.15.0]
+        qtver: [5.7, 5.12.8, 5.15.1]
+        include:
+          - os: ubuntu-20.04
+            py: 3.8
+            qtver: 6.0.0
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ sudo: false
 language: python
 matrix:
   include:
-    - python: 3.7
+    - python: 3.8
       env: TOXENV=check
-    - python: 3.7
+    - python: 3.8
       env: TOXENV=docs
-    - python: 3.7
+    - python: 3.8
       env:
-        TOXENV=py37
+        TOXENV=py38
         PYTEST_ADDOPTS="--remote-data"
 
 install: pip install tox-travis

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,11 +19,11 @@ jobs:
 - job: MatricesGenerator
   displayName: Matrices Generator
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.8'
         addToPath: true
     - bash: python ci/generate_azure_pipelines_matrices.py
       name: mtrx
@@ -52,7 +52,7 @@ jobs:
 - job: Linux
   dependsOn: MatricesGenerator
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.linux'] ]
   steps:
@@ -61,7 +61,7 @@ jobs:
 - job: LinuxSpecificMirror
   displayName: Linux (Specific Mirror)
   variables:
-    PYTHON_VERSION: '3.7'
+    PYTHON_VERSION: '3.8'
     QT_VERSION: 5.13.1
     HOST: linux
     TARGET: android
@@ -69,14 +69,14 @@ jobs:
     ARCHDIR: android_armv7
     QT_BASE_MIRROR: http://mirrors.ocf.berkeley.edu/qt/
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - template: ci/steps.yml
 
 - job: LinuxSubArchives
   displayName: Linux (subarchive spcified)
   variables:
-    PYTHON_VERSION: '3.7'
+    PYTHON_VERSION: '3.8'
     QT_VERSION: 5.15.0
     HOST: linux
     TARGET: desktop
@@ -84,45 +84,45 @@ jobs:
     ARCHDIR: gcc_64
     SUBARCHIVES: qtbase qttools qt icu
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - template: ci/steps.yml
 
 - job: LinuxSrc
   displayName: Linux (source)
   variables:
-    PYTHON_VERSION: '3.7'
+    PYTHON_VERSION: '3.8'
     QT_VERSION: 5.15.0
     HOST: linux
     TARGET: desktop
     TOOL_NAME: src
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - template: ci/steps.yml
 
 - job: LinuxExamples
   displayName: Linux (Examples)
   variables:
-    PYTHON_VERSION: '3.7'
+    PYTHON_VERSION: '3.8'
     QT_VERSION: 5.15.0
     HOST: linux
     TARGET: desktop
     TOOL_NAME: examples
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - template: ci/steps.yml
 
 - job: LinuxDoc
   displayName: Linux (doc)
   variables:
-    PYTHON_VERSION: '3.7'
+    PYTHON_VERSION: '3.8'
     QT_VERSION: 5.15.0
     HOST: linux
     TARGET: desktop
     TOOL_NAME: doc
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - template: ci/steps.yml

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -57,7 +57,7 @@ long options may be truncated to the shortest unambiguous abbreviation.
 
 .. option:: --base, -b <base url>
 
-    specify mirror site base url such as  -b 'http://mirrors.ocf.berkeley.edu/qt/'
+    specify mirror site base url such as  -b 'https://mirrors.ocf.berkeley.edu/qt/'
     where 'online' folder exist.
 
 .. option:: --modules, -m <list of modules>

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     importlib-metadata;python_version<"3.8"
     requests
     wheel
-    py7zr>=0.9.9,<0.10.0
+    py7zr>=0.9.9,!=0.10.0,<0.11.0
     packaging
     texttable
 setup_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ known_first_party = aqt
 known_third_party = docutils,flake8,pyannotate_runtime,pytest,pytz,requests,setuptools,sphinx,yaml,packaging
 
 [testenv:check]
-basepython = python3.7
+basepython = python3.8
 extras = check
 commands =
     check-manifest {toxinidir}
@@ -25,7 +25,7 @@ commands =
     twine check dist/*
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 extras = docs
 commands =
     sphinx-build {posargs:-E} -b html docs dist/docs


### PR DESCRIPTION
- Avoid py7zr v0.10.0
- GHA: test against Qt LTS versions
- GHA: Add test for Qt 6.0.0