### PR TITLE
Allow tool sub-command to specify tool_name without version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.rst
 include *.txt
-include *.cfg
+include setup.cfg
 include LICENSE
 include pyproject.toml
 include tox.ini
@@ -21,3 +21,5 @@ recursive-include tests *.ini
 recursive-include tests *.json
 recursive-include tests *.py
 recursive-include tests *.xml
+exclude .gitignore
+prune .github

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.rst
 include *.txt
-include setup.cfg
+include *.cfg
 include LICENSE
 include pyproject.toml
 include tox.ini

--- a/README.rst
+++ b/README.rst
@@ -220,14 +220,14 @@ Example: Install an Install FrameWork (IFW):
 
 .. code-block:: console
 
-    aqt tool linux tools_ifw 4.0 qt.tools.ifw.40
+    aqt tool linux desktop tools_ifw
 
 
 Example: Install vcredist:
 
 .. code-block:: console
 
-    py -m aqt tool windows tools_vcredist 2019-02-13-1 qt.tools.vcredist_msvc2019_x64
+    py -m aqt tool windows desktop tools_vcredist
     .\Qt\Tools\vcredist\vcredist_msvc2019_x64.exe /norestart /q
 
 
@@ -235,7 +235,7 @@ Example: Install MinGW on Windows
 
 .. code-block:: console
 
-    py -m aqt tool -O c:\Qt windows tools_mingw 8.1.0-1-202004170606 qt.tools.win64_mingw810
+    py -m aqt tool -O c:\Qt windows desktop tools_mingw qt.tools.win64_mingw810
     set PATH=C:\Qt\Tools\mingw810_64\bin
 
 

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -787,6 +787,7 @@ class ToolArchives(QtArchives):
         arch: Optional[str] = None,
         timeout: Tuple[int, int] = (5, 5),
     ):
+        self.tool_name = tool_name
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target=target,

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -118,6 +118,10 @@ class ListCommand:
         def __bool__(self):
             return len(self.strings) > 0 and len(self.strings[0]) > 0
 
+        def __iter__(self):
+            for item in self.strings:
+                yield item
+
     class Tools(ListOfStr):
         def pretty_print(self) -> str:
             return "\n".join(self.strings)

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -780,17 +780,19 @@ class ToolArchives(QtArchives):
     def __init__(
         self,
         os_name: str,
+        target: str,
         tool_name: str,
         base: str,
         arch: Optional[str] = None,
         timeout: Tuple[int, int] = (5, 5),
     ):
+        self.target = target
         self.tool_name = tool_name
         self.os_name = os_name
         self.logger = getLogger("aqt.archives")
         super(ToolArchives, self).__init__(
             os_name=os_name,
-            target="desktop",
+            target=target,
             version_str="0.0.1",  # dummy version
             arch=arch,
             base=base,

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -112,6 +112,9 @@ class ListCommand:
         def pretty_print(self) -> str:
             return " ".join(self.strings)
 
+        def get(self, index: int) -> str:
+            return self.strings[index]
+
         def __bool__(self):
             return len(self.strings) > 0 and len(self.strings[0]) > 0
 
@@ -188,7 +191,7 @@ class ListCommand:
             return 0
         except CliInputError as e:
             self.logger.error("Command line input error: {}".format(e))
-            exit(1)
+            return 1
         except (ArchiveConnectionError, ArchiveDownloadError) as e:
             self.logger.error("{}".format(e))
             self.print_suggested_follow_up(self.logger.error)
@@ -779,7 +782,6 @@ class ToolArchives(QtArchives):
         os_name: str,
         tool_name: str,
         base: str,
-        version_str: Optional[str] = None,
         arch: Optional[str] = None,
         timeout: Tuple[int, int] = (5, 5),
     ):
@@ -789,14 +791,14 @@ class ToolArchives(QtArchives):
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target="desktop",
-            version_str=version_str,
+            version_str="0.0.1",  # dummy version
             arch=arch,
             base=base,
             timeout=timeout,
         )
 
     def __str__(self):
