### PR TITLE
Improve test coverage for `aqt/metadata.py`

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -26,17 +26,7 @@ import random
 import re
 import shutil
 from logging import getLogger
-from typing import (
-    Callable,
-    Dict,
-    Generator,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Dict, Generator, Iterable, Iterator, List, Optional, Tuple, Union
 from xml.etree import ElementTree as ElementTree
 
 import bs4

--- a/tests/data/windows-desktop-tools_vcredist-expect.json
+++ b/tests/data/windows-desktop-tools_vcredist-expect.json
@@ -1,0 +1,177 @@
+{
+  "modules": [
+    "qt.tools.vcredist",
+    "qt.tools.vcredist_msvc2015_x86",
+    "qt.tools.vcredist_msvc2013_x64",
+    "qt.tools.vcredist_msvc2015_x64",
+    "qt.tools.vcredist_msvc2013_x86",
+    "qt.tools.vcredist_msvc2017_x64",
+    "qt.tools.vcredist_msvc2017_x86",
+    "qt.tools.vcredist_64",
+    "qt.tools.vcredist_msvc2019_x64",
+    "qt.tools.vcredist_msvc2019_x86"
+  ],
+  "architectures": [
+    "msvc2015_x86",
+    "msvc2013_x64",
+    "msvc2015_x64",
+    "msvc2013_x86",
+    "msvc2017_x64",
+    "msvc2017_x86",
+    "64",
+    "msvc2019_x64",
+    "msvc2019_x86"
+  ],
+  "modules_data": {
+    "qt.tools.vcredist": {
+      "DisplayName": "VCRedist for MSVC 32bit",
+      "Description": "Needed by all included Qt applications.",
+      "Version": "2011-03-03-1",
+      "ReleaseDate": "2014-11-17",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_x86.7z",
+      "UpdateFile": {
+        "CompressedSize": "9065989",
+        "UncompressedSize": "8990592",
+        "OS": "Any"
+      },
+      "SHA1": "6ef633831c4f10e2a975f0cb8bfbbf572dcec1dd"
+    },
+    "qt.tools.vcredist_msvc2015_x86": {
+      "DisplayName": "VCRedist for MSVC 2015 32bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2015 32 bit",
+      "Version": "2017-02-01-0",
+      "ReleaseDate": "2017-01-20",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2015_x86.7z",
+      "UpdateFile": {
+        "CompressedSize": "12766475",
+        "UncompressedSize": "14456912",
+        "OS": "Any"
+      },
+      "SHA1": "04c9b1bdc305877640643b1faae639c61f687b3b"
+    },
+    "qt.tools.vcredist_msvc2013_x64": {
+      "DisplayName": "VCRedist for MSVC 2013 64bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2013 64 bit",
+      "Version": "2017-3-22-0",
+      "ReleaseDate": "2017-03-23",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2013_x64.7z",
+      "UpdateFile": {
+        "CompressedSize": "6985453",
+        "UncompressedSize": "7194352",
+        "OS": "Any"
+      },
+      "SHA1": "51f48b502beb8600ec3a1a782513efdea76472ec"
+    },
+    "qt.tools.vcredist_msvc2015_x64": {
+      "DisplayName": "VCRedist for MSVC 2015 64bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2015 64 bit",
+      "Version": "2017-03-22-0",
+      "ReleaseDate": "2017-03-23",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2015_x64.7z",
+      "UpdateFile": {
+        "CompressedSize": "13606284",
+        "UncompressedSize": "14572040",
+        "OS": "Any"
+      },
+      "SHA1": "5ee3387de572f380387ade03ae8ec258c08e30c1"
+    },
+    "qt.tools.vcredist_msvc2013_x86": {
+      "DisplayName": "VCRedist for MSVC 2013 32bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2013 32 bit",
+      "Version": "2014-30-12-1",
+      "ReleaseDate": "2019-04-16",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2013_x86.7z",
+      "UpdateFile": {
+        "CompressedSize": "6233389",
+        "UncompressedSize": "6504024",
+        "OS": "Any"
+      },
+      "SHA1": "cda6e0ce528e0d38b34f41a8ba5fb57269611578"
+    },
+    "qt.tools.vcredist_msvc2017_x64": {
+      "DisplayName": "VCRedist for MSVC 2017 64bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2017 64 bit",
+      "Version": "2019-02-13-1",
+      "ReleaseDate": "2019-04-16",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2017_x64.7z",
+      "UpdateFile": {
+        "CompressedSize": "13483747",
+        "UncompressedSize": "15330104",
+        "OS": "Any"
+      },
+      "SHA1": "bec7506fdf840eeaa871c3b44b0c3064a81e9a40"
+    },
+    "qt.tools.vcredist_msvc2017_x86": {
+      "DisplayName": "VCRedist for MSVC 2017 32bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2017 32 bit",
+      "Version": "2019-02-13-1",
+      "ReleaseDate": "2019-04-16",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2017_x86.7z",
+      "UpdateFile": {
+        "CompressedSize": "12811307",
+        "UncompressedSize": "14648504",
+        "OS": "Any"
+      },
+      "SHA1": "26b5a9ae55b13a538791f549c98621a315d26969"
+    },
+    "qt.tools.vcredist_64": {
+      "DisplayName": "VCRedist for MSVC 64bit",
+      "Description": "Needed by all included Qt applications.",
+      "Version": "2020-03-18",
+      "ReleaseDate": "2020-03-19",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_x64.7z",
+      "UpdateFile": {
+        "CompressedSize": "10249462",
+        "UncompressedSize": "10274176",
+        "OS": "Any"
+      },
+      "SHA1": "3cb06ab7fc3a2633edeb1bc9f91ecf7048323b9e"
+    },
+    "qt.tools.vcredist_msvc2019_x64": {
+      "DisplayName": "VCRedist for MSVC 2019 64bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2019 64 bit",
+      "Version": "2020-05-19-1",
+      "ReleaseDate": "2020-05-19",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2019_x64.7z",
+      "UpdateFile": {
+        "CompressedSize": "13209756",
+        "UncompressedSize": "15060536",
+        "OS": "Any"
+      },
+      "SHA1": "5e1a6ebf086382c0f2f7e816fe0f15daecb07bf6"
+    },
+    "qt.tools.vcredist_msvc2019_x86": {
+      "DisplayName": "VCRedist for MSVC 2019 32bit",
+      "Description": "Visual C++ Redistributable Packages for Visual Studio 2019 32 bit",
+      "Version": "2019-05-19-1",
+      "ReleaseDate": "2020-05-19",
+      "Script": "installscript.qs",
+      "Virtual": "true",
+      "DownloadableArchives": "vcredist_msvc2019_x86.7z",
+      "UpdateFile": {
+        "CompressedSize": "12515252",
+        "UncompressedSize": "14364480",
+        "OS": "Any"
+      },
+      "SHA1": "e82eeed4f19dd172944149a478c8bf48ff148b0d"
+    }
+  }
+}

--- a/tests/data/windows-desktop-tools_vcredist-update.xml
+++ b/tests/data/windows-desktop-tools_vcredist-update.xml
@@ -1,0 +1,127 @@
+<Updates>
+ <ApplicationName>{AnyApplication}</ApplicationName>
+ <ApplicationVersion>1.0.0</ApplicationVersion>
+ <Checksum>true</Checksum>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist</Name>
+  <DisplayName>VCRedist for MSVC 32bit</DisplayName>
+  <Description>Needed by all included Qt applications.</Description>
+  <Version>2011-03-03-1</Version>
+  <ReleaseDate>2014-11-17</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_x86.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="9065989" UncompressedSize="8990592" OS="Any"/>
+  <SHA1>6ef633831c4f10e2a975f0cb8bfbbf572dcec1dd</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2015_x86</Name>
+  <DisplayName>VCRedist for MSVC 2015 32bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2015 32 bit</Description>
+  <Version>2017-02-01-0</Version>
+  <ReleaseDate>2017-01-20</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2015_x86.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="12766475" UncompressedSize="14456912" OS="Any"/>
+  <SHA1>04c9b1bdc305877640643b1faae639c61f687b3b</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2013_x64</Name>
+  <DisplayName>VCRedist for MSVC 2013 64bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2013 64 bit</Description>
+  <Version>2017-3-22-0</Version>
+  <ReleaseDate>2017-03-23</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2013_x64.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="6985453" UncompressedSize="7194352" OS="Any"/>
+  <SHA1>51f48b502beb8600ec3a1a782513efdea76472ec</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2015_x64</Name>
+  <DisplayName>VCRedist for MSVC 2015 64bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2015 64 bit</Description>
+  <Version>2017-03-22-0</Version>
+  <ReleaseDate>2017-03-23</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2015_x64.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="13606284" UncompressedSize="14572040" OS="Any"/>
+  <SHA1>5ee3387de572f380387ade03ae8ec258c08e30c1</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2013_x86</Name>
+  <DisplayName>VCRedist for MSVC 2013 32bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2013 32 bit</Description>
+  <Version>2014-30-12-1</Version>
+  <ReleaseDate>2019-04-16</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2013_x86.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="6233389" UncompressedSize="6504024" OS="Any"/>
+  <SHA1>cda6e0ce528e0d38b34f41a8ba5fb57269611578</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2017_x64</Name>
+  <DisplayName>VCRedist for MSVC 2017 64bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2017 64 bit</Description>
+  <Version>2019-02-13-1</Version>
+  <ReleaseDate>2019-04-16</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2017_x64.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="13483747" UncompressedSize="15330104" OS="Any"/>
+  <SHA1>bec7506fdf840eeaa871c3b44b0c3064a81e9a40</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2017_x86</Name>
+  <DisplayName>VCRedist for MSVC 2017 32bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2017 32 bit</Description>
+  <Version>2019-02-13-1</Version>
+  <ReleaseDate>2019-04-16</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2017_x86.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="12811307" UncompressedSize="14648504" OS="Any"/>
+  <SHA1>26b5a9ae55b13a538791f549c98621a315d26969</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_64</Name>
+  <DisplayName>VCRedist for MSVC 64bit</DisplayName>
+  <Description>Needed by all included Qt applications.</Description>
+  <Version>2020-03-18</Version>
+  <ReleaseDate>2020-03-19</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_x64.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="10249462" UncompressedSize="10274176" OS="Any"/>
+  <SHA1>3cb06ab7fc3a2633edeb1bc9f91ecf7048323b9e</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2019_x64</Name>
+  <DisplayName>VCRedist for MSVC 2019 64bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2019 64 bit</Description>
+  <Version>2020-05-19-1</Version>
+  <ReleaseDate>2020-05-19</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2019_x64.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="13209756" UncompressedSize="15060536" OS="Any"/>
+  <SHA1>5e1a6ebf086382c0f2f7e816fe0f15daecb07bf6</SHA1>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.tools.vcredist_msvc2019_x86</Name>
+  <DisplayName>VCRedist for MSVC 2019 32bit</DisplayName>
+  <Description>Visual C++ Redistributable Packages for Visual Studio 2019 32 bit</Description>
+  <Version>2019-05-19-1</Version>
+  <ReleaseDate>2020-05-19</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <DownloadableArchives>vcredist_msvc2019_x86.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="12515252" UncompressedSize="14364480" OS="Any"/>
+  <SHA1>e82eeed4f19dd172944149a478c8bf48ff148b0d</SHA1>
+ </PackageUpdate>
+ <MetadataName>2020-08-21-1951_meta.7z</MetadataName>
+ <SHA1>04180f6cd965558942863afd0390eb57990ee354</SHA1>
+</Updates>

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -568,13 +568,22 @@ def test_list_fetch_tool_by_simple_spec(monkeypatch):
     (
         (
             120,
-            "Tool Variant Name        Version         Release Date          Display Name                      Description            \n"
-            "========================================================================================================================\n"
-            "qt.tools.ifw.41     4.1.1-202105261132   2021-05-26     Qt Installer Framework 4.1   The Qt Installer Framework provides\n"
-            "                                                                                     a set of tools and utilities to    \n"
-            "                                                                                     create installers for the supported\n"
-            "                                                                                     desktop Qt platforms: Linux,       \n"
-            "                                                                                     Microsoft Windows, and macOS.      \n",
+            (
+                "Tool Variant Name        Version         Release Date          Display Name          "
+                "            Description            \n"
+                "====================================================================================="
+                "===================================\n"
+                "qt.tools.ifw.41     4.1.1-202105261132   2021-05-26     Qt Installer Framework 4.1   "
+                "The Qt Installer Framework provides\n"
+                "                                                                                     "
+                "a set of tools and utilities to    \n"
+                "                                                                                     "
+                "create installers for the supported\n"
+                "                                                                                     "
+                "desktop Qt platforms: Linux,       \n"
+                "                                                                                     "
+                "Microsoft Windows, and macOS.      \n"
+            ),
         ),
         (
             80,
@@ -585,14 +594,14 @@ def test_list_fetch_tool_by_simple_spec(monkeypatch):
         (
             0,
             "Tool Variant Name        Version         Release Date          Display Name          "
-            "                                                                           Description"
-            "                                                                            \n"
+            "                                                                           Descriptio"
+            "n                                                                            \n"
             "====================================================================================="
-            "======================================================================================"
-            "============================================================================\n"
+            "====================================================================================="
+            "=============================================================================\n"
             "qt.tools.ifw.41     4.1.1-202105261132   2021-05-26     Qt Installer Framework 4.1   "
-            "The Qt Installer Framework provides a set of tools and utilities to create installers "
-            "for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS.\n",
+            "The Qt Installer Framework provides a set of tools and utilities to create installers"
+            " for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS.\n",
         ),
     ),
 )

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -2,7 +2,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Generator
+from typing import Generator, List
 
 import pytest
 
@@ -432,5 +432,22 @@ wrong_ext_and_version_msg = [
         ),
     ),
 )
