### PR TITLE
Specify version by SimpleSpec

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -28,7 +28,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 from aqt.exceptions import ArchiveListError, NoPackageFound
 from aqt.helper import Settings, getUrl
-from aqt.metadata import Version
+from aqt.metadata import QtRepoProperty, Version
 
 
 @dataclass
@@ -152,12 +152,8 @@ class QtArchives:
         )
 
     def _arch_ext(self) -> str:
-        if self.arch == "wasm_32":
-            return "_wasm"
-        elif self.arch.startswith("android_") and self.version.major == 6:
-            return "{}".format(self.arch[7:])
-        else:
-            return ""
+        ext = QtRepoProperty.extension_for_arch(self.arch, self.version >= Version("6.0.0"))
+        return ("_" + ext) if ext else ""
 
     def _base_target_package_name(self) -> str:
         return "qt_base"

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -753,7 +753,9 @@ class Cli:
         subparser.add_argument("target", choices=["desktop", "winrt", "android", "ios"], help="target sdk")
         if not is_legacy:
             subparser.add_argument(
-                "qt_version_spec", help='Qt version in the format of "5.X.Y" or SimpleSpec like "5.X" or "<6.X"'
+                "qt_version_spec",
+                metavar="(VERSION | SPECIFICATION)",
+                help='Qt version in the format of "5.X.Y" or SimpleSpec like "5.X" or "<6.X"',
             )
 
     def _setup_settings(self, args=None):

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -358,6 +358,8 @@ class Cli:
 
     def run_install_src(self, args):
         """Run src subcommand"""
+        if not hasattr(args, "qt_version"):
+            args.qt_version = str(Cli._determine_qt_version(args.qt_version_spec, args.host, args.target, arch=""))
         if args.kde and args.qt_version != "5.15.2":
             raise CliInputError("KDE patch: unsupported version!!")
         start_time = time.perf_counter()

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -323,6 +323,34 @@ class ToolData:
         return [[name, *[content[key] for key in keys]] for name, content in self.tool_data.items()]
 
 
+class QtRepoProperty:
+    """
+    Describes properties of the Qt repository at https://download.qt.io/online/qtsdkrepository.
+    Intended to help decouple the logic of aqt from specific properties of the Qt repository.
+    """
+
+    @staticmethod
+    def extension_for_arch(architecture: str, is_version_ge_6: bool) -> str:
+        if architecture == "wasm_32":
+            return "wasm"
+        elif architecture.startswith("android_") and is_version_ge_6:
+            ext = architecture[len("android_") :]
+            if ext in ArchiveId.EXTENSIONS_REQUIRED_ANDROID_QT6:
+                return ext
+        return ""
+
+    @staticmethod
+    def possible_extensions_for_arch(arch: str) -> List[str]:
+        """Assumes no knowledge of the Qt version"""
+
+        # ext_ge_6: the extension if the version is greater than or equal to 6.0.0
+        # ext_lt_6: the extension if the version is less than 6.0.0
+        ext_lt_6, ext_ge_6 = [QtRepoProperty.extension_for_arch(arch, is_ge_6) for is_ge_6 in (False, True)]
+        if ext_lt_6 == ext_ge_6:
+            return [ext_lt_6]
+        return [ext_lt_6, ext_ge_6]
+
+
 class MetadataFactory:
     """Retrieve metadata of Qt variations, versions, and descriptions from Qt site."""
 

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -287,6 +287,8 @@ for platform_build_job in all_platform_build_jobs:
         key = "{} {} {} for {}".format(
             build_job.command, build_job.qt_version, build_job.arch, build_job.target
         )
+        if build_job.spec:
+            key = '{} (spec="{}")'.format(key, build_job.spec)
         if build_job.module:
             key = "{} ({})".format(key, build_job.module)
         if build_job.subarchives:

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -148,6 +148,16 @@ windows_build_jobs.extend(
             module="qtcharts qtnetworkauth",
             mirror=random.choice(MIRRORS),
         ),
+        BuildJob(
+            "install-qt",
+            "5.14.2",
+            "windows",
+            "desktop",
+            "win64_msvc2017_64",
+            "msvc2017_64",
+            spec=">1,<5.15",  # Don't redirect output! Must be wrapped in quotes!
+            mirror=random.choice(MIRRORS),
+        ),
     ]
 )
 

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -35,7 +35,11 @@ steps:
         if [[ "$(SUBARCHIVES)" != "" ]]; then
           opt+=" --archives $(SUBARCHIVES)"
         fi
