### PR TITLE
Change updater target path for Qt 6.2.0 for mac

### DIFF
--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -271,6 +271,8 @@ class Updater:
         """
         logger = getLogger("aqt.updater")
         arch = target.arch
+        version = Version(target.version)
+        os_name = target.os_name
         if arch is None:
             arch_dir = ""
         elif arch.startswith("win64_mingw"):
@@ -279,6 +281,8 @@ class Updater:
             arch_dir = arch[6:] + "_32"
         elif arch.startswith("win"):
             arch_dir = arch[6:]
+        elif version in SimpleSpec(">=6.2") and os_name == "mac" and arch == "clang_64":
+            arch_dir = "macos"
         else:
             arch_dir = arch
         try:

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -162,16 +162,27 @@ linux_build_jobs.extend(
         BuildJob("list", "6.1.0", "linux", "desktop", "", ""),
     ]
 )
-mac_build_jobs.append(
-    BuildJob(
-        "install",
-        "5.14.2",
-        "mac",
-        "desktop",
-        "clang_64",
-        "clang_64",
-        module="qcharts qtnetworkauth",
-    )
+mac_build_jobs.extend(
+    [
+        BuildJob(
+            "install",
+            "6.2.0",
+            "mac",
+            "desktop",
+            "clang_64",
+            "macos",
+            module="qcharts qtnetworkauth",
+        ),
+        BuildJob(
+            "install",
+            "5.14.2",
+            "mac",
+            "desktop",
+            "clang_64",
+            "clang_64",
+            module="qcharts qtnetworkauth",
+        ),
+    ]
 )
 
 # WASM

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -171,7 +171,6 @@ mac_build_jobs.extend(
             "desktop",
             "clang_64",
             "macos",
-            module="qcharts qtnetworkauth",
         ),
         BuildJob(
             "install",


### PR DESCRIPTION
Use `macos` other than `clang_64` for Qt6.2.0 and later on mac/desktop(#288)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>