### PR TITLE
Fix #282 - Refactor archives.py and make `aqt tool` take --version and --arch as optionals

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -20,13 +20,14 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import posixpath
 import xml.etree.ElementTree as ElementTree
 from logging import getLogger
+from typing import Optional, Tuple
+
 import packaging.version
 from packaging.version import Version
-import posixpath
 
-from typing import Optional, Tuple
 from aqt.exceptions import ArchiveListError, NoPackageFound
 from aqt.helper import Settings, getUrl, satifiesVersion
 
@@ -39,11 +40,13 @@ class TargetConfig:
         self.os_name = os_name
 
     def __str__(self):
-        print(f'TargetConfig(version={self.version}, target={self.target}, '
-              f'arch={self.arch}, os_name={self.os_name}')
+        print(
+            f"TargetConfig(version={self.version}, target={self.target}, "
+            f"arch={self.arch}, os_name={self.os_name}"
+        )
 
     def __repr__(self):
-        print(f'({self.version}, {self.target}, {self.arch}, {self.os_name})')
+        print(f"({self.version}, {self.target}, {self.arch}, {self.os_name})")
 
 
 class QtPackage:
@@ -51,9 +54,15 @@ class QtPackage:
     Hold package information.
     """
 
-    def __init__(self, name: str , archive_url: str, archive: str,
-                 package_desc: str, hashurl: str,
-                 version: Optional[Version] = None):
+    def __init__(
+        self,
+        name: str,
+        archive_url: str,
+        archive: str,
+        package_desc: str,
+        hashurl: str,
+        version: Optional[Version] = None,
+    ):
         self.name = name
         self.url = archive_url
         self.archive = archive
@@ -62,16 +71,16 @@ class QtPackage:
         self.version = version
 
     def __repr__(self):
-        v_info = f', version={self.version}' if self.version else ''
-        return (
-            f'QtPackage(name={self.name}, archive={self.archive}{v_info})'
-        )
+        v_info = f", version={self.version}" if self.version else ""
+        return f"QtPackage(name={self.name}, archive={self.archive}{v_info})"
 
     def __str__(self):
-        v_info = f', version={self.version}' if self.version else ''
-        return (f'QtPackage(name={self.name}, url={self.url}, '
-                f'archive={self.archive}, desc={self.desc}'
-                f'hashurl={self.hashurl}{v_info})')
+        v_info = f", version={self.version}" if self.version else ""
+        return (
+            f"QtPackage(name={self.name}, url={self.url}, "
+            f"archive={self.archive}, desc={self.desc}"
+            f"hashurl={self.hashurl}{v_info})"
+        )
 
 
 class ListInfo:
@@ -106,9 +115,11 @@ class PackagesList:
         # Get packages index
         if self.version.major == 6 and self.target == "android":
             arch_ext = ["_armv7/", "_x86/", "_x86_64/", "_arm64_v8a/"]
-        elif ((self.target == 'desktop') and
-              (self.version >= Version('5.13.0')) and
-              (self.version < Version('6.0.0'))):
+        elif (
+            (self.target == "desktop")
+            and (self.version >= Version("5.13.0"))
+            and (self.version < Version("6.0.0"))
+        ):
             arch_ext = ["/", "_wasm/"]
         else:
             arch_ext = ["/"]
@@ -165,7 +176,9 @@ class QtArchives:
         timeout=(5, 5),
     ):
         self.version_str = version_str
-        self.version = packaging.version.parse(version_str) if version_str is not None else None
+        self.version = (
+            packaging.version.parse(version_str) if version_str is not None else None
+        )
         self.target = target
         self.arch = arch
         self.os_name = os_name
@@ -237,9 +250,9 @@ class QtArchives:
             )
         )
         target_packages.extend(self.mod_list)
-        self.logger.debug('QtArchives::_get_archives')
-        self.logger.debug(f'{update_xml_url=}')
-        self.logger.debug(f'{target_packages=}')
+        self.logger.debug("QtArchives::_get_archives")
+        self.logger.debug(f"{update_xml_url=}")
+        self.logger.debug(f"{target_packages=}")
 
         self._download_update_xml(update_xml_url)
         self._parse_update_xml(archive_url, target_packages)
@@ -277,7 +290,7 @@ class QtArchives:
                     ).text.split(", ")
                     full_version = packageupdate.find("Version").text
                     # keep only '5.15.2' in '5.15.2-0-202011130724'
-                    parsed_version = packaging.version.parse(full_version.split('-')[0])
+                    parsed_version = packaging.version.parse(full_version.split("-")[0])
                     package_desc = packageupdate.find("Description").text
                     for archive in downloadable_archives:
                         archive_name = archive.split("-", maxsplit=1)[0]
@@ -287,7 +300,7 @@ class QtArchives:
                             # qt.qt5.5150.gcc_64/
                             name,
                             # 5.15.0-0-202005140804qtbase-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z
-                            full_version + archive
+                            full_version + archive,
                         )
                         hashurl = package_url + ".sha1"
                         self.archives.append(
@@ -297,7 +310,7 @@ class QtArchives:
                                 archive,
                                 package_desc,
                                 hashurl,
-                                parsed_version
+                                parsed_version,
                             )
                         )
         if len(self.archives) == 0:
@@ -305,7 +318,7 @@ class QtArchives:
                 "Specified packages are not found while parsing XML of package information!"
             )
             raise NoPackageFound
-        self.logger.debug(f'Archives: {self.archives}')
+        self.logger.debug(f"Archives: {self.archives}")
 
     def get_archives(self):
         """
