### PR TITLE
Fail installation on missing tool variants

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -321,7 +321,7 @@ class ToolArchives(QtArchives):
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target=target,
-            version_str=version_str,
+            version_str=version_str or "0.0.1",  # dummy value
             arch=arch,
             base=base,
             timeout=timeout,

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -347,45 +347,47 @@ class ToolArchives(QtArchives):
         )
         update_xml_url = posixpath.join(archive_url, "Updates.xml")
         self._download_update_xml(update_xml_url)  # call super method.
-        self._parse_update_xml(archive_url, [])
+        self._parse_update_xml(archive_url, None)
 
-    def _parse_update_xml(self, archive_url, target_packages):
+    def _parse_update_xml(self, archive_url, *ignored):
         try:
             self.update_xml = ElementTree.fromstring(self.update_xml_text)
         except ElementTree.ParseError as perror:
             self.logger.error("Downloaded metadata is corrupted. {}".format(perror))
             raise ArchiveListError("Downloaded metadata is corrupted.")
 
-        for packageupdate in self.update_xml.iter("PackageUpdate"):
-            name = packageupdate.find("Name").text
-            if name != self.arch:
-                continue
-            _archives = packageupdate.find("DownloadableArchives").text
-            if _archives is not None:
-                downloadable_archives = _archives.split(", ")
-            else:
-                downloadable_archives = []
-            named_version = packageupdate.find("Version").text
-            package_desc = packageupdate.find("Description").text
-            for archive in downloadable_archives:
-                package_url = posixpath.join(
-                    # https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/tools_ifw/
-                    archive_url,
-                    # qt.tools.ifw.41/
-                    name,
-                    #  4.1.1-202105261130ifw-linux-x64.7z
-                    f"{named_version}{archive}",
+        try:
+            packageupdate = next(filter(lambda x: x.find("Name").text == self.arch, self.update_xml.iter("PackageUpdate")))
+        except StopIteration:
+            message = f"The package {self.arch} was not found while parsing XML of package information!"
+            raise NoPackageFound(message)
+
+        name = packageupdate.find("Name").text
+        named_version = packageupdate.find("Version").text
+        package_desc = packageupdate.find("Description").text
+        downloadable_archives = packageupdate.find("DownloadableArchives").text
+        if not downloadable_archives:
+            message = f"The package {self.arch} contains no downloadable archives!"
+            raise NoPackageFound(message)
+        for archive in downloadable_archives.split(", "):
+            package_url = posixpath.join(
+                # https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/tools_ifw/
+                archive_url,
+                # qt.tools.ifw.41/
+                name,
+                #  4.1.1-202105261130ifw-linux-x64.7z
+                f"{named_version}{archive}",
+            )
+            hashurl = package_url + ".sha1"
+            self.archives.append(
+                QtPackage(
+                    name=name,
+                    archive_url=package_url,
+                    archive=archive,
+                    package_desc=package_desc,
+                    hashurl=hashurl,
                 )
-                hashurl = package_url + ".sha1"
-                self.archives.append(
-                    QtPackage(
-                        name=name,
-                        archive_url=package_url,
-                        archive=archive,
-                        package_desc=package_desc,
-                        hashurl=hashurl,
-                    )
-                )
+            )
 
     def get_target_config(self) -> TargetConfig:
         """Get target configuration.

--- a/tests/data/mac-desktop-tools_qtcreator-expect.json
+++ b/tests/data/mac-desktop-tools_qtcreator-expect.json
@@ -26,5 +26,66 @@
       "Qt Creator 4.15.1 Plugin Development",
       "Headers and libs required to develop additional plugins"
     ]
+  ],
+  "variants_metadata": [
+    {
+      "Name": "qt.tools.qtcreator",
+      "DisplayName": "Qt Creator 4.15.1",
+      "Description": "IDE for Qt application development",
+      "Version": "4.15.1-0-202106081242",
+      "ReleaseDate": "2021-06-08",
+      "Script": "installscript.qs",
+      "Dependencies": "",
+      "SortingPriority": "1000",
+      "ForcedInstallation": "true",
+      "DownloadableArchives": [
+        "qtcreator.7z",
+        "qtcreator_sdktool.7z"
+      ],
+      "UpdateFile": {
+        "CompressedSize": "136099945",
+        "UncompressedSize": "533316311",
+        "OS": "Any"
+      },
+      "UserInterfaces": [
+        "associatecommonfiletypesform.ui",
+        "launchqtcreatorcheckboxform.ui"
+      ],
+      "SHA1": "684ee4525e6412623167a5442b7c262cac52c9bb"
+    },
+    {
+      "Name": "qt.tools.qtcreatordbg",
+      "DisplayName": "Qt Creator 4.15.1 Debug Symbols",
+      "Description": "Additional symbol files required to debug Qt Creator",
+      "Version": "4.15.1-0-202106081242",
+      "ReleaseDate": "2021-06-08",
+      "SortingPriority": "994",
+      "DownloadableArchives": [
+        "qtcreator-debug.7z"
+      ],
+      "UpdateFile": {
+        "CompressedSize": "235240929",
+        "UncompressedSize": "1570679561",
+        "OS": "Any"
+      },
+      "SHA1": "c71f2e138df7232f7482e66a4cc2db5f94a3c7b4"
+    },
+    {
+      "Name": "qt.tools.qtcreatordev",
+      "DisplayName": "Qt Creator 4.15.1 Plugin Development",
+      "Description": "Headers and libs required to develop additional plugins",
+      "Version": "4.15.1-0-202106081242",
+      "ReleaseDate": "2021-06-08",
+      "SortingPriority": "990",
+      "DownloadableArchives": [
+        "qtcreator_dev.7z"
+      ],
+      "UpdateFile": {
+        "CompressedSize": "12377799",
+        "UncompressedSize": "104362249",
+        "OS": "Any"
+      },
+      "SHA1": "0e2127ef128a87f6bc04e0c9eccab677aac21ec0"
+    }
   ]
 }


### PR DESCRIPTION
This implements the other half of #374, so that `aqt install-tool` should fail if you tell it to install a tool variant that doesn't exist.