-        python -m aqt install-qt $(HOST) $(TARGET) $(QT_VERSION) $(ARCH) $opt
+        if [[ "$(SPEC)" == "" ]]; then
+          python -m aqt install-qt $(HOST) $(TARGET) $(QT_VERSION) $(ARCH) $opt
+        else
+          python -m aqt install-qt $(HOST) $(TARGET) "$(SPEC)" $(ARCH) $opt
+        fi
         if [[ "$(TARGET)" == "android" || "$(TARGET)" == "ios" ]]; then
           if [[ "$(HOST)" == "windows" ]]; then
             python -m aqt install-qt $(HOST) desktop $(QT_VERSION) mingw81_64 --archives qtbase

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -265,7 +265,7 @@ install-qt command
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
         [--noarchives]
-        <host> <target> <Qt version> [<arch>]
+        <host> <target> (<Qt version> | <spec>) [<arch>]
 
 Install Qt library, with specified version and target.
 There are various combinations to accept according to Qt version.
@@ -282,6 +282,20 @@ There are various combinations to accept according to Qt version.
 
     This is a Qt version such as 5.9.7, 5.12.1 etc.
     Use the :ref:`List Qt Command` to list available versions.
+
+.. describe:: spec
+
+    This is a `SimpleSpec`_ that specifies a range of versions.
+    If you type something in the ``<Qt version>`` positional argument that
+    cannot be interpreted as a version, it will be interpreted as a `SimpleSpec`_,
+    and ``aqt`` will select the highest available version within that `SimpleSpec`_.
+
+    For example, ``aqt install-qt mac desktop 5.12`` would install the newest
+    version of Qt 5.12 available, and ``aqt install-qt mac desktop "*"`` would
+    install the highest version of Qt available.
+
+    When using this option, ``aqt`` will print the version that it has installed
+    in the logs so that you can verify it easily.
 
 .. describe:: arch
 
@@ -324,7 +338,7 @@ install-src command
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
         [--kde]
-        <host> <target> <Qt version>
+        <host> <target> (<Qt version> | <spec>)
 
 Install Qt source code for the specified version and target.
 
@@ -339,7 +353,19 @@ Install Qt source code for the specified version and target.
 
 .. describe:: Qt version
 
-    This is a Qt version such as 5.9.7, 5.12.1 etc
+    This is a Qt version such as 5.9.7, 5.12.1 etc.
+    Use the :ref:`List Qt Command` to list available versions.
+
+.. describe:: spec
+
+    This is a `SimpleSpec`_ that specifies a range of versions.
+    If you type something in the ``<Qt version>`` positional argument that
+    cannot be interpreted as a version, it will be interpreted as a `SimpleSpec`_,
+    and ``aqt`` will select the highest available version within that `SimpleSpec`_.
+
+    For example, ``aqt install-qt mac desktop 5.12`` would install the newest
+    version of Qt 5.12 available, and ``aqt install-qt mac desktop "*"`` would
+    install the highest version of Qt available.
 
 .. option:: --kde
 
@@ -368,7 +394,7 @@ install-doc command
         [-k | --keep]
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
-        <host> <target> <Qt version>
+        <host> <target> (<Qt version> | <spec>)
 
 Install Qt documentation for the specified version and target.
 
@@ -382,7 +408,19 @@ Install Qt documentation for the specified version and target.
 
 .. describe:: Qt version
 
-    This is a Qt version such as 5.9.7, 5.12.1 etc
+    This is a Qt version such as 5.9.7, 5.12.1 etc.
+    Use the :ref:`List Qt Command` to list available versions.
+
+.. describe:: spec
+
+    This is a `SimpleSpec`_ that specifies a range of versions.
+    If you type something in the ``<Qt version>`` positional argument that
+    cannot be interpreted as a version, it will be interpreted as a `SimpleSpec`_,
+    and ``aqt`` will select the highest available version within that `SimpleSpec`_.
+
+    For example, ``aqt install-qt mac desktop 5.12`` would install the newest
+    version of Qt 5.12 available, and ``aqt install-qt mac desktop "*"`` would
+    install the highest version of Qt available.
 
 See `common options`_.
 