-        return f"ToolArchives(tool_name={self.tool_name}, version={self.version_str}, arch={self.arch})"
+        return f"ToolArchives(tool_name={self.tool_name}, arch={self.arch})"
 
     def _get_archives(self):
         _a = "_x64"

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -838,14 +838,6 @@ class ToolArchives(QtArchives):
             else:
                 downloadable_archives = []
             named_version = packageupdate.find("Version").text
-            full_version = Version(named_version)
-            if full_version.truncate("patch") != self.version.truncate("patch"):
-                self.logger.warning(
-                    "Base Version of {} is different from requested version {} -- skip.".format(
-                        named_version, self.version
-                    )
-                )
-                continue
             package_desc = packageupdate.find("Description").text
             for archive in downloadable_archives:
                 package_url = posixpath.join(

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -783,13 +783,14 @@ class ToolArchives(QtArchives):
         target: str,
         tool_name: str,
         base: str,
+        version_str: Optional[str] = None,
         arch: Optional[str] = None,
         timeout: Tuple[int, int] = (5, 5),
     ):
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target=target,
-            version_str="0.0.1",  # dummy version
+            version_str=version_str,
             arch=arch,
             base=base,
             timeout=timeout,

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -786,10 +786,6 @@ class ToolArchives(QtArchives):
         arch: Optional[str] = None,
         timeout: Tuple[int, int] = (5, 5),
     ):
-        self.target = target
-        self.tool_name = tool_name
-        self.os_name = os_name
-        self.logger = getLogger("aqt.archives")
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target=target,

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -433,7 +433,11 @@ class Cli:
         else:
             timeout = (Settings.connection_timeout, Settings.response_timeout)
         if args.arch is None:
-            archs = ListCommand(archive_id=ArchiveId("tools", os_name, target, ""), is_latest_version=True, tool_name=tool_name).action()
+            archs = ListCommand(
+                archive_id=ArchiveId("tools", os_name, target, ""),
+                is_latest_version=True,
+                tool_name=tool_name,
+            ).action()
         else:
             archs = [args.arch]
 
@@ -470,7 +474,9 @@ class Cli:
                         timeout=timeout,
                     )
                 except Exception:
-                    self.logger.error("Connection to the download site failed. Aborted...")
+                    self.logger.error(
+                        "Connection to the download site failed. Aborted..."
+                    )
                     exit(1)
             except ArchiveDownloadError or ArchiveListError:
                 exit(1)

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -402,12 +402,13 @@ class Cli:
         """Run tool subcommand"""
         start_time = time.perf_counter()
         self.show_aqt_version()
+        target = args.target
         tool_name = args.tool_name
         os_name = args.host
         output_dir = args.outputdir
         arch = args.arch
         if arch is None:
-            getArch = ListCommand(archive_id=ArchiveId("tools", os_name, "desktop", ""), is_latest_version=True, tool_name=tool_name)
+            getArch = ListCommand(archive_id=ArchiveId("tools", os_name, target, ""), is_latest_version=True, tool_name=tool_name)
             arch = getArch.action().get(0)
         if output_dir is None:
             base_dir = os.getcwd()
@@ -437,6 +438,7 @@ class Cli:
             tool_archives = ToolArchives(
                 os_name=os_name,
                 tool_name=tool_name,
+                target=target,
                 base=base,
                 arch=arch,
                 timeout=timeout,
@@ -448,6 +450,7 @@ class Cli:
                 )
                 tool_archives = ToolArchives(
                     os_name=os_name,
+                    target=target,
                     tool_name=tool_name,
                     base=random.choice(Settings.fallbacks),
                     arch=arch,
@@ -727,6 +730,13 @@ class Cli:
         tools_parser.add_argument(
             "host", choices=["linux", "mac", "windows"], help="host os name"
         )
+        tools_parser.add_argument(
+            "target",
+            default=None,
+            choices=["desktop", "winrt", "android", "ios"],
+            help="Target SDK.",
+        )
+
         tools_parser.add_argument(
             "tool_name", help="Name of tool such as tools_ifw, tools_mingw"
         )

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -402,10 +402,13 @@ class Cli:
         """Run tool subcommand"""
         start_time = time.perf_counter()
         self.show_aqt_version()
-        arch = args.arch
         tool_name = args.tool_name
         os_name = args.host
         output_dir = args.outputdir
+        arch = args.arch
+        if arch is None:
+            getArch = ListCommand(archive_id=ArchiveId("tools", os_name, "desktop", ""), is_latest_version=True, tool_name=tool_name)
+            arch = getArch.action().get(0)
         if output_dir is None:
             base_dir = os.getcwd()
         else:
@@ -414,7 +417,6 @@ class Cli:
         if EXT7Z and sevenzip is None:
             # override when py7zr is not exist
             sevenzip = self._set_sevenzip(Settings.zipcmd)
-        version = args.version
         keep = args.keep
         if args.base is not None:
             base = args.base
@@ -436,7 +438,6 @@ class Cli:
                 os_name=os_name,
                 tool_name=tool_name,
                 base=base,
-                version_str=version,
                 arch=arch,
                 timeout=timeout,
             )