@@ -397,24 +410,30 @@ class ToolArchives(QtArchives):
     when installing ifw tool, argument would be
     ToolArchive(linux, desktop, 3.1.1, ifw)
     """
-    def __init__(self,
-                 os_name: str,
-                 tool_name: str,
-                 base: str,
-                 version_str: Optional[str] = None,
-                 arch: Optional[str] = None,
-                 timeout: Tuple[int, int] = (5, 5)):
+
+    def __init__(
+        self,
+        os_name: str,
+        tool_name: str,
+        base: str,
+        version_str: Optional[str] = None,
+        arch: Optional[str] = None,
+        timeout: Tuple[int, int] = (5, 5),
+    ):
         self.tool_name = tool_name
         self.os_name = os_name
         self.logger = getLogger("aqt.archives")
         super(ToolArchives, self).__init__(
-            os_name=os_name, target="desktop",
-            version_str=version_str, arch=arch,
-            base=base, timeout=timeout,
+            os_name=os_name,
+            target="desktop",
+            version_str=version_str,
+            arch=arch,
+            base=base,
+            timeout=timeout,
         )
 
     def __str__(self):
-        return f'ToolArchives(tool_name={self.tool_name}, version={self.version_str}, arch={self.arch})'
+        return f"ToolArchives(tool_name={self.tool_name}, version={self.version_str}, arch={self.arch})"
 
     def _get_archives(self):
         _a = "_x64"
@@ -429,7 +448,7 @@ class ToolArchives(QtArchives):
             # desktop/
             self.target,
             # tools_ifw/
-            self.tool_name
+            self.tool_name,
         )
         update_xml_url = posixpath.join(archive_url, "Updates.xml")
         self._download_update_xml(update_xml_url)  # call super method.
@@ -448,11 +467,11 @@ class ToolArchives(QtArchives):
             name = packageupdate.find("Name").text
             full_version = packageupdate.find("Version").text
             # keep only '4.1.1' in '4.1.1-20210526113'
-            parsed_version = packaging.version.parse(full_version.split('-')[0])
+            parsed_version = packaging.version.parse(full_version.split("-")[0])
             versions.append((name, str(parsed_version)))
 
             # Filter out on version first
-            parsed_version = packaging.version.parse(full_version.split('-')[0])
+            parsed_version = packaging.version.parse(full_version.split("-")[0])
 
             if self.version:
                 if not satifiesVersion(self.version, parsed_version):
@@ -466,8 +485,8 @@ class ToolArchives(QtArchives):
             # Filter out on arch next
             if self.arch and name != self.arch:
                 self.logger.warning(
-                    f'Arch of {name} is different from requested '
-                    f'arch {self.arch} -- skip.'
+                    f"Arch of {name} is different from requested "
+                    f"arch {self.arch} -- skip."
                 )
                 continue
 
@@ -485,21 +504,27 @@ class ToolArchives(QtArchives):
                     # qt.tools.ifw.41/
                     name,
                     #  4.1.1-202105261130ifw-linux-x64.7z
-                    f'{full_version}{archive}'
+                    f"{full_version}{archive}",
                 )
                 hashurl = package_url + ".sha1"
                 self.archives.append(
-                    QtPackage(name, package_url, archive, package_desc,
-                              hashurl, parsed_version)
+                    QtPackage(
+                        name,
+                        package_url,
+                        archive,
+                        package_desc,
+                        hashurl,
+                        parsed_version,
+                    )
                 )
 
         if self.archives:
-            self.logger.debug(f'ToolArchives: {self.archives}')
+            self.logger.debug(f"ToolArchives: {self.archives}")
         else:
             msg = f"{self} did not match any available tools. "
             if versions:
-                msg += 'Available tools\n'
-                msg += f'[(version, arch)] = {versions}'
+                msg += "Available tools\n"
+                msg += f"[(version, arch)] = {versions}"
             else:
                 url = posixpath.join(archive_url, "Updates.xml")
                 msg += f"Zero tools where found to be available in {url}"
@@ -507,12 +532,14 @@ class ToolArchives(QtArchives):
 
         if len(self.archives) > 1:
             self.logger.info(
-                f"Found {len(self.archives)} potential archives. "
-                "Returning the max.")
-            archive_max = max(self.archives,
-                              key=lambda package: package.version
-                              if package.version
-                              else packaging.version.Version('0'))
+                f"Found {len(self.archives)} potential archives. " "Returning the max."
+            )
+            archive_max = max(
+                self.archives,
+                key=lambda package: package.version
+                if package.version
+                else packaging.version.Version("0"),
+            )
             self.archives = [archive_max]
 
     def get_target_config(self) -> TargetConfig:

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -505,6 +505,16 @@ class ToolArchives(QtArchives):
                 msg += f"Zero tools where found to be available in {url}"
             raise NoPackageFound(msg)
 
+        if len(self.archives) > 1:
+            self.logger.info(
+                f"Found {len(self.archives)} potential archives. "
+                "Returning the max.")
+            archive_max = max(self.archives,
+                              key=lambda package: package.version
+                              if package.version
+                              else packaging.version.Version('0'))
+            self.archives = [archive_max]
+
     def get_target_config(self) -> TargetConfig:
         """Get target configuration.
 

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -29,7 +29,7 @@ import packaging.version
 from packaging.version import Version
 
 from aqt.exceptions import ArchiveListError, NoPackageFound