@@ -404,7 +442,7 @@ install-example command
         [-k | --keep]
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
-        <host> <target> <Qt version>
+        <host> <target> (<Qt version> | <spec>)
 
 Install Qt examples for the specified version and target.
 
@@ -419,7 +457,19 @@ Install Qt examples for the specified version and target.
 
 .. describe:: Qt version
 
-    This is a Qt version such as 5.9.7, 5.12.1 etc
+    This is a Qt version such as 5.9.7, 5.12.1 etc.
+    Use the :ref:`List Qt Command` to list available versions.
+
+.. describe:: spec
+
+    This is a `SimpleSpec`_ that specifies a range of versions.
+    If you type something in the ``<Qt version>`` positional argument that
+    cannot be interpreted as a version, it will be interpreted as a `SimpleSpec`_,
+    and ``aqt`` will select the highest available version within that `SimpleSpec`_.
+
+    For example, ``aqt install-qt mac desktop 5.12`` would install the newest
+    version of Qt 5.12 available, and ``aqt install-qt mac desktop "*"`` would
+    install the highest version of Qt available.
 
 
 See `common options`_.
@@ -490,6 +540,14 @@ Example: Installing Qt SDK 5.12.0 for Linux with QtCharts and QtNetworkAuth:
 
     pip install aqtinstall
     sudo aqt install-qt --outputdir /opt linux desktop 5.12.0 -m qtcharts qtnetworkauth
+
+
+Example: Installing the newest LTS version of Qt 5.12:
+
+.. code-block:: console
+
+    pip install aqtinstall
+    sudo aqt install-qt linux desktop 5.12 win64_mingw73
 
 
 Example: Installing Android (armv7) Qt 5.10.2:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -21,7 +21,7 @@ General usage of ``aqt`` looks like this:
 
 .. code-block:: bash
 
-    aqt install-qt <host> <target> <Qt version> [<arch>]
+    aqt install-qt <host> <target> (<Qt version> | <spec>) [<arch>]
 
 If you have installed ``aqt`` with pip, you can run it with the command script ``aqt``,
 but in some cases you may need to run it as ``python -m aqt``.
@@ -89,6 +89,16 @@ The installation command we need is:
 .. code-block:: console
 
     $ aqt install-qt windows desktop 6.2.0 win64_mingw81
+
+Let's say that we want to install the next version of Qt 6.2 as soon as it is available.
+We can do this by using a
+`SimpleSpec <https://python-semanticversion.readthedocs.io/en/latest/reference.html#semantic_version.SimpleSpec>`_
+instead of an explicit version:
+
+.. code-block:: console
+
+    $ aqt install-qt windows desktop 6.2 win64_mingw81
+
 
 External 7-zip extractor
 ------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
 import re
 import sys
+from pathlib import Path
 
 import pytest
 
+from aqt.exceptions import CliInputError
 from aqt.installer import Cli
-from aqt.metadata import Version
+from aqt.metadata import MetadataFactory, SimpleSpec, Version
 
 
 def test_cli_help(capsys):
