### PR TITLE
WIP Update tests for new cmd syntax

### DIFF
--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -43,22 +43,22 @@ jobs:
           timeout = 300
           os.mkdir("Qt")
           os.chdir("Qt")
-          command_line = ["python", "-m", "aqt", "install"]
+          command_line = ["python", "-m", "aqt", "install-qt"]
           platform = "${{ matrix.os }}"
           qtver = "${{ matrix.qtver }}"
           if platform == "windows-latest":
             if qtver.startswith('5.15'):
-              args = [qtver, "windows", "desktop", "win64_msvc2019_64"]
+              args = ["windows", "desktop", qtver, "win64_msvc2019_64"]
             elif qtver.startswith('5.14'):
-              args = [qtver, "windows", "desktop", "win64_msvc2017_64"]
+              args = ["windows", "desktop", qtver, "win64_msvc2017_64"]
             elif qtver.startswith('6'):
-              args = [qtver, "windows", "desktop", "win64_mingw81"]
+              args = ["windows", "desktop", qtver, "win64_mingw81"]
             else:
-              args = [qtver, "windows", "desktop", "win64_msvc2015_64"]
+              args = ["windows", "desktop", qtver, "win64_msvc2015_64"]
           elif platform == "macOS-latest":
-            args = [qtver, "mac", "desktop", "clang_64"]
+            args = ["mac", "desktop", qtver, "clang_64"]
           else:
-            args = [qtver, "linux", "desktop", "gcc_64"]
+            args = ["linux", "desktop", qtver, "gcc_64"]
           command_line.extend(args)
           command_line.extend(["--archives", "qtbase", "icu", "qt"])
           env = os.environ.copy()
@@ -73,13 +73,13 @@ jobs:
           assert res.returncode == 0
           if qtver.startswith('6'):
             if platform == 'ubuntu-20.04':
-              command_line = ["python", "-m", "aqt", "install", qtver, "linux", "android", "android_armv7"]
+              command_line = ["python", "-m", "aqt", "install-qt", "linux", "android", qtver, "android_armv7"]
               timeout = 360
             elif platform == "macOS-latest":
-              command_line = ["python", "-m", "aqt", "install", qtver, "mac", "ios", "ios"]
+              command_line = ["python", "-m", "aqt", "install-qt", "mac", "ios", qtver, "ios"]
               timeout = 360
             else:
-              command_line = ["python", "-m", "aqt", "install", qtver, "windows", "android", "android_armv7"]
+              command_line = ["python", "-m", "aqt", "install-qt", "windows", "android", qtver, "android_armv7"]
               timeout = 360
             try:
               res = subprocess.run(command_line, timeout=timeout, check=True)

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -35,12 +35,12 @@ steps:
         if [[ "$(SUBARCHIVES)" != "" ]]; then
           opt+=" --archives $(SUBARCHIVES)"
         fi
-        python -m aqt install $(QT_VERSION) $(HOST) $(TARGET) $(ARCH) $opt
+        python -m aqt install-qt $(HOST) $(TARGET) $(QT_VERSION) $(ARCH) $opt
         if [[ "$(TARGET)" == "android" || "$(TARGET)" == "ios" ]]; then
           if [[ "$(HOST)" == "windows" ]]; then
-            python -m aqt install $(QT_VERSION) $(HOST) desktop mingw81_64 --archives qtbase
+            python -m aqt install-qt $(HOST) desktop $(QT_VERSION) mingw81_64 --archives qtbase
           else
-            python -m aqt install $(QT_VERSION) $(HOST) desktop --archives qtbase
+            python -m aqt install-qt $(HOST) desktop $(QT_VERSION) --archives qtbase
           fi
         fi
         if [[ "$(OUTPUT_DIR)" != "" ]]; then
@@ -99,10 +99,10 @@ steps:
         aqt list-qt $(HOST) $(TARGET) $ext --spec "$(SPEC)" --arch latest
       fi
       if [[ "$(SUBCOMMAND)" == "src" ]]; then
-        python -m aqt $(SUBCOMMAND) $(QT_VERSION) $(HOST) $(TARGET) --archives $(SUBARCHIVES)
+        python -m aqt install-src $(HOST) $(TARGET) $(QT_VERSION) --archives $(SUBARCHIVES)
       fi
       if [[ "$(SUBCOMMAND)" == "doc" ]]; then
-        python -m aqt $(SUBCOMMAND) $(QT_VERSION) $(HOST) $(TARGET) --archives $(SUBARCHIVES)
+        python -m aqt install-doc $(HOST) $(TARGET) $(QT_VERSION) --archives $(SUBARCHIVES)
       fi
     workingDirectory: $(Build.BinariesDirectory)
     env:
