### PR TITLE
Improve error handling

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -262,7 +262,6 @@ class QtArchives:
         # if we have located every requested package, then target_packages will be empty
         if len(target_packages) > 0:
             message = f"The packages {target_packages} were not found while parsing XML of package information!"
-            self.logger.error(message)
             raise NoPackageFound(message)
 
     def get_packages(self) -> List[QtPackage]:

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -212,8 +212,7 @@ class QtArchives:
         try:
             self.update_xml = ElementTree.fromstring(self.update_xml_text)
         except ElementTree.ParseError as perror:
-            self.logger.error("Downloaded metadata is corrupted. {}".format(perror))
-            raise ArchiveListError("Downloaded metadata is corrupted.")
+            raise ArchiveListError(f"Downloaded metadata is corrupted. {perror}") from perror
 
         for packageupdate in self.update_xml.iter("PackageUpdate"):
             pkg_name = packageupdate.find("Name").text
@@ -387,8 +386,7 @@ class ToolArchives(QtArchives):
         try:
             self.update_xml = ElementTree.fromstring(self.update_xml_text)
         except ElementTree.ParseError as perror:
-            self.logger.error("Downloaded metadata is corrupted. {}".format(perror))
-            raise ArchiveListError("Downloaded metadata is corrupted.")
+            raise ArchiveListError(f"Downloaded metadata is corrupted. {perror}") from perror
 
         try:
             packageupdate = next(filter(lambda x: x.find("Name").text == self.arch, self.update_xml.iter("PackageUpdate")))

--- a/aqt/exceptions.py
+++ b/aqt/exceptions.py
@@ -65,3 +65,7 @@ class CliInputError(AqtException):
 
 class CliKeyboardInterrupt(AqtException):
     pass
+
+
+class ArchiveExtractionError(AqtException):
+    pass

--- a/aqt/exceptions.py
+++ b/aqt/exceptions.py
@@ -18,23 +18,50 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+from typing import Iterable
 
 
-class ArchiveDownloadError(Exception):
+class AqtException(Exception):
+    def __init__(self, *args, **kwargs):
+        self.suggested_action: Iterable[str] = kwargs.pop("suggested_action", [])
+        self.should_show_help: bool = kwargs.pop("should_show_help", False)
+        super(AqtException, self).__init__(*args, **kwargs)
+
+    def __format__(self, format_spec) -> str:
+        base_msg = "{}".format(super(AqtException, self).__format__(format_spec))
+        if not self.suggested_action:
+            return base_msg
+        return f"{base_msg}\n{self._format_suggested_follow_up()}"
+
+    def _format_suggested_follow_up(self) -> str:
+        return ("=" * 30 + "Suggested follow-up:" + "=" * 30 + "\n") + "\n".join(
+            ["* " + suggestion for suggestion in self.suggested_action]
+        )
+
+
+class ArchiveDownloadError(AqtException):
     pass
 
 
-class ArchiveConnectionError(Exception):
+class ArchiveConnectionError(AqtException):
     pass
 
 
-class ArchiveListError(Exception):
+class ArchiveListError(AqtException):
     pass
 
 
-class NoPackageFound(Exception):
+class NoPackageFound(AqtException):
     pass
 
 
-class CliInputError(Exception):
+class EmptyMetadata(AqtException):
+    pass
+
+
+class CliInputError(AqtException):
+    pass
+
+
+class CliKeyboardInterrupt(AqtException):
     pass

--- a/aqt/exceptions.py
+++ b/aqt/exceptions.py
@@ -69,3 +69,7 @@ class CliKeyboardInterrupt(AqtException):
 
 class ArchiveExtractionError(AqtException):
     pass
+
+
+class UpdaterError(AqtException):
+    pass

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -349,6 +349,10 @@ class SettingsClass:
     def kde_patches(self):
         return self.config.getlist("kde_patches", "patches", fallback=[])
 
+    @property
+    def print_stacktrace_on_error(self):
+        return self.config.getboolean("aqt", "print_stacktrace_on_error", fallback=False)
+
 
 Settings = SettingsClass()
 

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -102,17 +102,12 @@ def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: str, timeout):
                         fd.write(chunk)
                         hash.update(chunk)
                     fd.flush()