-def test_suggested_follow_up(meta: MetadataFactory, expected_message: str):
+def test_suggested_follow_up(meta: MetadataFactory, expected_message: List[str]):
     assert suggested_follow_up(meta) == expected_message
+
+
+@pytest.mark.parametrize(
+    "meta, expect",
+    (
+        (MetadataFactory(ArchiveId("qt5", "mac", "desktop"), filter_minor=42),
+         "qt5/mac/desktop with minor version 42"),
+        (MetadataFactory(ArchiveId("qt5", "mac", "desktop", "wasm"), filter_minor=42),
+         "qt5/mac/desktop/wasm with minor version 42"),
+        (MetadataFactory(ArchiveId("qt5", "mac", "desktop")),
+         "qt5/mac/desktop"),
+        (MetadataFactory(ArchiveId("qt5", "mac", "desktop", "wasm")),
+         "qt5/mac/desktop/wasm"),
+    )
+)
+def test_list_describe_filters(meta: MetadataFactory, expect: str):
+    assert meta.describe_filters() == expect

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,12 +1,19 @@
 import json
 import re
 import sys
+import textwrap
 from pathlib import Path
 
 import pytest
 
 from aqt.installer import Cli
-from aqt.metadata import ArchiveId, MetadataFactory, SimpleSpec, Version
+from aqt.metadata import (
+    ArchiveId,
+    MetadataFactory,
+    SimpleSpec,
+    Version,
+    suggested_follow_up,
+)
 
 MINOR_REGEX = re.compile(r"^\d+\.(\d+)")
 