@@ -190,10 +190,10 @@ steps:
         jom
       } elseif ( $env:TOOLCHAIN -eq 'MINGW' ) {
         if ( $env:ARCH -eq 'win64_mingw81' ) {
-          python -m aqt tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) desktop tools_mingw qt.tools.win64_mingw810
+          python -m aqt install-tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) desktop tools_mingw qt.tools.win64_mingw810
           [Environment]::SetEnvironmentVariable("Path", ";$(Build.BinariesDirectory)\Qt\Tools\mingw810_64\bin" + $env:Path, "Machine")
         } else {
-          python -m aqt tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) desktop tools_mingw qt.tools.win32_mingw810
+          python -m aqt install-tool --outputdir $(Build.BinariesDirectory)/Qt $(HOST) desktop tools_mingw qt.tools.win32_mingw810
           [Environment]::SetEnvironmentVariable("Path", ";$(Build.BinariesDirectory)\Qt\Tools\mingw810_32\bin" + $env:Path, "Machine")
         }
         $env:Path = "$(Build.BinariesDirectory)\Qt\Tools\$(ARCHDIR)\bin;$(WIN_QT_BINDIR);" + $env:Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,8 @@ def test_cli_help(capsys):
     expected = "".join(
         [
             "usage: aqt [-h] [-c CONFIG]\n",
-            "           {install,doc,examples,src,tool,list-qt,list-tool,help,version} ...\n",
+            "           {install-qt,install-doc,install-examples,install-src,install-tool,"
+            "list-qt,list-tool,install,doc,examples,src,tool,help,version} ...\n",
             "\n",
             "Installer for Qt SDK.\n",
             "\n",
@@ -23,7 +24,8 @@ def test_cli_help(capsys):
             "subcommands:\n",
             "  Valid subcommands\n",
             "\n",
-            "  {install,doc,examples,src,tool,list-qt,list-tool,help,version}\n",
+            "  {install-qt,install-doc,install-examples,install-src,install-tool,"
+            "list-qt,list-tool,install,doc,examples,src,tool,help,version}\n",
             "                        subcommand for aqt Qt installer\n",
         ]
     )
@@ -79,8 +81,8 @@ def test_cli_invalid_version(capsys, invalid_version):
     )
 
     for cmd in (
-        ("install", invalid_version, "mac", "desktop"),
-        ("doc", invalid_version, "mac", "desktop"),
+        ("install-qt", "mac", "desktop", invalid_version),
+        ("install-doc", "mac", "desktop", invalid_version),
         ("list-qt", "mac", "desktop", "--modules", invalid_version),
     ):
         with pytest.raises(SystemExit) as pytest_wrapped_e:
@@ -98,7 +100,7 @@ def test_cli_check_mirror():
     cli = Cli()
     cli._setup_settings()
     assert cli._check_mirror(None)
-    arg = ["install", "5.11.3", "linux", "desktop", "-b", "https://download.qt.io/"]
+    arg = ["install-qt", "linux", "desktop", "5.11.3", "-b", "https://download.qt.io/"]
     args = cli.parser.parse_args(arg)
     assert args.base == "https://download.qt.io/"
     assert cli._check_mirror(args.base)
@@ -108,7 +110,8 @@ def test_cli_launch_with_no_argument(capsys):
     expected = "".join(
         [
             "usage: aqt [-h] [-c CONFIG]\n",
-            "           {install,doc,examples,src,tool,list-qt,list-tool,help,version} ...\n",
+            "           {install-qt,install-doc,install-examples,install-src,install-tool,"
+            "list-qt,list-tool,install,doc,examples,src,tool,help,version} ...\n",
             "\n",
             "Installer for Qt SDK.\n",
             "\n",
@@ -120,7 +123,8 @@ def test_cli_launch_with_no_argument(capsys):
             "subcommands:\n",
             "  Valid subcommands\n",
             "\n",
-            "  {install,doc,examples,src,tool,list-qt,list-tool,help,version}\n",
+            "  {install-qt,install-doc,install-examples,install-src,install-tool,"
+            "list-qt,list-tool,install,doc,examples,src,tool,help,version}\n",
             "                        subcommand for aqt Qt installer\n",
         ]
     )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -12,7 +12,7 @@ def test_cli_unknown_version(capsys):
     wrong_url_ending = "mac_x64/desktop/qt5_5160/Updates.xml"
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         cli = aqt.installer.Cli()
-        cli.run(["install", wrong_version, "mac", "desktop"])
+        cli.run(["install-qt", "mac", "desktop", wrong_version])
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
     out, err = capsys.readouterr()


### PR DESCRIPTION
This PR is intended to give a head start to anyone working on #306. You can merge these two commits into your branch that implements #306, and your CI tests will fail if #306 is not fully implemented.

Note that these tests do not yet test the `--spec` flag for the `aqt install-qt` subcommand.