### PR TITLE
Remove odd unicode characters from Settings docstring

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -206,10 +206,10 @@ class MyQueueListener(QueueListener):
 
 
 class Settings:
-    """Class to hold configuration and settings.		￼
-    ￼    Actual values are stored in 'settings.ini' file.
-    ￼    It also holds a combinations database.
-    ￼"""
+    """Class to hold configuration and settings.
+    Actual values are stored in 'settings.ini' file.
+    It also holds a combinations database.
+    """
 
     def __init__(self):
         self.config = MyConfigParser()


### PR DESCRIPTION
These characters caused Black to crash on my PC. I believe that these characters were committed by mistake; if I am wrong, please close this PR.