@@ -302,3 +309,82 @@ def test_list_invalid_extensions(
     sys.stdout.write(out)
     sys.stderr.write(err)
     assert expected_msg in err
+
+
+mac_qt5 = ArchiveId("qt5", "mac", "desktop")
+mac_wasm = ArchiveId("qt5", "mac", "desktop", "wasm")
+wrong_qt_version_msg = [
+    "Please use 'aqt list qt5 mac desktop' to show versions of Qt available."
+]
+wrong_ext_and_version_msg = [
+    "Please use 'aqt list qt5 mac desktop --extensions <QT_VERSION>' to list valid extensions.",
+    "Please use 'aqt list qt5 mac desktop' to show versions of Qt available.",
+]
+
+
+@pytest.mark.parametrize(
+    "meta, expected_message",
+    (
+        (MetadataFactory(mac_qt5), []),
+        (
+            MetadataFactory(mac_qt5, filter_minor=0),
+            [
+                "Please use 'aqt list qt5 mac desktop' to check that versions of qt5 exist with the minor version '0'."
+            ],
+        ),
+        (
+            MetadataFactory(ArchiveId("tools", "mac", "desktop"), tool_name="ifw"),
+            [
+                "Please use 'aqt list tools mac desktop' to check what tools are available."
+            ],
+        ),
+        (
+            MetadataFactory(mac_qt5, architectures_ver="1.2.3"),
+            wrong_qt_version_msg,
+        ),
+        (
+            MetadataFactory(mac_qt5, modules_ver="1.2.3"),
+            wrong_qt_version_msg,
+        ),
+        (
+            MetadataFactory(mac_qt5, extensions_ver="1.2.3"),
+            wrong_qt_version_msg,
+        ),
+        (
+            MetadataFactory(mac_wasm),
+            [
+                "Please use 'aqt list qt5 mac desktop --extensions <QT_VERSION>' to list valid extensions."
+            ],
+        ),
+        (
+            MetadataFactory(mac_wasm, filter_minor=0),
+            [
+                "Please use 'aqt list qt5 mac desktop --extensions <QT_VERSION>' to list valid extensions.",
+                "Please use 'aqt list qt5 mac desktop' to check that versions of qt5 exist with the minor version '0'.",
+            ],
+        ),
+        (
+            MetadataFactory(
+                ArchiveId("tools", "mac", "desktop", "wasm"), tool_name="ifw"
+            ),
+            [
+                "Please use 'aqt list tools mac desktop --extensions <QT_VERSION>' to list valid extensions.",
+                "Please use 'aqt list tools mac desktop' to check what tools are available.",
+            ],
+        ),
+        (
+            MetadataFactory(mac_wasm, architectures_ver="1.2.3"),
+            wrong_ext_and_version_msg,
+        ),
+        (
+            MetadataFactory(mac_wasm, modules_ver="1.2.3"),
+            wrong_ext_and_version_msg,
+        ),
+        (
+            MetadataFactory(mac_wasm, extensions_ver="1.2.3"),
+            wrong_ext_and_version_msg,
+        ),
+    ),
+)
+def test_suggested_follow_up(meta: MetadataFactory, expected_message: str):
+    assert suggested_follow_up(meta) == expected_message

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -124,30 +124,10 @@ def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
 
     monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _xml)
 
