### PR TITLE
Fix `test_cli_unknown_version`

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -22,7 +22,7 @@ def test_cli_unknown_version(capsys):
 
     """
     Expected result when no redirect occurs:
-    
+
     aqtinstall(aqt) v.* on Python 3.*
     Specified Qt version is unknown: 5.16.0.
     Download error when access to https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 import pytest
@@ -7,14 +8,8 @@ import aqt
 
 @pytest.mark.remote_data
 def test_cli_unknown_version(capsys):
-    wrong_version = "5.12"
-    wrong_url = "https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_512/Updates.xml"
-    expected = [
-        "<<ignore>>",
-        "aqt - WARNING - Specified Qt version is unknown: {}.".format(wrong_version),
-        "aqt - ERROR - Download error when access to {}"
-        " Server response code: 404, reason code: Not Found".format(wrong_url),
-    ]
+    wrong_version = "5.16.0"
+    wrong_url_ending = "mac_x64/desktop/qt5_5160/Updates.xml"
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         cli = aqt.installer.Cli()
         cli.run(["install", wrong_version, "mac", "desktop"])
@@ -23,7 +18,31 @@ def test_cli_unknown_version(capsys):
     out, err = capsys.readouterr()
     sys.stdout.write(out)
     sys.stderr.write(err)
-    for i, line in enumerate(out):
-        if i == 0:
-            continue
-        assert line.endswith(expected[i])
+    assert not out
+
+    """
+    Expected result when no redirect occurs:
+    
+    aqtinstall(aqt) v.* on Python 3.*
+    Specified Qt version is unknown: 5.16.0.
+    Download error when access to https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml
+    Server response code: 404, reason: Not Found
+
+    Expected result when redirect occurs:
+
+    aqtinstall(aqt) v.* on Python 3.*
+    Specified Qt version is unknown: 5.16.0.
+    Connection to the download site failed and fallback to mirror site.
+    Download error when access to .*/mac_x64/desktop/qt5_5160/Updates.xml
+    Server response code: 404, reason: Not Found
+    Connection to the download site failed. Aborted...
+    """
+
+    matcher = re.compile(
+        r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
+        r".*Specified Qt version is unknown: " + re.escape(wrong_version) + r"\.\n"
+        r".*Download error when access to .*" + re.escape(wrong_url_ending) + r"\n"
+        r".*Server response code: 404, reason: Not Found.*"
+    )
+
+    assert matcher.match(err)


### PR DESCRIPTION
The test test_cli_unknown_version, in `tests/test_connection.py`, is never run in CI because it is marked as requiring remote data. When I run `pytest` locally, this test always fails because the version string "5.12" cannot be parsed into a valid `semantic_version.Version` object. This change modifies that version string to "5.16.0", so that it will make a valid Version object that is an invalid version of Qt.

This also modifies the assertion code in test_cli_unknown_version. On my machine, the new logger prints directly to `stderr` and not `stdout` when run via `pytest`, and the `aqt - WARNING` and `aqt - ERROR` prefixes are omitted. The new assertion code uses a regex to pick out the required parts of the output and ignore anything that might not show up.

This change also accounts for what happens during a redirect. In my testing, I noticed that redirects would occasionally insert some additional lines of output regarding a redirect. This change describes this output in a comment, and swallows up the additional lines using a Kleene star.