-from aqt.helper import Settings, getUrl, satifiesVersion
+from aqt.helper import Settings, getUrl, satisfiesVersion
 
 
 class TargetConfig:
@@ -474,7 +474,7 @@ class ToolArchives(QtArchives):
             parsed_version = packaging.version.parse(full_version.split("-")[0])
 
             if self.version:
-                if not satifiesVersion(self.version, parsed_version):
+                if not satisfiesVersion(self.version, parsed_version):
                     self.logger.warning(
                         "Base Version of {} is different from requested version {} -- skip.".format(
                             full_version, self.version

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -34,6 +34,8 @@ from urllib.parse import urlparse
 import requests
 import requests.adapters
 
+from packaging.version import Version
+
 from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError
 
 
@@ -203,6 +205,17 @@ class MyQueueListener(QueueListener):
         logger = logging.getLogger("aqt.installer")
         record.name = "aqt.installer"
         logger.handle(record)
+
+
+def satifiesVersion(requestedVersion: Version, candidateVersion: Version):
+    """
+    This will return true if the candidateVersion matches the requestedVersion
+    It will only compare the number of components of the candidateVersion
+    """
+    for (a, b) in zip(requestedVersion.release, candidateVersion.release):
+        if a != b:
+            return False
+    return True
 
 
 class Settings:

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -28,7 +28,7 @@ import os
 import sys
 import xml.etree.ElementTree as ElementTree
 from logging.handlers import QueueListener
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -125,11 +125,15 @@ def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: str, timeout, lo
                 raise e
 
 
-def altlink(url: str, alt: str):
-    """Blacklisting redirected(alt) location based on Settings.blacklist configuration.
+def altlink(url: str, alt: str, logger: Optional[logging.Logger] = None):
+    """
+    Blacklisting redirected(alt) location based on Settings.blacklist configuration.
     When found black url, then try download a url + .meta4 that is a metalink version4
-    xml file, parse it and retrieve best alternative url."""
-    logger = logging.getLogger("aqt.helper")
+    xml file, parse it and retrieve best alternative url.
+    """
+    if logger is None:
+        logger = logging.getLogger("aqt.helper")
+
     if not any(alt.startswith(b) for b in Settings.blacklist):
         return alt
     try:

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -210,7 +210,7 @@ class MyQueueListener(QueueListener):
         logger.handle(record)
 
 
-def satifiesVersion(requestedVersion: Version, candidateVersion: Version):
+def satisfiesVersion(requestedVersion: Version, candidateVersion: Version):
     """
     This will return true if the candidateVersion matches the requestedVersion
     It will only compare the number of components of the candidateVersion

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -221,7 +221,7 @@ def satifiesVersion(requestedVersion: Version, candidateVersion: Version):
     return True
 
 
-class Settings:
+class SettingsClass:
     """
     Class to hold configuration and settings.
     Actual values are stored in 'settings.ini' file.
@@ -334,7 +334,7 @@ class Settings:
         return self.config.getlist("kde_patches", "patches", fallback=[])
 
 
-Settings = Settings()
+Settings = SettingsClass()
 
 
 def setup_logging(env_key="LOG_CFG"):

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -33,7 +33,6 @@ from urllib.parse import urlparse
 
 import requests
 import requests.adapters
-
 from packaging.version import Version
 
 from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError
@@ -219,10 +218,11 @@ def satifiesVersion(requestedVersion: Version, candidateVersion: Version):
 
 
 class Settings:
-    """Class to hold configuration and settings.		￼
-    ￼    Actual values are stored in 'settings.ini' file.
-    ￼    It also holds a combinations database.
-    ￼"""
+    """
+    Class to hold configuration and settings.
+    Actual values are stored in 'settings.ini' file.
+    It also holds a combinations database.
+    """
 
     def __init__(self):
         self.config = MyConfigParser()

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -690,8 +690,8 @@ class Cli:
         return result
 
     def call_installer(self, qt_archives, base_dir, sevenzip, keep):
-        if not qt_archives.get_archives():
-            raise NoPackageFound("Couldn't find any archives")
+        # if not qt_archives.get_archives():
+        #     raise NoPackageFound("Couldn't find any archives")
         queue = multiprocessing.Manager().Queue(-1)
         listener = MyQueueListener(queue)
         listener.start()

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -427,13 +427,14 @@ class Cli:
                     os_name, tool_name, arch
                 )
             )
