### PR TITLE
Refactor `suggested_follow_up`

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -20,7 +20,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import itertools
-import logging
 import operator
 import posixpath
 import random
@@ -28,7 +27,6 @@ import re
 import shutil
 from logging import getLogger
 from typing import (
-    Callable,
     Dict,
     Generator,
     Iterable,

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -20,6 +20,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import itertools
+import logging
 import operator
 import posixpath
 import random
@@ -717,11 +718,12 @@ def suggested_follow_up(meta: MetadataFactory) -> List[str]:
     return msg
 
 
-def show_suggestion(suggestions: List[str], printer: Callable[[str], None]):
+def log_suggested_follow_up(suggestions: List[str], log_level: int):
     if suggestions:
-        printer("=" * 30 + "Suggested follow-up:" + "=" * 30)
+        logger = getLogger("aqt.metadata")
+        logger.log(log_level, "=" * 30 + "Suggested follow-up:" + "=" * 30)
         for suggestion in suggestions:
-            printer("* " + suggestion)
+            logger.log(log_level, "* " + suggestion)
 
 
 def show_list(meta: MetadataFactory) -> int:
@@ -730,7 +732,7 @@ def show_list(meta: MetadataFactory) -> int:
         output = meta.getList()
         if not output:
             logger.info("No {} available for this request.".format(meta.request_type))
-            show_suggestion(suggested_follow_up(meta), logger.info)
+            log_suggested_follow_up(suggested_follow_up(meta), logging.INFO)
             return 1
         if isinstance(output, Versions):
             print(format(output))
@@ -752,5 +754,5 @@ def show_list(meta: MetadataFactory) -> int:
         return 1
     except (ArchiveConnectionError, ArchiveDownloadError) as e:
         logger.error("{}".format(e))
-        show_suggestion(suggested_follow_up(meta), logger.error)
+        log_suggested_follow_up(suggested_follow_up(meta), logging.ERROR)
         return 1

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -718,12 +718,12 @@ def suggested_follow_up(meta: MetadataFactory) -> List[str]:
     return msg
 
 
-def log_suggested_follow_up(suggestions: List[str], log_level: int):
-    if suggestions:
-        logger = getLogger("aqt.metadata")
-        logger.log(log_level, "=" * 30 + "Suggested follow-up:" + "=" * 30)
-        for suggestion in suggestions:
-            logger.log(log_level, "* " + suggestion)
+def format_suggested_follow_up(suggestions: Iterable[str]) -> str:
+    if not suggestions:
+        return ""
+    return ("=" * 30 + "Suggested follow-up:" + "=" * 30 + "\n") + "\n".join(
+        ["* " + suggestion for suggestion in suggestions]
+    )
 
 
 def show_list(meta: MetadataFactory) -> int:
@@ -732,7 +732,9 @@ def show_list(meta: MetadataFactory) -> int:
         output = meta.getList()
         if not output:
             logger.info("No {} available for this request.".format(meta.request_type))
-            log_suggested_follow_up(suggested_follow_up(meta), logging.INFO)
+            suggestions = suggested_follow_up(meta)
+            if suggestions:
+                logger.info(format_suggested_follow_up(suggestions))
             return 1
         if isinstance(output, Versions):
             print(format(output))
@@ -754,5 +756,7 @@ def show_list(meta: MetadataFactory) -> int:
         return 1
     except (ArchiveConnectionError, ArchiveDownloadError) as e:
         logger.error("{}".format(e))
-        log_suggested_follow_up(suggested_follow_up(meta), logging.ERROR)
+        suggestions = suggested_follow_up(meta)
+        if suggestions:
+            logger.error(format_suggested_follow_up(suggestions))
         return 1

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -26,16 +26,7 @@ import random
 import re
 import shutil
 from logging import getLogger
-from typing import (
-    Dict,
-    Generator,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Dict, Generator, Iterable, Iterator, List, Optional, Tuple, Union
 from xml.etree import ElementTree as ElementTree
 
 import bs4

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -695,35 +695,43 @@ class MetadataFactory:
         return "{} with minor version {}".format(self.archive_id, self.filter_minor)
 
 
-def suggested_follow_up(meta: MetadataFactory, printer: Callable[[str], None]) -> None:
+def suggested_follow_up(meta: MetadataFactory) -> List[str]:
     """Makes an informed guess at what the user got wrong, in the event of an error."""
-    base_cmd = "aqt {0.category} {0.host} {0.target}".format(meta.archive_id)
+    msg = []
+    base_cmd = "aqt list {0.category} {0.host} {0.target}".format(meta.archive_id)
     if meta.archive_id.extension:
-        msg = "Please use '{} --extensions <QT_VERSION>' to list valid extensions.\n".format(
-            base_cmd
+        msg.append(
+            f"Please use '{base_cmd} --extensions <QT_VERSION>' to list valid extensions."
         )
-        printer(msg)
 
     if meta.archive_id.is_tools() and meta.request_type == "tool variant names":
-        msg = "Please use '{}' to check what tools are available.".format(base_cmd)
-        printer(msg)
+        msg.append(f"Please use '{base_cmd}' to check what tools are available.")
     elif meta.filter_minor is not None:
-        msg = "Please use '{}' to check that versions of {} exist with the minor version '{}'".format(
-            base_cmd, meta.archive_id.category, meta.filter_minor
+        msg.append(
+            f"Please use '{base_cmd}' to check that versions of {meta.archive_id.category} "
+            f"exist with the minor version '{meta.filter_minor}'."
         )
-        printer(msg)
     elif meta.request_type in ("architectures", "modules", "extensions"):
-        msg = "Please use '{}' to show versions of Qt available".format(base_cmd)
-        printer(msg)
+        msg.append(f"Please use '{base_cmd}' to show versions of Qt available.")
+
+    return msg
 
 
 def show_list(meta: MetadataFactory) -> int:
     logger = getLogger("aqt.list")
+
+    def show_suggestion(printer):
+        suggestions = suggested_follow_up(meta)
+        if suggestions:
+            printer("=" * 30 + "Suggested follow-up:" + "=" * 30)
+            for suggestion in suggestions:
+                printer("* " + suggestion)
+
     try:
         output = meta.getList()
         if not output:
             logger.info("No {} available for this request.".format(meta.request_type))
-            suggested_follow_up(meta, logger.info)
+            show_suggestion(logger.info)
             return 1
         if isinstance(output, Versions):
             print(format(output))
@@ -745,5 +753,5 @@ def show_list(meta: MetadataFactory) -> int:
         return 1
     except (ArchiveConnectionError, ArchiveDownloadError) as e:
         logger.error("{}".format(e))
-        suggested_follow_up(meta, logger.error)
+        show_suggestion(logger.error)
         return 1

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -717,21 +717,21 @@ def suggested_follow_up(meta: MetadataFactory) -> List[str]:
     return msg
 
 
+def show_suggestion(suggestions: List[str], printer: Callable[[str], None]):
+    if suggestions:
+        printer("=" * 30 + "Suggested follow-up:" + "=" * 30)
+        for suggestion in suggestions:
+            printer("* " + suggestion)
+
+
 def show_list(meta: MetadataFactory) -> int:
     logger = getLogger("aqt.list")
-
-    def show_suggestion(printer):
-        suggestions = suggested_follow_up(meta)
-        if suggestions:
-            printer("=" * 30 + "Suggested follow-up:" + "=" * 30)
-            for suggestion in suggestions:
-                printer("* " + suggestion)
 
     try:
         output = meta.getList()
         if not output:
             logger.info("No {} available for this request.".format(meta.request_type))
-            show_suggestion(logger.info)
+            show_suggestion(suggested_follow_up(meta), logger.info)
             return 1
         if isinstance(output, Versions):
             print(format(output))
@@ -753,5 +753,5 @@ def show_list(meta: MetadataFactory) -> int:
         return 1
     except (ArchiveConnectionError, ArchiveDownloadError) as e:
         logger.error("{}".format(e))
-        show_suggestion(logger.error)
+        show_suggestion(suggested_follow_up(meta), logger.error)
         return 1

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -13,6 +13,7 @@ from aqt.metadata import (
     SimpleSpec,
     Version,
     Versions,
+    show_suggestion,
     suggested_follow_up,
 )
 
@@ -454,3 +455,23 @@ wrong_ext_and_version_msg = [
 )
 def test_suggested_follow_up(meta: MetadataFactory, expected_message: str):
     assert suggested_follow_up(meta) == expected_message
+
+
+def test_show_suggestion():
+    suggestions = [
+        "Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.",
+        "Please use 'aqt list tools mac desktop' to check what tools are available.",
+    ]
+    expected = (
+        "==============================Suggested follow-up:==============================\n"
+        "* Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.\n"
+        "* Please use 'aqt list tools mac desktop' to check what tools are available.\n"
+    )
+
+    output = [""]
+
+    def outputter(msg: str) -> None:
+        output[0] = output[0] + msg + "\n"
+
+    show_suggestion(suggestions, outputter)
+    assert output[0] == expected

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import re
 import sys
 from pathlib import Path
@@ -7,7 +6,6 @@ from typing import Generator
 
 import pytest
 
-from aqt.helper import setup_logging
 from aqt.installer import Cli
 from aqt.metadata import (
     ArchiveId,
@@ -15,7 +13,8 @@ from aqt.metadata import (
     SimpleSpec,
     Version,
     Versions,
-    suggested_follow_up, format_suggested_follow_up,
+    format_suggested_follow_up,
+    suggested_follow_up,
 )
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -15,8 +15,7 @@ from aqt.metadata import (
     SimpleSpec,
     Version,
     Versions,
-    log_suggested_follow_up,
-    suggested_follow_up,
+    suggested_follow_up, format_suggested_follow_up,
 )
 
 
@@ -459,17 +458,15 @@ def test_suggested_follow_up(meta: MetadataFactory, expected_message: str):
     assert suggested_follow_up(meta) == expected_message
 
 
-def test_log_suggested_follow_up(caplog, monkeypatch):
+def test_format_suggested_follow_up():
     suggestions = [
         "Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.",
         "Please use 'aqt list tools mac desktop' to check what tools are available.",
     ]
-    expected = [
-        "==============================Suggested follow-up:==============================",
-        "* Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.",
-        "* Please use 'aqt list tools mac desktop' to check what tools are available.",
-    ]
+    expected = (
+        "==============================Suggested follow-up:==============================\n"
+        "* Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.\n"
+        "* Please use 'aqt list tools mac desktop' to check what tools are available."
+    )
 
-    log_suggested_follow_up(suggestions, logging.ERROR)
-    actual = [rec.message for rec in caplog.records]
-    assert actual == expected
+    assert format_suggested_follow_up(suggestions) == expected

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -7,7 +7,14 @@ from typing import Generator
 import pytest
 
 from aqt.installer import Cli
-from aqt.metadata import ArchiveId, MetadataFactory, SimpleSpec, Version, Versions
+from aqt.metadata import (
+    ArchiveId,
+    MetadataFactory,
+    SimpleSpec,
+    Version,
+    Versions,
+    suggested_follow_up,
+)
 
 
 def test_versions():
@@ -368,3 +375,82 @@ def test_list_invalid_extensions(
     sys.stdout.write(out)
     sys.stderr.write(err)
     assert expected_msg in err
+
+
+mac_qt5 = ArchiveId("qt5", "mac", "desktop")
+mac_wasm = ArchiveId("qt5", "mac", "desktop", "wasm")
+wrong_qt_version_msg = [
+    "Please use 'aqt list qt5 mac desktop' to show versions of Qt available."
+]
+wrong_ext_and_version_msg = [
+    "Please use 'aqt list qt5 mac desktop --extensions <QT_VERSION>' to list valid extensions.",
+    "Please use 'aqt list qt5 mac desktop' to show versions of Qt available.",
+]
+
+
+@pytest.mark.parametrize(
+    "meta, expected_message",
+    (
+        (MetadataFactory(mac_qt5), []),
+        (
+            MetadataFactory(mac_qt5, filter_minor=0),
+            [
+                "Please use 'aqt list qt5 mac desktop' to check that versions of qt5 exist with the minor version '0'."
+            ],
+        ),
+        (
+            MetadataFactory(ArchiveId("tools", "mac", "desktop"), tool_name="ifw"),
+            [
+                "Please use 'aqt list tools mac desktop' to check what tools are available."
+            ],
+        ),
+        (
+            MetadataFactory(mac_qt5, architectures_ver="1.2.3"),
+            wrong_qt_version_msg,
+        ),
+        (
+            MetadataFactory(mac_qt5, modules_ver="1.2.3"),
+            wrong_qt_version_msg,
+        ),
+        (
+            MetadataFactory(mac_qt5, extensions_ver="1.2.3"),
+            wrong_qt_version_msg,
+        ),
+        (
+            MetadataFactory(mac_wasm),
+            [
+                "Please use 'aqt list qt5 mac desktop --extensions <QT_VERSION>' to list valid extensions."
+            ],
+        ),
+        (
+            MetadataFactory(mac_wasm, filter_minor=0),
+            [
+                "Please use 'aqt list qt5 mac desktop --extensions <QT_VERSION>' to list valid extensions.",
+                "Please use 'aqt list qt5 mac desktop' to check that versions of qt5 exist with the minor version '0'.",
+            ],
+        ),
+        (
+            MetadataFactory(
+                ArchiveId("tools", "mac", "desktop", "wasm"), tool_name="ifw"
+            ),
+            [
+                "Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.",
+                "Please use 'aqt list tools mac desktop' to check what tools are available.",
+            ],
+        ),
+        (
+            MetadataFactory(mac_wasm, architectures_ver="1.2.3"),
+            wrong_ext_and_version_msg,
+        ),
+        (
+            MetadataFactory(mac_wasm, modules_ver="1.2.3"),
+            wrong_ext_and_version_msg,
+        ),
+        (
+            MetadataFactory(mac_wasm, extensions_ver="1.2.3"),
+            wrong_ext_and_version_msg,
+        ),
+    ),
+)
+def test_suggested_follow_up(meta: MetadataFactory, expected_message: str):
+    assert suggested_follow_up(meta) == expected_message


### PR DESCRIPTION
This PR splits `aqt.metadata.suggested_follow_up` into:
1. a function that returns a list of strings, and
2. a function that formats and prints those strings

This PR also adds test code for both functions.

Here is an example of what the formatter prints:
```
==============================Suggested follow-up:==============================
* Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.
* Please use 'aqt list tools mac desktop' to check what tools are available.
```