-                if exp is not None:
-                    if hash.digest() != exp:
-                        raise ArchiveDownloadError(
-                            "Download file is corrupted! Detect checksum error.\nExpected {}, Actual {}".format(
-                                exp, hash.digest()
-                            )
-                        )
             except Exception as e:
-                exc = sys.exc_info()
-                logger.error("Download error: %s" % exc[1])
-                raise e
+                raise ArchiveDownloadError(f"Download error: {e}") from e
+            if exp is not None and hash.digest() != exp:
+                raise ArchiveDownloadError(
+                    f"Download file is corrupted! Detect checksum error.\nExpected {exp}, Actual {hash.digest()}"
+                )
 
 
 def altlink(url: str, alt: str):

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -29,6 +29,7 @@ import platform
 import random
 import signal
 import subprocess
+import sys
 import time
 from logging import getLogger
 from logging.handlers import QueueHandler
@@ -93,6 +94,17 @@ class Cli:
             self.logger.error(format(e), exc_info=Settings.print_stacktrace_on_error)
             if e.should_show_help:
                 self.show_help()
+            return 1
+        except Exception as e:
+            # If we didn't account for it, and wrap it in an AqtException, it's a bug.
+            self.logger.exception(e)  # Print stack trace
+            self.logger.error(
+                f"Arguments: `{sys.argv}` Host: `{platform.uname()}`\n"
+                "===========================PLEASE FILE A BUG REPORT===========================\n"
+                "You have discovered a bug in aqt.\n"
+                "Please file a bug report at https://github.com/miurahr/aqtinstall/issues.\n"
+                "Please remember to include a copy of this program's output in your report."
+            )
             return 1
 
     def _check_tools_arg_combination(self, os_name, tool_name, arch):

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -393,8 +393,8 @@ class Cli:
         try:
             if args.spec is not None:
                 spec = SimpleSpec(args.spec)
