### PR TITLE
CI: remove berkley.edu from mirrors test site

### DIFF
--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -7,7 +7,6 @@ import random
 from itertools import product
 
 MIRRORS = [
-    "https://mirrors.ocf.berkeley.edu/qt",
     "https://ftp.jaist.ac.jp/pub/qtproject",
     "http://ftp1.nluug.nl/languages/qt",
     "https://mirrors.dotsrc.org/qtproject",


### PR DESCRIPTION
to reduce CI failed with timeout

Signed-off-by: Hiroshi Miura <miurahr@linux.com>