### PR TITLE
behaviour change - fail install if modules are missing

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -249,7 +249,12 @@ class Cli:
             )
         all_extra = True if modules is not None and "all" in modules else False
         if not all_extra and not self._check_modules_arg(qt_version, modules):
-            self.logger.warning("Some of specified modules are unknown.")
+            available = Settings.available_modules(qt_version)
+            self.logger.error("Some of specified modules are unknown!")
+            self.logger.error("Supported packages: {}".format(available))
+            self.logger.error("Requested packages: {}".format(modules))
+            exit()
+
         try:
             qt_archives = QtArchives(
                 os_name,


### PR DESCRIPTION
This PR changes the behaviour of aqtinstall so it will fail if a module isn't available for the requested qt version or if a module is typed incorrectly in the command line. The current behaviour is to log a warning message to the console and continue regardless.

The current behaviour can cause confusion for the end-users who may believe its a problem with their build system not being able to detect the Qt module as its easy to miss this message in the build log. This change in behaviour makes it clear that the issue was with the Qt install. 