### PR TITLE
Add helpful error messages when modules/tools/Qt version does not exist

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -271,17 +271,16 @@ class QtArchives:
             raise NoPackageFound(message, suggested_action=self.help_msg(target_packages.get_modules()))
 
     def help_msg(self, missing_modules: Iterable[str]) -> Iterable[str]:
-        num_missing = len(list(missing_modules))
-        assert num_missing > 0
-        arch = "Please use 'aqt list-qt {0.os_name} {0.target} --arch {0.version}' to show architectures available."
-        mods = "Please use 'aqt list-qt {0.os_name} {0.target} --modules {0.version} <arch>' to show modules available."
+        base_cmd = f"aqt list-qt {self.os_name} {self.target}"
+        arch = f"Please use '{base_cmd} --arch {self.version}' to show architectures available."
+        mods = f"Please use '{base_cmd} --modules {self.version} <arch>' to show modules available."
         has_base_pkg: bool = self._base_target_package_name() in missing_modules
-        has_non_base_pkg: bool = num_missing > 1 or not has_base_pkg
+        has_non_base_pkg: bool = len(list(missing_modules)) > 1 or not has_base_pkg
         messages = []
         if has_base_pkg:
-            messages.append(arch.format(self))
+            messages.append(arch)
         if has_non_base_pkg:
-            messages.append(mods.format(self))
+            messages.append(mods)
         return messages
 
     def get_packages(self) -> List[QtPackage]:

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from logging import getLogger
 from typing import Dict, Iterable, List, Optional, Tuple
 
-from aqt.exceptions import ArchiveListError, NoPackageFound
+from aqt.exceptions import ArchiveDownloadError, ArchiveListError, NoPackageFound
 from aqt.helper import Settings, getUrl
 from aqt.metadata import QtRepoProperty, Version
 
@@ -105,11 +105,14 @@ class ModuleToPackage:
     def has_package(self, package_name: str):
         return package_name in self._packages_to_modules
 
+    def get_modules(self) -> Iterable[str]:
+        return self._modules_to_packages.keys()
+
     def __len__(self) -> int:
         return len(self._modules_to_packages)
 
     def __format__(self, format_spec) -> str:
-        return str(set(self._modules_to_packages.keys()))
+        return str(sorted(set(self._modules_to_packages.keys())))
 
 
 class QtArchives:
@@ -142,9 +145,17 @@ class QtArchives:
         self.archives: List[QtPackage] = []
         self.mod_list: Iterable[str] = modules or []
         self.timeout = timeout
-        self._get_archives()
+        try:
+            self._get_archives()
+        except ArchiveDownloadError as e:
+            self.handle_missing_updates_xml(e)
         if not all_archives:
             self.archives = list(filter(lambda a: a.name in subarchives, self.archives))