+
         try:
             tool_archives = ToolArchives(
-                os_name,
-                tool_name,
-                version,
-                arch,
-                base,
+                os_name=os_name,
+                tool_name=tool_name,
+                base=base,
+                version_str=version,
+                arch=arch,
                 timeout=timeout,
             )
         except ArchiveConnectionError:
@@ -442,11 +443,11 @@ class Cli:
                     "Connection to the download site failed and fallback to mirror site."
                 )
                 tool_archives = ToolArchives(
-                    os_name,
-                    tool_name,
-                    version,
-                    arch,
-                    random.choice(Settings.fallbacks),
+                    os_name=os_name,
+                    tool_name=tool_name,
+                    base=random.choice(Settings.fallbacks),
+                    version_str=version,
+                    arch=arch,
                     timeout=timeout,
                 )
             except Exception:

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -636,17 +636,20 @@ class Cli:
             "tool_name", help="Name of tool such as tools_ifw, tools_mingw"
         )
         tools_parser.add_argument(
-            '-v',
-            '--version',
+            "-v",
+            "--version",
             type=str,
-            help=('Tool version in the format of "4.1.2". '
-                  'If not supplied, defaults to latest found'),
+            help=(
+                'Tool version in the format of "4.1.2". '
+                "If not supplied, defaults to latest found"
+            ),
         )
 
         tools_parser.add_argument(
-            '-a', '--arch',
+            "-a",
+            "--arch",
             type=str,
-            help='Name of full tool name such as "qt.tools.ifw.31"'
+            help='Name of full tool name such as "qt.tools.ifw.31"',
         )
         self._set_common_options(tools_parser)
         #

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -684,6 +684,8 @@ class Cli:
         return result
 
     def call_installer(self, qt_archives, base_dir, sevenzip, keep):
