### PR TITLE
Rename `aqt.list` logger to `aqt.metadata`

### DIFF
--- a/aqt/logging.ini
+++ b/aqt/logging.ini
@@ -32,10 +32,10 @@ handlers=NOTSET
 propagate=0
 qualname=aqt.installer
 
-[logger_aqt_list]
+[logger_aqt_metadata]
 level=INFO
 propagate=1
-qualname=aqt.list
+qualname=aqt.metadata
 
 [logger_aqt_updater]
 level=INFO

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -367,7 +367,7 @@ class MetadataFactory:
         :param extensions_ver:      Version of Qt for which to list extensions
         :param architectures_ver:   Version of Qt for which to list architectures
         """
-        self.logger = getLogger("aqt.archives")
+        self.logger = getLogger("aqt.metadata")
         self.archive_id = archive_id
         self.filter_minor = filter_minor
 
@@ -718,7 +718,7 @@ def suggested_follow_up(meta: MetadataFactory, printer: Callable[[str], None]) -
 
 
 def show_list(meta: MetadataFactory) -> int:
-    logger = getLogger("aqt.list")
+    logger = getLogger("aqt.metadata")
     try:
         output = meta.getList()
         if not output:


### PR DESCRIPTION
This follows the convention set out by the rest of the project, where the loggers are all named after the files in which they are used.