@@ -66,6 +68,47 @@ def test_cli_check_version():
 
 
 @pytest.mark.parametrize(
+    "host, target, arch, version_or_spec, expected_version, is_bad_spec",
+    (
+        ("windows", "desktop", "wasm_32", "6.1", None, False),
+        ("windows", "desktop", "wasm_32", "5.12", None, False),
+        ("windows", "desktop", "wasm_32", "5.13", Version("5.13.2"), False),
+        ("windows", "desktop", "wasm_32", "5", Version("5.15.2"), False),
+        ("windows", "desktop", "wasm_32", "<5.14.5", Version("5.14.2"), False),
+        ("windows", "desktop", "mingw32", "6.0", Version("6.0.3"), False),
+        ("windows", "winrt", "mingw32", "6", None, False),
+        ("windows", "winrt", "mingw32", "bad spec", None, True),
+        ("windows", "android", "android_x86", "6", Version("6.1.0"), False),
+        ("windows", "desktop", "android_x86", "6", Version("6.1.0"), False),  # does not validate arch
+        ("windows", "desktop", "android_fake", "6", Version("6.1.0"), False),  # does not validate arch
+    ),
+)
+def test_cli_determine_qt_version(
+    monkeypatch, host, target, arch, version_or_spec: str, expected_version: Version, is_bad_spec: bool
+):
+    _html = (Path(__file__).parent / "data" / f"{host}-{target}.html").read_text("utf-8")
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _html)
+    cli = Cli()
+    cli._setup_settings()
+
+    if is_bad_spec:
+        with pytest.raises(CliInputError) as e:
+            Cli._determine_qt_version(version_or_spec, host, target, arch)
+        assert e.type == CliInputError
+        assert format(e.value) == f"Invalid version or SimpleSpec: '{version_or_spec}'\n" + SimpleSpec.usage()
+    elif not expected_version:
+        with pytest.raises(CliInputError) as e:
+            Cli._determine_qt_version(version_or_spec, host, target, arch)
+        assert e.type == CliInputError
+        expect_msg = f"No versions of Qt exist for spec={version_or_spec} with host={host}, target={target}, arch={arch}"
+        actual_msg = format(e.value)
+        assert actual_msg == expect_msg
+    else:
+        ver = Cli._determine_qt_version(version_or_spec, host, target, arch)
+        assert ver == expected_version
+
+
+@pytest.mark.parametrize(
     "invalid_version",
     ("5.15", "five-dot-fifteen", "5", "5.5.5.5"),
 )
@@ -81,12 +124,13 @@ def test_cli_invalid_version(capsys, invalid_version):
 
     matcher = re.compile(
         r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
+        r"(.*\n)*"
         r".*Invalid version: '" + invalid_version + r"'! Please use the form '5\.X\.Y'\.\n.*"
     )
 
     for cmd in (
-        ("install-qt", "mac", "desktop", invalid_version),
-        ("install-doc", "mac", "desktop", invalid_version),
+        ("install", invalid_version, "mac", "desktop"),
+        ("doc", invalid_version, "mac", "desktop"),
         ("list-qt", "mac", "desktop", "--modules", invalid_version),
     ):
         with pytest.raises(SystemExit) as pytest_wrapped_e:

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -15,6 +15,7 @@ from aqt.installer import Cli
 from aqt.metadata import (
     ArchiveId,
     MetadataFactory,
+    QtRepoProperty,
     SimpleSpec,
     ToolData,
     Version,
@@ -25,6 +26,37 @@ from aqt.metadata import (
 )
 
 Settings.load_settings()
+
+
+@pytest.mark.parametrize(
+    "arch, version, expect",
+    (
+        ("wasm_32", Version("5.13.1"), "wasm"),
+        ("mingw", Version("5.13.1"), ""),
+        ("android_fake", Version("5.13.1"), ""),
+        ("android_x86", Version("5.13.1"), ""),
+        ("android_x86", Version("6.13.1"), "x86"),
+        ("android_x86", Version("6.0.0"), "x86"),
+    ),
+)
+def test_list_extension_for_arch(arch: str, version: Version, expect: str):
+    ext = QtRepoProperty.extension_for_arch(arch, version >= Version("6.0.0"))
+    assert ext == expect
+
+
+@pytest.mark.parametrize(
+    "arch, expect",
+    (
+        ("wasm_32", ["wasm"]),
+        ("mingw", [""]),
+        ("android_fake", [""]),
+        ("android", [""]),
+        ("android_x86", ["", "x86"]),
+    ),
+)
+def test_list_possible_extension_for_arch(arch: str, expect: List[str]):
+    exts = QtRepoProperty.possible_extensions_for_arch(arch)
+    assert set(exts) == set(expect)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This implements the last item in #306: installing Qt by specifying a SimpleSpec rather than a Version.

This makes a small but important change to the planned interface:

```diff
aqt install-qt mac desktop 5.15.2                   # installs Qt 5.15.2
- aqt install-qt mac desktop --spec ">1,<6"         # installs Qt 5.15.2 by SimpleSpec
+ aqt install-qt mac desktop ">1,<6"                # installs Qt 5.15.2 by SimpleSpec
```

I felt that it was easier to implement the feature this way, as well as being easier to type and explain in the documentation. If you disagree with this change, please let me know and I'll figure out how to implement the interface as planned.

Fix #306