### PR TITLE
Fix `ToolArchives.__str__()`

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -796,7 +796,7 @@ class ToolArchives(QtArchives):
         )
 
     def __str__(self):
-        return f"ToolArchives(tool_name={self.tool_name}, version={self.version_str}, arch={self.arch})"
+        return f"ToolArchives(tool_name={self.tool_name}, version={self.version}, arch={self.arch})"
 
     def _get_archives(self):
         _a = "_x64"


### PR DESCRIPTION
This change prevents an AttributeError from being raised when `ToolArchive.__str__()` is called.

Neither `ToolArchives` nor the parent class `QtArchives` contains the data member `version_str`, yet it is referenced in the `__str__` method. This change replaces it with the correct data member, `QtArchives.version`.