### PR TITLE
Add `aqt.metadata.Versions.flattened()`

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -160,9 +160,13 @@ class Versions:
             return None
         return self.versions[-1][-1]
 
-    def __iter__(self) -> List[Version]:
+    def __iter__(self) -> Generator[List[Version], None, None]:
         for item in self.versions:
             yield item
+
+    def flattened(self) -> List[Version]:
+        """Return a flattened list of all versions"""
+        return [version for row in self for version in row]
 
 
 def get_semantic_version(qt_ver: str, is_preview: bool) -> Optional[Version]:

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -2,11 +2,57 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from aqt.installer import Cli
-from aqt.metadata import ArchiveId, MetadataFactory, SimpleSpec, Version
+from aqt.metadata import ArchiveId, MetadataFactory, SimpleSpec, Version, Versions
+
+
+def test_versions():
+    versions = Versions(
+        [
+            (1, [Version("1.1.1"), Version("1.1.2")]),
+            (2, [Version("1.2.1"), Version("1.2.2")]),
+        ]
+    )
+    assert (
+        str(versions)
+        == "[[Version('1.1.1'), Version('1.1.2')], [Version('1.2.1'), Version('1.2.2')]]"
+    )
+    assert format(versions) == "1.1.1 1.1.2\n1.2.1 1.2.2"
+    assert format(versions, "s") == str(versions)
+    assert versions.flattened() == [
+        Version("1.1.1"),
+        Version("1.1.2"),
+        Version("1.2.1"),
+        Version("1.2.2"),
+    ]
+    assert isinstance(versions.__iter__(), Generator)
+    assert versions.latest() == Version("1.2.2")
+    assert versions
+
+    empty_versions = Versions(None)
+    assert str(empty_versions) == "[]"
+    assert format(empty_versions) == ""
+    assert empty_versions.flattened() == []
+    assert isinstance(empty_versions.__iter__(), Generator)
+    assert empty_versions.latest() is None
+    assert not empty_versions
+
+    one_version = Versions(Version("1.2.3"))
+    assert str(one_version) == "[[Version('1.2.3')]]"
+    assert format(one_version) == "1.2.3"
+    assert one_version.flattened() == [Version("1.2.3")]
+    assert isinstance(one_version.__iter__(), Generator)
+    assert one_version.latest() == Version("1.2.3")
+    assert one_version
+
+    with pytest.raises(TypeError) as pytest_wrapped_e:
+        format(versions, "x")
+    assert pytest_wrapped_e.type == TypeError
+
 
 MINOR_REGEX = re.compile(r"^\d+\.(\d+)")
 


### PR DESCRIPTION
This adds a function to Versions that returns a flattened list of Version objects. This is a spinoff from #318 that I needed for that feature, but I think it's outside the scope of that PR.

This also adds test coverage for the whole Versions class.