### PR TITLE
README: Change recommended python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Requirements
 ------------
 
 - Minimum Python version:  3.6
-- Recommended Python version: 3.7.5 or later
+- Recommended Python version: 3.8, 3.9 (frequently tested on)
 
 - Dependent libraries: requests, py7zr
 


### PR DESCRIPTION
Recommend  3.8 and 3.9 from 3.7 because there are frequently tested one.