+        if not qt_archives.get_archives():
+            raise NoPackageFound("Couldn't find any archives")
         queue = multiprocessing.Manager().Queue(-1)
         listener = MyQueueListener(queue)
         listener.start()

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -636,10 +636,17 @@ class Cli:
             "tool_name", help="Name of tool such as tools_ifw, tools_mingw"
         )
         tools_parser.add_argument(
-            "version", help='Tool version in the format of "4.1.2"'
+            '-v',
+            '--version',
+            type=str,
+            help=('Tool version in the format of "4.1.2". '
+                  'If not supplied, defaults to latest found'),
         )
+
         tools_parser.add_argument(
-            "arch", help="Name of full tool name such as qt.tools.ifw.31"
+            '-a', '--arch',
+            type=str,
+            help='Name of full tool name such as "qt.tools.ifw.31"'
         )
         self._set_common_options(tools_parser)
         #

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -32,7 +32,7 @@ import time
 from logging import getLogger
 from logging.handlers import QueueHandler
 
-from semantic_version import Version
+import packaging.version
 from texttable import Texttable
 
 import aqt
@@ -149,7 +149,10 @@ class Cli:
                 arch = "clang_64"
             elif os_name == "mac" and target == "ios":
                 arch = "ios"
-            elif target == "android" and Version(qt_version) >= Version("5.14.0"):
+            elif target == "android" and (
+                packaging.version.parse(qt_version)
+                >= packaging.version.Version("5.14.0")
+            ):
                 arch = "android"
             else:
                 print("Please supply a target architecture.")

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -24,8 +24,8 @@ import pathlib
 import subprocess
 from logging import getLogger
 
-import patch
 import packaging.version
+import patch
 
 from aqt.helper import Settings
 
@@ -304,7 +304,9 @@ class Updater:
                     updater.patch_libtool("/Users/qt/work/install/lib", target.os_name)
                 elif target.os_name == "windows":
                     updater.make_qtenv2(base_dir, target.version, arch_dir)
-                if packaging.version.parse(target.version) < packaging.version.Version("5.14.0"):
+                if packaging.version.parse(target.version) < packaging.version.Version(
+                    "5.14.0"
+                ):
                     updater.patch_qtcore(target)
             elif packaging.version.parse(target.version).major == 5:
                 updater.patch_qmake()

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -25,7 +25,7 @@ import subprocess
 from logging import getLogger
 
 import patch
-from semantic_version import SimpleSpec, Version
+import packaging.version
 
 from aqt.helper import Settings
 
@@ -304,9 +304,9 @@ class Updater:
                     updater.patch_libtool("/Users/qt/work/install/lib", target.os_name)
                 elif target.os_name == "windows":
                     updater.make_qtenv2(base_dir, target.version, arch_dir)
-                if Version(target.version) < Version("5.14.0"):
+                if packaging.version.parse(target.version) < packaging.version.Version("5.14.0"):
                     updater.patch_qtcore(target)
