### PR TITLE
Turn warnings into errors when building docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,8 @@ commands =
 basepython = python3.8
 extras = docs
 commands =
-    sphinx-build {posargs:-E} -b html docs build/docs
-    sphinx-build -b linkcheck docs build/docs
+    sphinx-build {posargs:-E} -W -b html docs build/docs
+    sphinx-build -W -b linkcheck docs build/docs
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
This turns on 'warnings as errors' for `sphinx-build`, which will help to prevent problems in the documentation. 

The CI for this PR will fail because the master branch contains broken links in `docs/getting_started.rst`, for the 'Available Versions' wiki page. #358 will fix these broken links.

Here's an example run where the build failed because of a broken link in the documentation:
https://github.com/ddalcino/aqtinstall/runs/3245370308

Here's a run where the link was fixed, causing the build to succeed:
https://github.com/ddalcino/aqtinstall/runs/3245406178