### PR TITLE
Fix failure of requests for Qt 5.9.0

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -578,9 +578,12 @@ class ListCommand:
         self, version: Version
     ) -> Tuple[List[str], List[str]]:
         """Returns [list of modules, list of architectures]"""
+        # NOTE: The url at `<base>/<host>/<target>/qt5_590/` does not exist; the real one is `qt5_590`
         patch = (
             ""
-            if version.prerelease or self.archive_id.is_preview()
+            if version.prerelease 
+            or self.archive_id.is_preview()
+            or version in SimpleSpec("5.9.0")
             else str(version.patch)
         )
         qt_ver_str = "{}{}{}".format(version.major, version.minor, patch)

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -581,7 +581,7 @@ class ListCommand:
         # NOTE: The url at `<base>/<host>/<target>/qt5_590/` does not exist; the real one is `qt5_590`
         patch = (
             ""
-            if version.prerelease 
+            if version.prerelease
             or self.archive_id.is_preview()
             or version in SimpleSpec("5.9.0")
             else str(version.patch)


### PR DESCRIPTION
Currently, the following two commands fail with an HTTP 404 when they shouldn't:

```bash
aqt list qt5 windows desktop --modules 5.9.0
aqt list qt5 windows desktop --arch 5.9.0
```

This happens because ListCommand is looking for an xml file at `<base>/<host>/<target>/qt5_590/Updates.xml`; that file doesn't exist because it's actually at `<base>/<host>/<target>/qt5_59/Updates.xml`. So far, this is the only exception like this.

This change accounts for this exception.