@@ -449,7 +450,6 @@ class Cli:
                     os_name=os_name,
                     tool_name=tool_name,
                     base=random.choice(Settings.fallbacks),
-                    version_str=version,
                     arch=arch,
                     timeout=timeout,
                 )
@@ -731,10 +731,9 @@ class Cli:
             "tool_name", help="Name of tool such as tools_ifw, tools_mingw"
         )
         tools_parser.add_argument(
-            "version", help='Tool version in the format of "4.1.2"'
-        )
-        tools_parser.add_argument(
             "arch",
+            nargs="?",
+            default=None,
             help="Name of full tool name such as qt.tools.ifw.31. "
             "Please use 'aqt list --tool' to list acceptable values for this parameter.",
         )

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -410,9 +410,9 @@ class Cli:
         """Run tool subcommand"""
         start_time = time.perf_counter()
         self.show_aqt_version()
-        target = args.target
-        tool_name = args.tool_name
-        os_name = args.host
+        os_name = args.host  # windows, linux and mac
+        target = args.target  # desktop, android and ios
+        tool_name = args.tool_name  # such as tools_openssl_x64
         output_dir = args.outputdir
         arch = args.arch
         if arch is None:
@@ -426,6 +426,7 @@ class Cli:
         if EXT7Z and sevenzip is None:
             # override when py7zr is not exist
             sevenzip = self._set_sevenzip(Settings.zipcmd)
+        version = "0.0.1"  # just store a dummy version
         keep = args.keep
         if args.base is not None:
             base = args.base
@@ -448,6 +449,7 @@ class Cli:
                 tool_name=tool_name,
                 target=target,
                 base=base,
+                version_str=version,
                 arch=arch,
                 timeout=timeout,
             )
@@ -461,6 +463,7 @@ class Cli:
                     target=target,
                     tool_name=tool_name,
                     base=random.choice(Settings.fallbacks),
+                    version_str=version,
                     arch=arch,
                     timeout=timeout,
                 )

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -189,10 +189,10 @@ steps:
         jom
       } elseif ( $env:TOOLCHAIN -eq 'MINGW' ) {
         if ( $env:ARCH -eq 'win64_mingw81' ) {
-          python -m aqt tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) tools_mingw 8.1.0-1-202004170606 qt.tools.win64_mingw810
+          python -m aqt tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) desktop tools_mingw qt.tools.win64_mingw810
           [Environment]::SetEnvironmentVariable("Path", ";$(Build.BinariesDirectory)\Qt\Tools\mingw810_64\bin" + $env:Path, "Machine")
         } else {
-          python -m aqt tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) tools_mingw 8.1.0-1-202004170606 qt.tools.win32_mingw810
+          python -m aqt tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) desktop tools_mingw qt.tools.win32_mingw810
           [Environment]::SetEnvironmentVariable("Path", ";$(Build.BinariesDirectory)\Qt\Tools\mingw810_32\bin" + $env:Path, "Machine")
         }
         $env:Path = "$(Build.BinariesDirectory)\Qt\Tools\$(ARCHDIR)\bin;$(WIN_QT_BINDIR);" + $env:Path

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -295,7 +295,7 @@ Example: Install vcredist on Windows:
 .. code-block:: doscon
 
 
