### PR TITLE
make sure binfile patches are a full 256 bytes, including

### DIFF
--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -39,12 +39,13 @@ class Updater:
         if idx < 0:
             return
         assert len(newpath) < 256, "Qt Prefix path is too long(255)."
-        data = (
-            data[: idx + len(key)]
-            + newpath
-            + bytes(256 - len(newpath))
-            + data[idx + len(key) + 256 :]
-        )
+        oldlen = data[idx + len(key) :].find(b"\0")
+        assert oldlen >= 0
+        if oldlen > len(newpath):
+            value = newpath + bytes(oldlen - len(newpath))
+        else:
+            value = newpath
+        data = data[: idx + len(key)] + value + data[idx + len(key) + len(value) :]
         file.write_bytes(data)
         os.chmod(str(file), st.st_mode)
 

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -41,10 +41,7 @@ class Updater:
         assert len(newpath) < 256, "Qt Prefix path is too long(255)."
         oldlen = data[idx + len(key) :].find(b"\0")
         assert oldlen >= 0
-        if oldlen > len(newpath):
-            value = newpath + bytes(oldlen - len(newpath))
-        else:
-            value = newpath
+        value = newpath + b"\0" * (oldlen - len(newpath))
         data = data[: idx + len(key)] + value + data[idx + len(key) + len(value) :]
         file.write_bytes(data)
         os.chmod(str(file), st.st_mode)

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -38,8 +38,13 @@ class Updater:
         idx = data.find(key)
         if idx < 0:
             return
-        assert len(key) + len(newpath) < 256, "Qt Prefix path is too long(255)."
-        data = data[:idx] + key + newpath + bytearray(256 - (len(key) + len(newpath))) + data[idx + 256 :]
+        assert len(newpath) < 256, "Qt Prefix path is too long(255)."
+        data = (
+            data[: idx + len(key)]
+            + newpath
+            + bytes(256 - len(newpath))
+            + data[idx + len(key) + 256 :]
+        )
         file.write_bytes(data)
         os.chmod(str(file), st.st_mode)
 

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -104,6 +104,16 @@ class Updater:
                 key=b"qt_prfxpath=",
                 newpath=bytes(str(self.prefix), "UTF-8"),
             )
+            self._patch_binfile(
+                self.qmake_path,
+                key=b"qt_epfxpath=",
+                newpath=bytes(str(self.prefix), "UTF-8"),
+            )
+            self._patch_binfile(
+                self.qmake_path,
+                key=b"qt_hpfxpath=",
+                newpath=bytes(str(self.prefix), "UTF-8"),
+            )
 
     def patch_qmake_script(self, base_dir, qt_version, os_name):
         if os_name == "linux":

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -38,8 +38,8 @@ class Updater:
         idx = data.find(key)
         if idx < 0:
             return
-        assert len(newpath) < 256, "Qt Prefix path is too long(255)."
-        data = data[:idx] + key + newpath + data[idx + len(key) + len(newpath) :]
+        assert len(key) + len(newpath) < 256, "Qt Prefix path is too long(255)."
+        data = data[:idx] + key + newpath + bytearray(256 - (len(key) + len(newpath))) + data[idx + 256 :]
         file.write_bytes(data)
         os.chmod(str(file), st.st_mode)
 


### PR DESCRIPTION
any necessary padding.

This also fixes the assertion regarding the length of the new path.

This is an additional required fix for #256.  The need for this additional fix was pointed out in #256 by @ddalcino.

Again, please check my python.  The intent is that every patch insertion shall be exactly 256 bytes consisting of 
1) the key
2) the new path
3) zero padding of at least 1 byte

It's not clear to me that this fixed length string needs to be null terminated, but it might, and it the reduction of the maximum new path length by 1 byte seems an insignificant concession.

I believe python assertions only run with __debug__ is true, which only happens when optimization is not requested. https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement
Therefore we may want to further change the length check so it always runs.