### PR TITLE
List tool versions

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -40,6 +40,7 @@ from typing import (
 
 import bs4
 from semantic_version import SimpleSpec, Version
+from texttable import Texttable
 
 from aqt import helper
 from aqt.exceptions import (
@@ -130,6 +131,20 @@ class ListCommand:
         def pretty_print(self) -> str:
             return "\n".join(self.strings)
 
+    class Table:
+        def __init__(self, head: List[str], rows: List[List[str]], max_width: int = 0):
+            # max_width is set to 0 by default: this disables wrapping of text table cells
+            self.head = head
+            self.rows = rows
+            self.max_width = max_width
+
+        def pretty_print(self) -> str:
+            table = Texttable(max_width=self.max_width)
+            table.set_deco(Texttable.HEADER)
+            table.header(self.head)
+            table.add_rows(self.rows, header=False)
+            return table.draw()
+
     def __init__(
         self,
         archive_id: ArchiveId,
@@ -140,6 +155,7 @@ class ListCommand:
         extensions_ver: Optional[str] = None,
         architectures_ver: Optional[str] = None,
         tool_name: Optional[str] = None,
+        tool_long_listing: Optional[str] = None,
     ):
         """
         Construct ListCommand.
@@ -160,6 +176,9 @@ class ListCommand:
             if tool_name:
                 self.request_type = "tool variant names"
                 self._action = lambda: self.fetch_tool_modules(tool_name)
+            elif tool_long_listing:
+                self.request_type = "tool long listing"
+                self._action = lambda: self.fetch_tool_long_listing(tool_long_listing)
             else:
                 self.request_type = "tools"
                 self._action = self.fetch_tools
@@ -274,6 +293,22 @@ class ListCommand:
         # Get data for all the tool modules
         all_tools_data = self._fetch_tool_data(tool_name)
         return ListCommand.choose_highest_version_in_spec(all_tools_data, simple_spec)
+
+    def fetch_tool_long_listing(self, tool_name: str) -> Table:
+        head = [
+            "Tool Variant Name",
+            "Version",
+            "Release Date",
+            "Display Name",
+            "Description",
+        ]
+        keys = ("Version", "ReleaseDate", "DisplayName", "Description")
+        tool_data = self._fetch_tool_data(tool_name, keys_to_keep=keys)
+        rows = [
+            [name, *[content[key] for key in keys]]
+            for name, content in tool_data.items()
+        ]
+        return ListCommand.Table(head, rows)
 
     @staticmethod
     def choose_highest_version_in_spec(

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -510,6 +510,7 @@ class Cli:
             extensions_ver=args.extensions,
             architectures_ver=args.arch,
             tool_name=args.tool,
+            tool_long_listing=args.tool_long,
         )
         return command.run()
 
@@ -599,6 +600,16 @@ class Cli:
             "When set, this prints all 'tool variant names' available. "
             # TODO: find a better word ^^^^^^^^^^^^^^^^^^^^; this is a mysterious help message
             "The output of this command is intended to be used with `aqt tool`.",
+        )
+        output_modifier_exclusive_group.add_argument(
+            "--tool-long",
+            type=str,
+            metavar="TOOL_NAME",
+            help="The name of a tool. Use 'aqt list tools <host> <target>' to see accepted values. "
+            "This flag only works with the 'tools' category, and cannot be combined with any other flags. "
+            "When set, this prints all 'tool variant names' available, along with versions and release dates. "
+            # TODO: find a better word ^^^^^^^^^^^^^^^^^^^^; this is a mysterious help message
+            "The output of this command is formatted as a table.",
         )
         list_parser.set_defaults(func=self.run_list)
 

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -76,6 +76,11 @@ steps:
         aqt list $qtmajor $(HOST)                                               # print all targets for host
         aqt list tools $(HOST) $(TARGET)                                        # print all tools for host/target
         aqt list tools $(HOST) $(TARGET) --tool tools_qt3dstudio_runtime_240    # print all tool variant names for qt3dstudio
+        aqt list tools $(HOST) $(TARGET) --tool-long tools_qt3dstudio_runtime_240    # print tool variant names, versions, release dates
+        if [[ "$(TARGET)" == "desktop" ]]; then
+          aqt list tools $(HOST) $(TARGET) --tool tools_qtcreator               # print all tool variant names for qtcreator
+          aqt list tools $(HOST) $(TARGET) --tool-long tools_qtcreator          # print tool variant names, versions, release dates
+        fi
         aqt list $qtmajor $(HOST) $(TARGET)                                     # print all versions of Qt
         if [[ $(HAS_WASM_EXTENSION) == "True" ]]; then
           aqt list $qtmajor $(HOST) $(TARGET) --extension wasm                  # print all wasm versions of Qt5

--- a/tests/data/mac-desktop-tools_cmake-expect.json
+++ b/tests/data/mac-desktop-tools_cmake-expect.json
@@ -1,5 +1,14 @@
 {
   "modules": [
     "qt.tools.cmake"
+  ],
+  "long_listing": [
+    [
+      "qt.tools.cmake",
+      "3.19.2-202101071155",
+      "2021-01-07",
+      "CMake 3.19.2",
+      "CMake tools 3.19.2"
+    ]
   ]
 }

--- a/tests/data/mac-desktop-tools_ifw-expect.json
+++ b/tests/data/mac-desktop-tools_ifw-expect.json
@@ -1,5 +1,14 @@
 {
   "modules": [
     "qt.tools.ifw.41"
+  ],
+  "long_listing": [
+    [
+      "qt.tools.ifw.41",
+      "4.1.1-202105261132",
+      "2021-05-26",
+      "Qt Installer Framework 4.1",
+      "The Qt Installer Framework provides a set of tools and utilities to create installers for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS."
+    ]
   ]
 }

--- a/tests/data/mac-desktop-tools_qtcreator-expect.json
+++ b/tests/data/mac-desktop-tools_qtcreator-expect.json
@@ -3,5 +3,28 @@
     "qt.tools.qtcreator",
     "qt.tools.qtcreatordbg",
     "qt.tools.qtcreatordev"
+  ],
+  "long_listing": [
+    [
+      "qt.tools.qtcreator",
+      "4.15.1-0-202106081242",
+      "2021-06-08",
+      "Qt Creator 4.15.1",
+      "IDE for Qt application development"
+    ],
+    [
+      "qt.tools.qtcreatordbg",
+      "4.15.1-0-202106081242",
+      "2021-06-08",
+      "Qt Creator 4.15.1 Debug Symbols",
+      "Additional symbol files required to debug Qt Creator"
+    ],
+    [
+      "qt.tools.qtcreatordev",
+      "4.15.1-0-202106081242",
+      "2021-06-08",
+      "Qt Creator 4.15.1 Plugin Development",
+      "Headers and libs required to develop additional plugins"
+    ]
   ]
 }

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -102,10 +102,10 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "version, expect",
     [
-        ('1.33.1', Version('1.33.1')),
-        ('1.33.1-202102101246', Version('1.33.1-202102101246')),
-        ('1.33-202102101246', Version('1.33.0-202102101246')),
-        ('2020-05-19-1', Version('2020.0.0-05-19-1')),
+        ("1.33.1", Version("1.33.1")),
+        ("1.33.1-202102101246", Version("1.33.1-202102101246")),
+        ("1.33-202102101246", Version("1.33.0-202102101246")),
+        ("2020-05-19-1", Version("2020.0.0-05-19-1")),
     ],
 )
 def test_helper_to_version_permissive(version, expect):

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,8 +1,10 @@
 import binascii
 import os
 
+import pytest
 import requests
 from requests.models import Response
+from semantic_version import Version
 
 from aqt import helper
 
@@ -95,3 +97,16 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
     helper.downloadBinaryFile(
         "http://example.com/test.xml", out, "sha256", expected, 60
     )
+
+
+@pytest.mark.parametrize(
+    "version, expect",
+    [
+        ('1.33.1', Version('1.33.1')),
+        ('1.33.1-202102101246', Version('1.33.1-202102101246')),
+        ('1.33-202102101246', Version('1.33.0-202102101246')),
+        ('2020-05-19-1', Version('2020.0.0-05-19-1')),
+    ],
+)
+def test_helper_to_version_permissive(version, expect):
+    assert helper.to_version_permissive(version) == expect

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -260,13 +260,13 @@ def test_list_cli(
 @pytest.mark.parametrize(
     "simple_spec, expected_name",
     (
-            (SimpleSpec("*"), "mytool.999"),
-            (SimpleSpec(">3.5"), "mytool.999"),
-            (SimpleSpec("3.5.5"), "mytool.355"),
-            (SimpleSpec("<3.5"), "mytool.300"),
-            (SimpleSpec("<=3.5"), "mytool.355"),
-            (SimpleSpec("<=3.5.0"), "mytool.350"),
-            (SimpleSpec(">10"), None),
+        (SimpleSpec("*"), "mytool.999"),
+        (SimpleSpec(">3.5"), "mytool.999"),
+        (SimpleSpec("3.5.5"), "mytool.355"),
+        (SimpleSpec("<3.5"), "mytool.300"),
+        (SimpleSpec("<=3.5"), "mytool.355"),
+        (SimpleSpec("<=3.5.0"), "mytool.350"),
+        (SimpleSpec(">10"), None),
     ),
 )
 def test_list_choose_tool_by_version(simple_spec, expected_name):


### PR DESCRIPTION
This adds the ability to list tool module names alongside some extra metadata, including version, release date, display name, and description. Here's some sample output:

```
$ python -m aqt list tools windows desktop --tool-long tools_conan

 Tool Variant Name           Version         Release Date     Display Name              Description         
============================================================================================================
qt.tools.conan         1.33-202102101246     2021-02-10     Conan 1.33          Conan command line tool 1.33
qt.tools.conan.cmake   0.16.0-202102101246   2021-02-10     Conan conan.cmake   Conan conan.cmake (0.16.0)
```

This kind of output is really helpful for me personally, since I'm trying to work on `aqt tool`, and that requires looking for the version and release date of packages in Updates.xml files. This command makes that a lot easier. I think that if it's useful to me, it might be pretty useful for others as well.

The only part of this I'm unsure about is the inclusion of Display Name and Description. I think that part could be really useful for some people, but it makes the output really wide. I'm using `texttable` to print the tables, and when the tables are set to the default width (80 characters), many entries become completely unreadable. I think it would make sense to add some cli flags that change this kind of output, but I don't want to make the `aqt list` interface too complicated. 