### PR TITLE
WIP: aqt tool improvements

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -274,9 +274,18 @@ class ListCommand:
     def fetch_tool_by_simple_spec(
         self, tool_name: str, simple_spec: SimpleSpec
     ) -> Optional[Dict[str, str]]:
-        # Get data for all the tool modules
+        """This fetches the whole XML record"""
         all_tools_data = self._fetch_tool_data(tool_name)
         return ListCommand.choose_highest_version_in_spec(all_tools_data, simple_spec)
+
+    def fetch_tool_module_by_simple_spec(
+        self, tool_name: str, simple_spec: SimpleSpec
+    ) -> Optional[str]:
+        """This fetches just the name of the XML record"""
+        tool_data = self.fetch_tool_by_simple_spec(tool_name, simple_spec)
+        if tool_data is None:
+            return None
+        return tool_data["Name"]
 
     @staticmethod
     def choose_highest_version_in_spec(

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -20,12 +20,23 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import itertools
+import operator
 import posixpath
 import random
 import re
 import xml.etree.ElementTree as ElementTree
 from logging import getLogger
-from typing import Callable, Generator, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import (
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import bs4
 from semantic_version import SimpleSpec, Version
@@ -243,15 +254,55 @@ class ListCommand:
         html_doc = self.fetch_http(self.archive_id.to_url())
         return ListCommand.Tools(list(ListCommand.iterate_folders(html_doc, "tools")))
 
-    def fetch_tool_modules(self, tool_name: str) -> ListOfStr:
+    def _fetch_tool_data(
+        self, tool_name: str, keys_to_keep: Optional[Iterable[str]] = None
+    ) -> Dict[str, Dict[str, str]]:
+        # raises ArchiveDownloadError, ArchiveConnectionError
         rest_of_url = self.archive_id.to_url() + tool_name + "/Updates.xml"
-        xml = self.fetch_http(rest_of_url)  # raises RequestException
+        xml = self.fetch_http(rest_of_url)
         modules = xml_to_modules(
             xml,
             predicate=ListCommand._has_nonempty_downloads,
-            keys_to_keep=(),  # Just want names
+            keys_to_keep=keys_to_keep,
         )
-        return ListCommand.ListOfStr(strings=list(modules.keys()))
+        return modules
+
+    def fetch_tool_modules(self, tool_name: str) -> ListOfStr:
+        tool_data = self._fetch_tool_data(tool_name, keys_to_keep=())
+        return ListCommand.ListOfStr(strings=list(tool_data.keys()))
+
+    def fetch_tool_by_simple_spec(
+        self, tool_name: str, simple_spec: SimpleSpec
+    ) -> Optional[Dict[str, str]]:
+        # Get data for all the tool modules
+        all_tools_data = self._fetch_tool_data(tool_name)
+        return ListCommand.choose_highest_version_in_spec(all_tools_data, simple_spec)
+
+    @staticmethod
+    def choose_highest_version_in_spec(
+        all_tools_data: Dict[str, Dict[str, str]], simple_spec: SimpleSpec
+    ) -> Optional[Dict[str, str]]:
+        # Get versions of all modules. Fail if version cannot be determined.
+        try:
+            tools_versions = [
+                (name, tool_data, helper.to_version_permissive(tool_data["Version"]))
+                for name, tool_data in all_tools_data.items()
+            ]
+        except ValueError:
+            return None
+
+        # Remove items that don't conform to simple_spec
+        tools_versions = filter(
+            lambda tool_item: tool_item[2] in simple_spec, tools_versions
+        )
+
+        try:
+            # Return the conforming item with the highest version.
+            # If there are multiple items with the same version, the result will not be predictable.
+            return max(tools_versions, key=operator.itemgetter(2))[1]
+        except ValueError:
+            # There were no tools that fit the simple_spec
+            return None
 
     def _to_version(self, qt_ver: str) -> Version:
         """

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -837,6 +837,7 @@ class ToolArchives(QtArchives):
         arch: Optional[str] = None,
         timeout: Tuple[int, int] = (5, 5),
     ):
+        self.tool_name = tool_name
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target=target,

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -102,10 +102,10 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "version, expect",
     [
-        ('1.33.1', Version('1.33.1')),
-        ('1.33.1-202102101246', Version('1.33.1-202102101246')),
-        ('1.33-202102101246', Version('1.33.0-202102101246')),
-        ('2020-05-19-1', Version('2020.0.0-05-19-1')),
+        ("1.33.1", Version("1.33.1")),
+        ("1.33.1-202102101246", Version("1.33.1-202102101246")),
+        ("1.33-202102101246", Version("1.33.0-202102101246")),
+        ("2020-05-19-1", Version("2020.0.0-05-19-1")),
     ],
 )
 def test_helper_to_version_permissive(version, expect):

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,8 +1,10 @@
 import binascii
 import os
 
+import pytest
 import requests
 from requests.models import Response
+from semantic_version import Version
 
 from aqt import helper
 
@@ -95,3 +97,16 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
     helper.downloadBinaryFile(
         "http://example.com/test.xml", out, "sha256", expected, 60
     )
+
+
+@pytest.mark.parametrize(
+    "version, expect",
+    [
+        ('1.33.1', Version('1.33.1')),
+        ('1.33.1-202102101246', Version('1.33.1-202102101246')),
+        ('1.33-202102101246', Version('1.33.0-202102101246')),
+        ('2020-05-19-1', Version('2020.0.0-05-19-1')),
+    ],
+)
+def test_helper_to_version_permissive(version, expect):
+    assert helper.to_version_permissive(version) == expect

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 
 import pytest
-from semantic_version import Version, SimpleSpec
+from semantic_version import SimpleSpec, Version
 
 from aqt import archives, installer
 from aqt.archives import ListCommand
@@ -237,13 +237,13 @@ def test_list_cli(
 @pytest.mark.parametrize(
     "simple_spec, expected_name",
     (
-            (SimpleSpec("*"), "mytool.999"),
-            (SimpleSpec(">3.5"), "mytool.999"),
-            (SimpleSpec("3.5.5"), "mytool.355"),
-            (SimpleSpec("<3.5"), "mytool.300"),
-            (SimpleSpec("<=3.5"), "mytool.355"),
-            (SimpleSpec("<=3.5.0"), "mytool.350"),
-            (SimpleSpec(">10"), None),
+        (SimpleSpec("*"), "mytool.999"),
+        (SimpleSpec(">3.5"), "mytool.999"),
+        (SimpleSpec("3.5.5"), "mytool.355"),
+        (SimpleSpec("<3.5"), "mytool.300"),
+        (SimpleSpec("<=3.5"), "mytool.355"),
+        (SimpleSpec("<=3.5.0"), "mytool.350"),
+        (SimpleSpec(">10"), None),
     ),
 )
 def test_list_choose_tool_by_version(simple_spec, expected_name):


### PR DESCRIPTION
This allows commands such as `aqt tool windows desktop tools_openssl_x64 --spec ">=1.1"`.

This adds a command line argument to `aqt tool` called `--spec` that allows the user to specify constraints on the version number of the tool being installed, using a SimpleSpec. When `arch` is not specified, `aqt tool` will install the highest version of the tool available that fits the specified SimpleSpec. This argument is '*' by default, so if neither `arch` nor `--spec` is specified, `aqt tool` will select the highest version of the tools available in `tool_name`.

This feature will work on all tools, but it will not necessarily produce the intended results. Some `tool_names` include several different tools whose versions are not comparable. For example, `tools_conan` includes Conan 1.33 and Conan.cmake 0.16.0. These are completely different tools with different version histories. To install them properly, it only makes sense to install both variants `qt.tools.conan.cmake` and `qt.tools.conan` by name. `--spec` would only install one of them. Additionally, `tools_vcredist` and `tools_mingw` come in 32-bit and 64-bit flavors, and this tool does not distinguish between them.

So far, only two tests have been added for this feature, but I think they cover the most important parts of this code. However, this will require some additions to the Azure pipelines tests that have not been implemented yet.

Addresses #233 and #282.