### PR TITLE
Fix tox check in GH Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Check package
 
-on: push
+on: [push, pull_request]
 
 jobs:
   check_document:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,15 +6,19 @@ jobs:
   check_document:
     name: Check packaging 📦
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: [3.6, 3.8]
+
     steps:
     - uses: actions/checkout@master
       with:
         fetch-depth: 20
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python }}
     - name: Install tools
       run: |
         pip install -U pip

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,4 +20,5 @@ jobs:
         pip install -U pip
         pip install tox tox-gh-actions build
     - name: Run check
-      run: tox
+      # Run tox using the version of python in PATH
+      run: tox -e py


### PR DESCRIPTION
This is meant to allow `tox` to run in Github Actions, every time a push or PR event occurs. In the discussion for #235, @miurahr mentioned that `tox` doesn't appear to run in CI, so I looked up the directions at https://docs.github.com/en/actions/guides/building-and-testing-python#running-tests-with-tox, and copied a few things. `tox` is now running properly in GH Actions, using Python 3.6 and 3.8.

~~Please see https://github.com/ddalcino/aqtinstall/actions/runs/838159498 for a successful run; I don't know why the link isn't showing up under **"Checks"** below.~~ A successful run should appear in the **"Checks"** below.