-    modules = MetadataFactory(archive_id).fetch_tool_modules(tool_name)
+    modules = MetadataFactory(archive_id, tool_name=tool_name).getList()
     assert modules == expect["modules"]
 
-
-@pytest.mark.parametrize(
-    "host, target, tool_name",
-    [
-        ("mac", "desktop", "tools_cmake"),
-        ("mac", "desktop", "tools_ifw"),
-        ("mac", "desktop", "tools_qtcreator"),
-    ],
-)
-def test_tool_long_listing(monkeypatch, host: str, target: str, tool_name: str):
-    archive_id = ArchiveId("tools", host, target)
-    in_file = "{}-{}-{}-update.xml".format(host, target, tool_name)
-    expect_out_file = "{}-{}-{}-expect.json".format(host, target, tool_name)
-    _xml = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
-    expect = json.loads(
-        (Path(__file__).parent / "data" / expect_out_file).read_text("utf-8")
-    )
-
-    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _xml)
-
-    table = MetadataFactory(archive_id).fetch_tool_long_listing(tool_name)
+    table = MetadataFactory(archive_id, tool_long_listing=tool_name).getList()
     assert table._rows() == expect["long_listing"]
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -439,15 +439,22 @@ def test_suggested_follow_up(meta: MetadataFactory, expected_message: List[str])
 @pytest.mark.parametrize(
     "meta, expect",
     (
-        (MetadataFactory(ArchiveId("qt5", "mac", "desktop"), filter_minor=42),
-         "qt5/mac/desktop with minor version 42"),
-        (MetadataFactory(ArchiveId("qt5", "mac", "desktop", "wasm"), filter_minor=42),
-         "qt5/mac/desktop/wasm with minor version 42"),
-        (MetadataFactory(ArchiveId("qt5", "mac", "desktop")),
-         "qt5/mac/desktop"),
-        (MetadataFactory(ArchiveId("qt5", "mac", "desktop", "wasm")),
-         "qt5/mac/desktop/wasm"),
-    )
+        (
+            MetadataFactory(ArchiveId("qt5", "mac", "desktop"), filter_minor=42),
+            "qt5/mac/desktop with minor version 42",
+        ),
+        (
+            MetadataFactory(
+                ArchiveId("qt5", "mac", "desktop", "wasm"), filter_minor=42
+            ),
+            "qt5/mac/desktop/wasm with minor version 42",
+        ),
+        (MetadataFactory(ArchiveId("qt5", "mac", "desktop")), "qt5/mac/desktop"),
+        (
+            MetadataFactory(ArchiveId("qt5", "mac", "desktop", "wasm")),
+            "qt5/mac/desktop/wasm",
+        ),
+    ),
 )
 def test_list_describe_filters(meta: MetadataFactory, expect: str):
     assert meta.describe_filters() == expect

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -458,6 +458,10 @@ def test_format_suggested_follow_up():
     assert format_suggested_follow_up(suggestions) == expected
 
 
