### PR TITLE
Fix unformatted help text for `aqt install -h`

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -580,7 +580,9 @@ class Cli:
             description="Valid subcommands",
             help="subcommand for aqt Qt installer",
         )
-        install_parser = subparsers.add_parser("install")
+        install_parser = subparsers.add_parser(
+            "install", formatter_class=argparse.RawTextHelpFormatter
+        )
         install_parser.set_defaults(func=self.run_install)
         self._set_common_argument(install_parser)
         self._set_common_options(install_parser)


### PR DESCRIPTION
The `aqt install -h` command prints the help text for the `arch` argument all together on one line. I noticed that the help text is formatted very carefully in code, with lots of meaningful whitespace, but on my computer, all that whitespace is being ignored.

With `formatter_class=argparse.RawTextHelpFormatter` added to the `subparsers.add_parser('install')` function call, all of the whitespace in the help text is preserved.

It looks like `formatter_class=argparse.RawTextHelpFormatter` already exists in the call that creates the root parser, but it appears that this property does not extend to all subparsers automatically.