### PR TITLE
add support for qt6 optional modules

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -97,24 +97,31 @@ class QtArchives:
             self.all_extra = True
         else:
             for m in modules if modules is not None else []:
-                self.mod_list.append(
-                    "qt.qt{0}.{0}{1}{2}.{3}.{4}".format(
+                if self.version.major == 6:
+                    mod_string = "{0}{1}{2}.addons.{3}.{4}".format(
                         self.version.major,
                         self.version.minor,
                         self.version.patch,
                         m,
                         arch,
                     )
-                )
-                self.mod_list.append(
-                    "qt.{0}{1}{2}.{3}.{4}".format(
+                elif self.version.major == 5:
+                    mod_string = "{0}{1}{2}.{3}.{4}".format(
                         self.version.major,
                         self.version.minor,
                         self.version.patch,
                         m,
                         arch,
                     )
-                )
+                else: 
+                    raise RuntimeError('unsupported qt version')
+
+                self.mod_list += [
+                    "qt.qt{0}.".format(self.version.major) + mod_string, 
+                    "qt." + mod_string
+                ]
+
+                
         self.timeout = timeout
         self._get_archives()
         if not all_archives:

--- a/aqt/combinations.json
+++ b/aqt/combinations.json
@@ -91,11 +91,11 @@
   {"qt_version": "5.15", "modules": ["qtcharts", "qtlottie", "qtnetworkauth", "qtpurchasing", "qtdatavis3d",
     "qtquick3d", "qtquicktimeline", "qtscript", "qtvirtualkeyboard", "qtwebengine", "qtwebglplugin"]},
   {"qt_version":  "6.0", "modules": ["qtwaylandcompositor", "qtshadertools", "qtquicktimeline", "qtquick3d",
-    "qt5compat"]},
+    "qt5compat", "qt3d", "qtcharts", "qtconnectivity", "qtdatavis3d", "qtimageformats", "qtlottie", "qtmultimedia", "qtnetworkauth", "qtpositioning", "qtremoteobjects", "qtscxml", "qtsensors", "qtserialbus", "qtserialport", "qtvirtualkeyboard", "qtwebchannel", "qtwebsockets", "qtwebview"]},
   {"qt_version":  "6.1", "modules": ["qtwaylandcompositor", "qtshadertools", "qtquicktimeline", "qtquick3d",
-    "qt5compat"]},
+    "qt5compat", "qt3d", "qtcharts", "qtconnectivity", "qtdatavis3d", "qtimageformats", "qtlottie", "qtmultimedia", "qtnetworkauth", "qtpositioning", "qtremoteobjects", "qtscxml", "qtsensors", "qtserialbus", "qtserialport", "qtvirtualkeyboard", "qtwebchannel", "qtwebsockets", "qtwebview"]},
   {"qt_version":  "6.2", "modules": ["qtwaylandcompositor", "qtshadertools", "qtquicktimeline", "qtquick3d",
-    "qt5compat"]}
+    "qt5compat", "qt3d", "qtcharts", "qtconnectivity", "qtdatavis3d", "qtimageformats", "qtlottie", "qtmultimedia", "qtnetworkauth", "qtpositioning", "qtremoteobjects", "qtscxml", "qtsensors", "qtserialbus", "qtserialport", "qtvirtualkeyboard", "qtwebchannel", "qtwebsockets", "qtwebview"]}
 ], "versions": [
   "5.9", "5.9.1", "5.9.2", "5.9.3", "5.9.4", "5.9.5", "5.9.6", "5.9.7", "5.9.8", "5.9.9",
   "5.10.0", "5.10.1", "5.11.0", "5.11.1", "5.11.2", "5.11.3",


### PR DESCRIPTION
Currently Qt6 fails to install optional modules such as Qt::Charts or Qt::WebViewer. This is because the syntax in the qt sdk repository has changed. In Qt 6 onwards the package names have changed from qt.qt5.5150.qtcharts.clang_64 to qt.qt6.620.addons.qtcharts.clang_64. The addition of this "addon" keyword broke the XML parser in the QtArchives class. 

https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt6_620/Updates.xml
https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5150/Updates.xml

You can see it now appears correctly in the logs, 
```
aqtinstall(aqt) v2.0.0b4.dev66 on Python 3.8.5 [CPython Clang 10.0.0 ]
Downloading qtbase...
Downloading qtcharts...
Downloading qtsvg...
Downloading qtdeclarative...
Redirected: mirrors.ukfast.co.uk
Redirected: mirrors.ukfast.co.uk
Redirected: mirrors.ukfast.co.uk
Redirected: mirrors.ukfast.co.uk
Finished installation of qtsvg-MacOS-MacOS_11_00-Clang-MacOS-MacOS_11_00-X86_64-ARM64.7z in 0.78178350
Downloading qttools...
Finished installation of qtcharts-MacOS-MacOS_11_00-Clang-MacOS-MacOS_11_00-X86_64-ARM64.7z in 1.30998046
Downloading qtquickcontrols2...
Redirected: mirrors.ukfast.co.uk
Redirected: mirrors.ukfast.co.uk
Finished installation of qtquickcontrols2-MacOS-MacOS_11_00-Clang-MacOS-MacOS_11_00-X86_64-ARM64.7z in 5.61572662
Downloading qttranslations...
Redirected: mirrors.ukfast.co.uk
Finished installation of qttranslations-MacOS-MacOS_11_00-Clang-MacOS-MacOS_11_00-X86_64-ARM64.7z in 3.71476571
Finished installation of qtbase-MacOS-MacOS_11_00-Clang-MacOS-MacOS_11_00-X86_64-ARM64.7z in 12.46363146
Finished installation of qttools-MacOS-MacOS_11_00-Clang-MacOS-MacOS_11_00-X86_64-ARM64.7z in 31.24148654
Finished installation of qtdeclarative-MacOS-MacOS_11_00-Clang-MacOS-MacOS_11_00-X86_64-ARM64.7z in 33.58599792
Patching qt/6.2.0/macos/bin/qmake
Finished installation
Time elapsed: 35.56388792 second
```

and the correct files are appearing in the download folder. Unit-test cases should be added to `test_archives.py`.