+def test_format_suggested_follow_up_empty():
+    assert format_suggested_follow_up([]) == ""
+
+
 @pytest.mark.parametrize(
     "meta, expect",
     (
@@ -633,6 +637,33 @@ def test_show_list_tools_long_ifw(capsys, monkeypatch, columns, expect):
     meta = MetadataFactory(
         ArchiveId("tools", "mac", "desktop"), tool_long_listing="tools_ifw"
     )
+    assert show_list(meta) == 0
+    out, err = capsys.readouterr()
+    sys.stdout.write(out)
+    sys.stderr.write(err)
+    assert out == expect
+
+
+def test_show_list_versions(monkeypatch, capsys):
+    _html = (Path(__file__).parent / "data" / "mac-desktop.html").read_text("utf-8")
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda *args: _html)
+
+    expect_file = Path(__file__).parent / "data" / "mac-desktop-expect.json"
+    expected = "\n".join(json.loads(expect_file.read_text("utf-8"))["qt5"]["qt"]) + "\n"
+
+    assert show_list(MetadataFactory(mac_qt5)) == 0
+    out, err = capsys.readouterr()
+    assert out == expected
+
+
+def test_show_list_tools(monkeypatch, capsys):
+    page = (Path(__file__).parent / "data" / "mac-desktop.html").read_text("utf-8")
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: page)
+
+    expect_file = Path(__file__).parent / "data" / "mac-desktop-expect.json"
+    expect = "\n".join(json.loads(expect_file.read_text("utf-8"))["tools"]) + "\n"
+
+    meta = MetadataFactory(ArchiveId("tools", "mac", "desktop"))
     assert show_list(meta) == 0
     out, err = capsys.readouterr()
     sys.stdout.write(out)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
-from typing import Generator, List
+from typing import Generator
 
 import pytest
 


### PR DESCRIPTION
This adds eleven tests to `tests/test_list.py`, and increases test coverage for `metadata.py` from 78% to 94%.

There's still room for improvement here. I haven't made progress with some of the tests for `metadata.show_list` because of some issues I'm having with caplog and pytest; see https://github.com/miurahr/aqtinstall/pull/325#discussion_r671942997.