-            elif Version(target.version) in SimpleSpec(">=5.0,<6.0"):
+            elif packaging.version.parse(target.version).major == 5:
                 updater.patch_qmake()
             else:  # qt6 non-desktop
                 updater.patch_qmake_script(base_dir, target.version, target.os_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 python_requires = >= 3.6
 install_requires =
     requests
-    semantic_version
+    packaging
     patch>=1.16
     py7zr>=0.15.1
     texttable

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,5 +1,7 @@
 import binascii
 import logging
+import packaging.version
+import pytest
 import os
 
 import requests
@@ -100,3 +102,26 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
     helper.downloadBinaryFile(
         "http://example.com/test.xml", out, "sha256", expected, 60, logger
     )
+
+
+@pytest.mark.parametrize(
+    "requestedVersion,candidateVersion,expected",
+    [
+        ('4.0', '4.0.0', True),
+        ('4.0', '4.0.1', True),
+        ('4.1', '4.0.1', False),
+        ('4.0.0', '4.0.0', True),
+        ('4.1.0', '4.1.1', False),
+        ('4.1.1', '4.1.1-202105261130', True),
+        ('4.1', '4.1.1-202105261130', True),
+        ('4', '4.1.1-202105261130', True),
+    ],
+)
+def test_satifiesVersion(requestedVersion, candidateVersion, expected):
+    v1 = packaging.version.parse(requestedVersion)
+    v2 = packaging.version.parse(candidateVersion)
+    matches = helper.satifiesVersion(v1, v2)
+    if expected:
+        assert matches, f"Expected {candidateVersion} to satify {requestedVersion}"
+    else:
+        assert not matches, f"Expected {candidateVersion} to NOT match {requestedVersion}"

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -117,10 +117,10 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
         ("4", "4.1.1-202105261130", True),
     ],
 )
-def test_satifiesVersion(requestedVersion, candidateVersion, expected):
+def test_satisfiesVersion(requestedVersion, candidateVersion, expected):
     v1 = packaging.version.parse(requestedVersion)
     v2 = packaging.version.parse(candidateVersion)
-    matches = helper.satifiesVersion(v1, v2)
+    matches = helper.satisfiesVersion(v1, v2)
     if expected:
         assert matches, f"Expected {candidateVersion} to satify {requestedVersion}"
     else:

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,9 +1,9 @@
 import binascii
 import logging
-import packaging.version
-import pytest
 import os
 
+import packaging.version
+import pytest
 import requests
 from requests.models import Response
 
@@ -107,14 +107,14 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "requestedVersion,candidateVersion,expected",
     [
-        ('4.0', '4.0.0', True),
-        ('4.0', '4.0.1', True),
-        ('4.1', '4.0.1', False),
-        ('4.0.0', '4.0.0', True),
-        ('4.1.0', '4.1.1', False),
-        ('4.1.1', '4.1.1-202105261130', True),
-        ('4.1', '4.1.1-202105261130', True),
-        ('4', '4.1.1-202105261130', True),
+        ("4.0", "4.0.0", True),
+        ("4.0", "4.0.1", True),
+        ("4.1", "4.0.1", False),
+        ("4.0.0", "4.0.0", True),
+        ("4.1.0", "4.1.1", False),
+        ("4.1.1", "4.1.1-202105261130", True),
+        ("4.1", "4.1.1-202105261130", True),
+        ("4", "4.1.1-202105261130", True),
     ],
 )
 def test_satifiesVersion(requestedVersion, candidateVersion, expected):
@@ -124,4 +124,6 @@ def test_satifiesVersion(requestedVersion, candidateVersion, expected):
     if expected:
         assert matches, f"Expected {candidateVersion} to satify {requestedVersion}"
     else:
-        assert not matches, f"Expected {candidateVersion} to NOT match {requestedVersion}"
+        assert (
+            not matches
+        ), f"Expected {candidateVersion} to NOT match {requestedVersion}"


### PR DESCRIPTION
- Use packaging.version instead of semantic_version
    - That way you could pass --version 4, it would allow building a version, and it would match any version that starts with 4. See the helper I added, and the unit tests that show the behavior clearly  
- Provide `__str__`, `__repr__` for classes for easier debugging
- Use `posixpath` instead of string manipulation to make urls
- Add type hints were I touched thing
   -  TODO: should add mypi as a checker

Edit: it's likely that some of the workflows will fail, and that's fine. I only ran the unit test locally + try `aqt tool`, haven't tried Qt. We can address problems as they are caught