### PR TITLE
Allow list-qt to describe Qt 6.2 wasm target

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -456,7 +456,7 @@ class MetadataFactory:
         1. On Qt6 for Android, an extension for processor architecture is required.
         2. On any platform other than Android, or on Qt5, an extension for
         processor architecture is forbidden.
-        3. The "wasm" extension only works on desktop targets for Qt 5.13-5.15.
+        3. The "wasm" extension only works on desktop targets for Qt 5.13-5.15, or for 6.2+
         """
         if (
             self.archive_id.target == "android"
@@ -472,11 +472,10 @@ class MetadataFactory:
             self.archive_id.target != "android" or qt_ver.major != 6
         ):
             raise CliInputError(f"The extension '{self.archive_id.extension}' is only valid for Qt 6 for Android")
-        if "wasm" in self.archive_id.extension and (
-            qt_ver not in SimpleSpec(">=5.13,<6") or self.archive_id.target != "desktop"
-        ):
+        is_in_wasm_range = qt_ver in SimpleSpec(">=5.13,<6") or qt_ver in SimpleSpec(">=6.2.0")
+        if "wasm" in self.archive_id.extension and (self.archive_id.target != "desktop" or not is_in_wasm_range):
             raise CliInputError(
-                f"The extension '{self.archive_id.extension}' is only available in Qt 5.13 to 5.15 on desktop."
+                f"The extension '{self.archive_id.extension}' is only available in Qt 5.13-5.15 and 6.2+ on desktop."
             )
 
     @staticmethod

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -345,7 +345,7 @@ qt6_android_requires_ext_msg = (
     "Please add your extension using the `--extension` flag."
 )
 no_arm64_v8_msg = "The extension 'arm64_v8a' is only valid for Qt 6 for Android"
-no_wasm_msg = "The extension 'wasm' is only available in Qt 5.13 to 5.15 on desktop."
+no_wasm_msg = "The extension 'wasm' is only available in Qt 5.13-5.15 and 6.2+ on desktop."
 
 
 @pytest.mark.parametrize(
@@ -356,10 +356,10 @@ no_wasm_msg = "The extension 'wasm' is only available in Qt 5.13 to 5.15 on desk
         ("desktop", "arm64_v8a", "5.13.0", no_arm64_v8_msg),
         ("desktop", "arm64_v8a", "6.2.0", no_arm64_v8_msg),
         ("desktop", "wasm", "5.12.11", no_wasm_msg),  # out of range
-        ("desktop", "wasm", "6.2.0", no_wasm_msg),  # out of range
+        ("desktop", "wasm", "6.1.9", no_wasm_msg),  # out of range
         ("android", "wasm", "5.12.11", no_wasm_msg),  # in range, wrong target
         ("android", "wasm", "5.14.0", no_wasm_msg),  # in range, wrong target
-        ("android", "wasm", "6.2.0", qt6_android_requires_ext_msg),
+        ("android", "wasm", "6.1.9", qt6_android_requires_ext_msg),
     ),
 )
 def test_list_invalid_extensions(capsys, monkeypatch, target, ext, version, expected_msg):


### PR DESCRIPTION
On August 19, the Qt repo added [a new wasm release for Qt 6.2.0](https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt6_620_wasm/). `list-qt` currently prints that the `wasm` extension is available for that version of Qt, but it will not let the user use it to query modules and architectures, because of a hardcoded version check. This change rewrites the version check so that a user may make queries.