### PR TITLE
docs(cli): correct the parameter of "list-tool" in an example

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -157,7 +157,7 @@ List available tools
 
 .. code-block:: console
 
-    $ python -m aqt list-tool windows desktop tools_conan
+    $ python -m aqt list-tool windows desktop tools_conan -l
 
      Tool Variant Name           Version         Release Date     Display Name              Description
     ============================================================================================================


### PR DESCRIPTION
Test result:

```console
$ aqt version
aqtinstall(aqt) v2.0.0rc4 on Python 3.8.10 [CPython GCC 9.4.0]
$ aqt list-tool windows desktop tools_conan
qt.tools.conan
qt.tools.conan.cmake
$ aqt list-tool windows desktop tools_conan -l
 Tool Variant Name           Version         Release Date     Display Name              Description         
============================================================================================================
qt.tools.conan         1.33-202102101246     2021-02-10     Conan 1.33          Conan command line tool 1.33
qt.tools.conan.cmake   0.16.0-202102101246   2021-02-10     Conan conan.cmake   Conan conan.cmake (0.16.0)  
```