### PR TITLE
Fix #268

### DIFF
--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -14,7 +14,7 @@ steps:
   - bash: |
       set -ex
       number=$RANDOM
-      let "number %= 60"
+      let "number %= 60" || true
       let "number += 1"
       sleep $number
       mkdir Qt


### PR DESCRIPTION
This prevents "number %= 60" from returning 1 and causing the job to fail.

Fixes #268