### PR TITLE
In the "check combinations.json" workflow, update the "update-combinations" branch as soon as possible to avoid merge conflicts

### DIFF
--- a/.github/workflows/check-combinations.yml
+++ b/.github/workflows/check-combinations.yml
@@ -17,6 +17,14 @@ jobs:
     - uses: actions/checkout@master
       with:
         fetch-depth: 20
+      
+    - name: Update the "update-combinations" branch (ff merge to master)
+      uses: MaximeHeckel/github-action-merge-fast-forward@b4e9b28dce30a682e5fbe3135be4053ea2a75e15
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        branchtomerge: "origin/master"
+        branch: "update-combinations"
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v2


### PR DESCRIPTION
See #386 .

Q: Why update so early?
A: The ["check combinations.json" step](https://github.com/miurahr/aqtinstall/blob/c094930a489795cedb11124fff89511825eb31d5/.github/workflows/check-combinations.yml#L34-L35) will update the "/aqt/combinations.json" file. If I check out the "update-combinations" branch after this step, git will complain that our *local changes would be overwritten by merge*. Also, I think it's not a bad thing to put git stuff together.

Q: Why use `branchtomerge: "origin/master"` , not `branchtomerge: "master"` ?
A: At that time, there was no "master" branch locally.

/cc @ddalcino 