-        except ValueError:
-            raise CliInputError(f"Invalid version specification: '{args.spec}'.\n" + SimpleSpec.usage())
+        except ValueError as e:
+            raise CliInputError(f"Invalid version specification: '{args.spec}'.\n" + SimpleSpec.usage()) from e
 
         meta = MetadataFactory(
             archive_id=ArchiveId(

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -36,7 +36,7 @@ from typing import Any, Callable, List, Optional
 
 import aqt
 from aqt.archives import QtArchives, QtPackage, SrcDocExamplesArchives, ToolArchives
-from aqt.exceptions import AqtException, ArchiveConnectionError, CliInputError, CliKeyboardInterrupt
+from aqt.exceptions import AqtException, ArchiveConnectionError, ArchiveExtractionError, CliInputError, CliKeyboardInterrupt
 from aqt.helper import MyQueueListener, Settings, downloadBinaryFile, getUrl, setup_logging
 from aqt.metadata import ArchiveId, MetadataFactory, SimpleSpec, Version, show_list
 from aqt.updater import Updater
@@ -823,12 +823,8 @@ def installer(
             proc = subprocess.run(command_args, stdout=subprocess.PIPE, check=True)
             logger.debug(proc.stdout)
         except subprocess.CalledProcessError as cpe:
-            logger.error("Extraction error: %d" % cpe.returncode)
-            if cpe.stdout is not None:
-                logger.error(cpe.stdout)
-            if cpe.stderr is not None:
-                logger.error(cpe.stderr)
-            raise cpe
+            msg = "\n".join(filter(None, [f"Extraction error: {cpe.returncode}", cpe.stdout, cpe.stderr]))
+            raise ArchiveExtractionError(msg) from cpe
     if not keep:
         os.unlink(archive)
     logger.info("Finished installation of {} in {:.8f}".format(archive, time.perf_counter() - start_time))

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -181,9 +181,7 @@ class Cli:
         target = args.target
         os_name = args.host
         qt_version = args.qt_version
-        if not Cli._is_valid_version_str(qt_version):
-            self.logger.error("Invalid version: '{}'! Please use the form '5.X.Y'.".format(qt_version))
-            exit(1)
+        Cli._validate_version_str(qt_version)
         keep = args.keep
         output_dir = args.outputdir
         if output_dir is None:
@@ -278,9 +276,7 @@ class Cli:
         target = args.target
         os_name = args.host
         qt_version = args.qt_version
-        if not Cli._is_valid_version_str(qt_version):
-            self.logger.error("Invalid version: '{}'! Please use the form '5.X.Y'.".format(qt_version))
-            exit(1)
+        Cli._validate_version_str(qt_version)
         output_dir = args.outputdir
         if output_dir is None:
             base_dir = os.getcwd()
@@ -447,9 +443,7 @@ class Cli:
             raise CliInputError("'{0.target}' is not a valid target for host '{0.host}'".format(args))
 
         for version_str in (args.modules, args.extensions, args.arch):
-            if not Cli._is_valid_version_str(version_str, allow_latest=True, allow_empty=True):
-                self.logger.error("Invalid version: '{}'! Please use the form '5.X.Y'.".format(version_str))
-                exit(1)  # TODO: maybe return 1 instead?
+            Cli._validate_version_str(version_str, allow_latest=True, allow_empty=True)
 
         spec = None
         try:
@@ -780,14 +774,13 @@ class Cli:
                 Settings.load_settings()
 
     @staticmethod
-    def _is_valid_version_str(version_str: str, *, allow_latest: bool = False, allow_empty: bool = False) -> bool:
+    def _validate_version_str(version_str: str, *, allow_latest: bool = False, allow_empty: bool = False):
         if (allow_latest and version_str == "latest") or (allow_empty and not version_str):
-            return True
+            return
         try:
             Version(version_str)
-            return True
-        except ValueError:
-            return False
+        except ValueError as e:
+            raise CliInputError(f"Invalid version: '{version_str}'! Please use the form '5.X.Y'.") from e
 
 
 def run_installer(archives: List[QtPackage], base_dir: str, sevenzip: Optional[str], keep: bool):

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -433,12 +433,12 @@ class Cli:
         self.logger.info("Finished installation")
         self.logger.info("Time elapsed: {time:.8f} second".format(time=time.perf_counter() - start_time))
 
-    def run_list_qt(self, args: argparse.ArgumentParser) -> int:
+    def run_list_qt(self, args: argparse.ArgumentParser):
         """Print versions of Qt, extensions, modules, architectures"""
 
         if not args.target:
             print(" ".join(ArchiveId.TARGETS_FOR_HOST[args.host]))
-            return 0
+            return
         if args.target not in ArchiveId.TARGETS_FOR_HOST[args.host]:
             raise CliInputError("'{0.target}' is not a valid target for host '{0.host}'".format(args))
 
@@ -465,14 +465,14 @@ class Cli:
             extensions_ver=args.extensions,
             architectures_ver=args.arch,
         )
-        return show_list(meta)
+        show_list(meta)
 
-    def run_list_tool(self, args: argparse.ArgumentParser) -> int:
+    def run_list_tool(self, args: argparse.ArgumentParser):
         """Print tools"""
 
         if not args.target:
             print(" ".join(ArchiveId.TARGETS_FOR_HOST[args.host]))
-            return 0
+            return
         if args.target not in ArchiveId.TARGETS_FOR_HOST[args.host]:
             raise CliInputError("'{0.target}' is not a valid target for host '{0.host}'".format(args))
 
@@ -481,7 +481,7 @@ class Cli:
             tool_name=args.tool_name,
             is_long_listing=args.long,
         )
-        return show_list(meta)
+        show_list(meta)
 
     def show_help(self, args=None):
         """Display help message"""

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -526,7 +526,7 @@ class MetadataFactory:
         try:
             version = Version(qt_ver)
         except ValueError as e:
-            raise CliInputError(e)
+            raise CliInputError(e) from e
         return version
 
     @staticmethod
@@ -542,7 +542,7 @@ class MetadataFactory:
 
             except (ArchiveDownloadError, ArchiveConnectionError) as e:
                 if i == len(base_urls) - 1:
-                    raise e
+                    raise e from e
 
     @staticmethod
     def iterate_folders(html_doc: str, filter_category: str = "") -> Generator[str, None, None]:

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -4,6 +4,7 @@
 concurrency: 4
 baseurl: https://download.qt.io
 7zcmd: 7z
+print_stacktrace_on_error: False
 
 [requests]
 connection_timeout: 3.5

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -27,6 +27,7 @@ from logging import getLogger
 
 import patch
 
+from aqt.archives import TargetConfig
 from aqt.exceptions import UpdaterError
 from aqt.helper import Settings
 from aqt.metadata import SimpleSpec, Version
@@ -250,7 +251,7 @@ class Updater:
         self._patch_textfile(target_qt_conf, "HostData=target", new_hostdata)
 
     @classmethod
-    def update(cls, target, base_dir: str):
+    def update(cls, target: TargetConfig, base_dir: str):
         """
         Make Qt configuration files, qt.conf and qtconfig.pri.
         And update pkgconfig and patch Qt5Core and qmake

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -27,6 +27,7 @@ from logging import getLogger
 
 import patch
 
+from aqt.exceptions import UpdaterError
 from aqt.helper import Settings
 from aqt.metadata import SimpleSpec, Version
 
@@ -307,7 +308,7 @@ class Updater:
                 updater.patch_qmake_script(base_dir, version_dir, target.os_name)
                 updater.patch_target_qt_conf(base_dir, version_dir, arch_dir, target.os_name)
         except IOError as e:
-            raise e
+            raise UpdaterError(f"Updater caused an IO error: {e}") from e
 
     @classmethod
     def patch_kde(cls, src_dir):

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterable
 import pytest
 
 from aqt.archives import ModuleToPackage, QtArchives, QtPackage, ToolArchives
-from aqt.exceptions import NoPackageFound, ArchiveListError
+from aqt.exceptions import ArchiveListError, NoPackageFound
 from aqt.helper import Settings
 from aqt.metadata import Version
 
@@ -71,10 +71,10 @@ def corrupt_xmlfile():
     (
         (QtArchives, ("mac", "desktop", "1.2.3", "clang", Settings.baseurl)),
         (ToolArchives, ("mac", "desktop", "tools_qtifw", Settings.baseurl)),
-    )
+    ),
 )
 def test_qtarchive_parse_corrupt_xmlfile(monkeypatch, corrupt_xmlfile, archives_class, init_args):
-    monkeypatch.setattr('aqt.archives.getUrl', lambda self, url: corrupt_xmlfile)
+    monkeypatch.setattr("aqt.archives.getUrl", lambda self, url: corrupt_xmlfile)
 
     with pytest.raises(ArchiveListError) as error:
         archives_class(*init_args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,3 +173,22 @@ def test_cli_input_errors(capsys, expected_help, cmd, expect_msg, should_show_he
     out, err = capsys.readouterr()
     assert out == (expected_help if should_show_help else "")
     assert err.rstrip().endswith(expect_msg)
+
+
+def test_cli_unexpected_error(monkeypatch, capsys):
+    def _mocked_run(*args):
+        raise RuntimeError("Some unexpected error")
+
+    monkeypatch.setattr("aqt.installer.Cli.run_install_qt", _mocked_run)
+
+    cli = Cli()
+    cli._setup_settings()
+    assert 1 == cli.run(["install-qt", "mac", "ios", "6.2.0"])
+    out, err = capsys.readouterr()
+    assert err.startswith("Some unexpected error")
+    assert err.rstrip().endswith(
+        "===========================PLEASE FILE A BUG REPORT===========================\n"
+        "You have discovered a bug in aqt.\n"
+        "Please file a bug report at https://github.com/miurahr/aqtinstall/issues.\n"
+        "Please remember to include a copy of this program's output in your report."
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,3 +192,12 @@ def test_cli_unexpected_error(monkeypatch, capsys):
         "Please file a bug report at https://github.com/miurahr/aqtinstall/issues.\n"
         "Please remember to include a copy of this program's output in your report."
     )
+
+
+def test_cli_set_7zip(monkeypatch):
+    cli = Cli()
+    cli._setup_settings()
+    with pytest.raises(CliInputError) as err:
+        cli._set_sevenzip("some_nonexistent_binary")
+    assert err.type == CliInputError
+    assert format(err.value) == "Specified 7zip command executable does not exist: 'some_nonexistent_binary'"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,11 +89,8 @@ def test_cli_invalid_version(capsys, invalid_version):
         ("install-doc", "mac", "desktop", invalid_version),
         ("list-qt", "mac", "desktop", "--modules", invalid_version),
     ):
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            cli = Cli()
-            cli.run(cmd)
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 1
+        cli = Cli()
+        assert cli.run(cmd) == 1
         out, err = capsys.readouterr()
         sys.stdout.write(out)
         sys.stderr.write(err)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,11 +10,8 @@ import aqt
 def test_cli_unknown_version(capsys):
     wrong_version = "5.16.0"
     wrong_url_ending = "mac_x64/desktop/qt5_5160/Updates.xml"
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        cli = aqt.installer.Cli()
-        cli.run(["install-qt", "mac", "desktop", wrong_version])
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 1
+    cli = aqt.installer.Cli()
+    assert cli.run(["install-qt", "mac", "desktop", wrong_version]) == 1
     out, err = capsys.readouterr()
     sys.stdout.write(out)
     sys.stderr.write(err)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import subprocess
 import sys
 import textwrap
 from dataclasses import dataclass
@@ -13,7 +14,9 @@ import py7zr
 import pytest
 from pytest_socket import disable_socket
 
-from aqt.installer import Cli
+from aqt.archives import QtPackage
+from aqt.exceptions import ArchiveExtractionError
+from aqt.installer import Cli, installer
 
 
 class MockMultiprocessingContext:
@@ -45,7 +48,7 @@ class MockMultiprocessingContext:
             pass
 
         def terminate(self):
-            assert False, "Did not expect to call terminate during unit test"
+            pass
 
 
 class MockMultiprocessingManager:
@@ -506,3 +509,53 @@ def test_install_bad_tools_modules(monkeypatch, capsys, cmd, xml_file, expected_
     assert match
     actual = set(map(lambda x: x[1:-1], match.group(1).split(", ")))
     assert actual == expect_missing
+
+
+def test_install_keyboard_interrupt(monkeypatch, capsys):
+    def mock_keyboard_interrupt(*args):
+        raise KeyboardInterrupt()
+
+    host, target, ver, arch = "windows", "desktop", "6.1.0", "win64_mingw81"
+    updates_url = "windows_x86/desktop/qt6_610/Updates.xml"
+    archives = [plain_qtbase_archive("qt.qt6.610.win64_mingw81", "win64_mingw81")]
+
+    cmd = ["install-qt", host, target, ver, arch]
+    mock_get_url, mock_download_archive = make_mock_geturl_download_archive(archives, arch, host, updates_url)
+    monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)
+    monkeypatch.setattr("aqt.installer.getUrl", mock_get_url)
+    monkeypatch.setattr("aqt.installer.installer", mock_keyboard_interrupt)
+
+    cli = Cli()
+    cli._setup_settings()
+    assert cli.run(cmd) == 1
+    out, err = capsys.readouterr()
+    assert err.rstrip().endswith(
+        "Caught KeyboardInterrupt, terminating installer workers\nInstaller halted by keyboard interrupt."
+    )
+
+
+def test_install_installer_archive_extraction_err(monkeypatch):
+    def mock_extractor_that_fails(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd="some command", output="out", stderr="err")
+
+    monkeypatch.setattr("aqt.installer.getUrl", lambda *args: "")
+    monkeypatch.setattr("aqt.installer.downloadBinaryFile", lambda *args: None)
+    monkeypatch.setattr("aqt.installer.subprocess.run", mock_extractor_that_fails)
+
+    with pytest.raises(ArchiveExtractionError) as err, TemporaryDirectory() as temp_dir:
+        installer(
+            qt_archive=QtPackage(
+                "name",
+                "archive-url",
+                "archive",
+                "package_desc",
+                "hashurl",
+                "pkg_update_name",
+            ),
+            base_dir=temp_dir,
+            command="some_nonexistent_7z_extractor",
+            queue=MockMultiprocessingManager.Queue(),
+        )
+    assert err.type == ArchiveExtractionError
+    err_msg = format(err.value).rstrip()
+    assert err_msg == "Extraction error: 1\nout\nerr"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -497,12 +497,9 @@ def test_install_bad_tools_modules(monkeypatch, capsys, cmd, xml_file, expected_
     monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)
     monkeypatch.setattr("aqt.installer.getUrl", mock_get_url)
 
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        cli = Cli()
-        cli._setup_settings()
-        cli.run(cmd.split())
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 1
+    cli = Cli()
+    cli._setup_settings()
+    assert cli.run(cmd.split()) == 1
 
     out, err = capsys.readouterr()
     match = expected_re.match(err)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,71 @@
+import re
+from tempfile import TemporaryDirectory
+
+import pytest
+from pytest_socket import disable_socket
+
+from aqt.archives import TargetConfig
+from aqt.exceptions import UpdaterError
+from aqt.helper import Settings
+from aqt.updater import Updater
+
+
+@pytest.fixture(autouse=True)
+def disable_sockets():
+    # This blocks all network connections, causing test failure if we used monkeypatch wrong
+    disable_socket()
+
+
+@pytest.fixture(autouse=True)
+def setup_settings():
+    Settings.load_settings()
+
+
+@pytest.mark.parametrize(
+    "target_config, expected_err_pattern",
+    (
+        (
+            TargetConfig("5.15.2", "winrt", "win64_msvc2019_winrt_x86", "windows"),
+            re.compile(
+                r"Updater caused an IO error: .*No such file or directory: "
+                # '.*' wildcard used to match path separators on windows/*nix
+                r".*5\.15\.2.*winrt_x86_msvc2019.*mkspecs.*qconfig.pri.*"
+            ),
+        ),
+        (
+            TargetConfig("5.15.2", "desktop", "win64_msvc2019_64", "windows"),
+            re.compile(
+                r"Updater caused an IO error: .*No such file or directory: "
+                # '.*' wildcard used to match path separators on windows/*nix
+                r".*5\.15\.2.*msvc2019_64.*mkspecs.*qconfig.pri.*"
+            ),
+        ),
+        (
+            TargetConfig("6.1.2", "desktop", "clang_64", "mac"),
+            re.compile(
+                r"Updater caused an IO error: .*No such file or directory: "
+                # '.*' wildcard used to match path separators on windows/*nix
+                r".*6\.1\.2.*macos.*mkspecs.*qconfig.pri.*"
+            ),
+        ),
+        (
+            TargetConfig("6.1.1", "desktop", "clang_64", "mac"),
+            re.compile(
+                r"Updater caused an IO error: .*No such file or directory: "
+                # '.*' wildcard used to match path separators on windows/*nix
+                r".*6\.1\.1.*clang_64.*mkspecs.*qconfig.pri.*"
+            ),
+        ),
+    ),
+)
+def test_updater_update_license_io_error(monkeypatch, target_config: TargetConfig, expected_err_pattern: re.Pattern):
+    """
+    All of these tests will raise IOError when they attempt to patch the license file.
+    """
+    with pytest.raises(UpdaterError) as err:
+        with TemporaryDirectory() as empty_dir:
+            # Try to update a Qt installation that does not exist
+            Updater.update(target_config, base_dir=empty_dir)
+    assert err.type == UpdaterError
+    err_msg = format(err.value)
+    assert expected_err_pattern.match(err_msg)


### PR DESCRIPTION
This migrates the error handling strategy of `aqt/installer.py` from "print error message, then exit(1)" towards consistently raising and catching exceptions. See #381 for more details.

This also adds an option to `settings.ini` that allows you to turn stack traces on and off during error reporting. This behavior could probably be triggered by a command line option, but I didn't think of that.

Fix #381.

**Note**: I intend to keep this on WIP until I have test coverage for every instance of `raise AqtException` that I have altered or added.

**Edit**: There are now at least 11 instances of `raise AqtException` that I have altered or added:

- [x] 2 uncovered exceptions in archives.py
- [x] 5 uncovered exceptions in helper.py
- [x] 3 uncovered exceptions in installer.py
- [x] 1 uncovered exception in updater.py