-    aqt tool windows tools_vcredist msvc2019_x64
+    aqt tool windows tools_vcredist
     .\Qt\Tools\vcredist\vcredist_msvc2019_x64.exe /norestart /q
 
 
@@ -303,7 +303,7 @@ Example: Install MinGW on Windows
 
 .. code-block:: doscon
 
-    aqt tool -O c:\Qt windows tools_mingw 8.1.0
+    aqt tool -O c:\Qt windows tools_mingw qt.tools.win64_mingw810
     set PATH=C:\Qt\Tools\mingw810_64\bin
 
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -162,8 +162,9 @@ Installation command
     This is advanced option and you should use with --modules option.
     This allow you to add modules to existent Qt installation.
 
-Tool installation commands
---------------------------
+
+Source installation command
+---------------------------
 
 .. program::  aqt
 
@@ -177,22 +178,32 @@ Tool installation commands
     such as qtbase.
 
 
+Document installation command
+-----------------------------
+
 .. option:: doc <Qt version> <target OS> <target variant>
 
     install Qt documents specified version and target.
 
+
+Example installation command
+----------------------------
 
 .. option:: examples <Qt version> <target OS> <target variant>
 
     install Qt examples specified version and target.
 
 
-.. option:: tool <target OS> <target tool name> <target tool version> <tool variant name>
+Tools installation command
+---------------------------
 
-    install tools specified. tool name may be 'tools_openssl_x64', 'tools_ninja', 'tools_ifw', 'tools_cmake'
-    and tool variants name may be 'qt.tools.openssl.gcc_64', 'qt.tools.ninja',  'qt.tools.ifw.32', 'qt.tools.cmake'.
-    You may use the :ref:`List command` with the `--tool` flag to display what tool variant names are available.
-    You may need to looking for version number at  https://download.qt.io/online/qtsdkrepository/
+.. option:: tool <target OS> <target variant> <tool name> [<tool variant name>]
+
+    install tools specified. tool name may be 'tools_openssl_x64', 'tools_vcredist', 'tools_ninja',
+    'tools_ifw', 'tools_cmake'
+    You may use the :ref:`List command` with the `--tool` flag to display what tool names are available.
+
+    tool variants name may be 'qt.tools.openssl.gcc_64', 'qt.tools.vcredist_msvc2013_x64'.
 
 
 Command examples
@@ -276,23 +287,23 @@ Example: Install an Install FrameWork (IFW):
 
 .. code-block:: bash
 
-    aqt tool linux tools_ifw 4.1 qt.tools.ifw.41
+    aqt tool linux desktop tools_ifw
 
 
 Example: Install vcredist:
 
 .. code-block:: bash
 
-    C:\ aqt tool windows tools_vcredist 2019-02-13-1 qt.tools.vcredist_msvc2019_x64
-    C:\ .\Qt\Tools\vcredist\vcredist_msvc2019_x64.exe /norestart /q
+    C:\ aqt tool -O c:\Qt windows desktop tools_vcredist
+    C:\ \Qt\Tools\vcredist\vcredist_msvc2019_x64.exe /norestart /q
 
 
 Example: Install MinGW on Windows
 
 .. code-block:: bash
 
-    C:\ aqt tool -O c:\Qt windows tools_mingw 8.1.0-1-202004170606 qt.tools.win64_mingw810w
-    c:\ set PATH=C:\Qt\Tools\mingw810_64\bin
+    C:\ aqt tool -O c:\Qt windows desktop tools_mingw qt.tools.mingw482
+    c:\ set PATH=C:\Qt\Tools\mingw482_32\bin
 
 
 Example: Show help message


### PR DESCRIPTION
Improve tool command; user can do such as follows;

- `aqt tool windows desktop tools_openssl_x64`
- `aqt tool windows android tools_qt3dstudio_runtime_240`
- `aqt tool windows desktop tools_conan`
- `aqt tool windows desktop tools_vcredist`
- `aqt tool linux desktop tools_ifw`
- `aqt tool mac desktop  tools_ninja`

Implement #282 and fix #233

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
