### PR TITLE
Validate version strings more consistently

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -188,7 +188,7 @@ class ListCommand:
             return 0
         except CliInputError as e:
             self.logger.error("Command line input error: {}".format(e))
-            exit(1)
+            return 1
         except (ArchiveConnectionError, ArchiveDownloadError) as e:
             self.logger.error("{}".format(e))
             self.print_suggested_follow_up(self.logger.error)


### PR DESCRIPTION
This removes the `exit(1)` call from the helper function `Cli._validate_version_str`, and makes that function return `True` or `False` instead. This puts the responsibilities of writing error messages and calling `exit` on the caller.

This change allows `Cli.run_list` to call `Cli._validate_version_str`, the same way that `run_install` and `run_src_doc_examples` do.

As a side effect, this allows `tests/test_cli.test_cli_invalid_version()` to pass, as discussed in my comment on #299.

This solution allows the test to pass, and I think it's a better solution than simply changing the test.