+
+    def handle_missing_updates_xml(self, e: ArchiveDownloadError):
+        msg = f"Failed to locate XML data for Qt version '{self.version}'."
+        help_msg = f"Please use 'aqt list-qt {self.os_name} {self.target}' to show versions available."
+        raise ArchiveListError(msg, suggested_action=[help_msg]) from e
 
     def _version_str(self) -> str:
         return ("{0.major}{0.minor}" if self.version == Version("5.9.0") else "{0.major}{0.minor}{0.patch}").format(
@@ -257,7 +268,21 @@ class QtArchives:
         # if we have located every requested package, then target_packages will be empty
         if len(target_packages) > 0:
             message = f"The packages {target_packages} were not found while parsing XML of package information!"
-            raise NoPackageFound(message)
+            raise NoPackageFound(message, suggested_action=self.help_msg(target_packages.get_modules()))
+
+    def help_msg(self, missing_modules: Iterable[str]) -> Iterable[str]:
+        num_missing = len(list(missing_modules))
+        assert num_missing > 0
+        arch = "Please use 'aqt list-qt {0.os_name} {0.target} --arch {0.version}' to show architectures available."
+        mods = "Please use 'aqt list-qt {0.os_name} {0.target} --modules {0.version} <arch>' to show modules available."
+        has_base_pkg: bool = self._base_target_package_name() in missing_modules
+        has_non_base_pkg: bool = num_missing > 1 or not has_base_pkg
+        messages = []
+        if has_base_pkg:
+            messages.append(arch.format(self))
+        if has_non_base_pkg:
+            messages.append(mods.format(self))
+        return messages
 
     def get_packages(self) -> List[QtPackage]:
         """
@@ -359,6 +384,11 @@ class ToolArchives(QtArchives):
     def __str__(self):
         return f"ToolArchives(tool_name={self.tool_name}, version={self.version}, arch={self.arch})"
 
+    def handle_missing_updates_xml(self, e: ArchiveDownloadError):
+        msg = f"Failed to locate XML data for the tool '{self.tool_name}'."
+        help_msg = f"Please use 'aqt list-tool {self.os_name} {self.target}' to show tools available."
+        raise ArchiveListError(msg, suggested_action=[help_msg]) from e
+
     def _get_archives(self):
         _a = "_x64"
         if self.os_name == "windows":
@@ -387,15 +417,15 @@ class ToolArchives(QtArchives):
         try:
             packageupdate = next(filter(lambda x: x.find("Name").text == self.arch, self.update_xml.iter("PackageUpdate")))
         except StopIteration:
-            message = f"The package {self.arch} was not found while parsing XML of package information!"
-            raise NoPackageFound(message)
+            message = f"The package '{self.arch}' was not found while parsing XML of package information!"
+            raise NoPackageFound(message, suggested_action=self.help_msg())
 
         name = packageupdate.find("Name").text
         named_version = packageupdate.find("Version").text
         package_desc = packageupdate.find("Description").text
         downloadable_archives = packageupdate.find("DownloadableArchives").text
         if not downloadable_archives:
-            message = f"The package {self.arch} contains no downloadable archives!"
+            message = f"The package '{self.arch}' contains no downloadable archives!"
             raise NoPackageFound(message)
         for archive in downloadable_archives.split(", "):
             package_url = posixpath.join(
@@ -417,6 +447,9 @@ class ToolArchives(QtArchives):
                     pkg_update_name=name,  # Redundant
                 )
             )
+
+    def help_msg(self, *args) -> Iterable[str]:
+        return [f"Please use 'aqt list-tool {self.os_name} {self.target} {self.tool_name}' to show tool variants available."]
 
     def get_target_config(self) -> TargetConfig:
         """Get target configuration.

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -34,7 +34,7 @@ from semantic_version import SimpleSpec as SemanticSimpleSpec
 from semantic_version import Version as SemanticVersion
 from texttable import Texttable
 
-from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError, ArchiveListError, CliInputError, EmptyMetadata
+from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError, CliInputError, EmptyMetadata
 from aqt.helper import Settings, getUrl, xml_to_modules
 
 
@@ -457,12 +457,9 @@ class MetadataFactory:
         return list(MetadataFactory.iterate_folders(html_doc, "tools"))
 
     def _fetch_tool_data(self, tool_name: str, keys_to_keep: Optional[Iterable[str]] = None) -> Dict[str, Dict[str, str]]:
+        # raises ArchiveDownloadError, ArchiveConnectionError
         rest_of_url = self.archive_id.to_url() + tool_name + "/Updates.xml"
-        try:
-            xml = self.fetch_http(rest_of_url)
-        except ArchiveDownloadError as e:
-            msg = f"Failed to locate XML data for the tool '{tool_name}'."
-            raise ArchiveListError(msg, suggested_action=suggested_follow_up(self)) from e
+        xml = self.fetch_http(rest_of_url)
         modules = xml_to_modules(
             xml,
             predicate=MetadataFactory._has_nonempty_downloads,

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -145,12 +145,14 @@ def test_qt_archives_modules(monkeypatch, arch, requested_module_names, has_none
         assert len(expected_7z_files) == 0, "Actual number of packages was fewer than expected"
 
     if has_nonexistent_modules:
+        expect_help = [f"Please use 'aqt list-qt {os_name} {target} --modules {version} <arch>' to show modules available."]
         for unexpected_module in requested_module_names:
             with pytest.raises(NoPackageFound) as e:
                 mod_names = ("qtcharts", unexpected_module)
                 QtArchives(os_name, target, str(version), arch, base, modules=mod_names)
             assert e.type == NoPackageFound
             assert unexpected_module in str(e.value), "Message should include the missing module"
+            assert e.value.suggested_action == expect_help
         return
 
     is_all_modules = "all" in requested_module_names
@@ -197,10 +199,12 @@ def test_tools_variants(monkeypatch, tool_name, tool_variant_name, is_expect_fai
     monkeypatch.setattr(QtArchives, "_download_update_xml", _mock)
 
     if is_expect_fail:
+        expect_help = [f"Please use 'aqt list-tool {host} {target} {tool_name}' to show tool variants available."]
         with pytest.raises(NoPackageFound) as e:
             ToolArchives(host, target, tool_name, base, arch=tool_variant_name)
         assert e.type == NoPackageFound
         assert tool_variant_name in str(e.value), "Message should include the missing variant"
+        assert e.value.suggested_action == expect_help
         return
 
     expect_json = json.loads((Path(__file__).parent / "data" / f"{datafile}-expect.json").read_text("utf-8"))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,7 +9,6 @@ import aqt
 @pytest.mark.remote_data
 def test_cli_unknown_version(capsys):
     wrong_version = "5.16.0"
-    wrong_url_ending = "mac_x64/desktop/qt5_5160/Updates.xml"
     cli = aqt.installer.Cli()
     assert cli.run(["install-qt", "mac", "desktop", wrong_version]) == 1
     out, err = capsys.readouterr()
@@ -22,24 +21,26 @@ def test_cli_unknown_version(capsys):
 
     aqtinstall(aqt) v.* on Python 3.*
     Specified Qt version is unknown: 5.16.0.
-    Failed to retrieve file at https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml
-    Server response code: 404, reason: Not Found
+    Failed to locate XML data for Qt version '5.16.0'.
+    ==============================Suggested follow-up:==============================
+    * Please use 'aqt list-qt mac desktop' to show versions available.
 
     Expected result when redirect occurs:
 
     aqtinstall(aqt) v.* on Python 3.*
     Specified Qt version is unknown: 5.16.0.
     Connection to the download site failed and fallback to mirror site.
-    Failed to retrieve file at .*/mac_x64/desktop/qt5_5160/Updates.xml
-    Server response code: 404, reason: Not Found
-    Connection to the download site failed. Aborted...
+    Failed to locate XML data for Qt version '5.16.0'.
+    ==============================Suggested follow-up:==============================
+    * Please use 'aqt list-qt mac desktop' to show versions available.
     """
 
     matcher = re.compile(
         r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
         r".*Specified Qt version is unknown: " + re.escape(wrong_version) + r"\.\n"
-        r".*Failed to retrieve file at .*" + re.escape(wrong_url_ending) + r"\n"
-        r".*Server response code: 404, reason: Not Found.*"
+        r".*Failed to locate XML data for Qt version '" + re.escape(wrong_version) + r"'\.\n"
+        r"==============================Suggested follow-up:==============================\n"
+        r"\* Please use 'aqt list-qt mac desktop' to show versions available\.\n",
     )
 
     assert matcher.match(err)


### PR DESCRIPTION
This adds error messages that suggest using `aqt list-*` when a user attempts to install:
1. Versions of Qt that don't exist
2. Modules that don't exist
3. Tools that don't exist
4. Tool variants that don't exist

See changes to `tests/test_install.py` for examples of the expected error messages.

The idea here is that the user will be encouraged to use `aqt list-qt` and `aqt list-tool` when one of these errors occur, instead of trying to figure out why a 404 occurred, and trying to debug `aqt` to figure out what went wrong.

There's one thing that I didn't do that could potentially improve this: We could automatically run the suggested `aqt list-*` command and print "These are the available values for the parameter you got wrong: [...]" in the error message, instead of asking the user to run `aqt list-*`.