### PR TITLE
Fix broken mirror link in cli.rst 

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -212,7 +212,7 @@ are described here:
 
 .. option:: --base, -b <base url>
 
-    Specify mirror site base url such as  -b ``https://mirrors.ocf.berkeley.edu/qt/``
+    Specify mirror site base url such as  -b ``https://mirrors.dotsrc.org/qtproject``
     where 'online' folder exist.
 
 .. option:: --timeout <timeout(sec)>

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -212,7 +212,7 @@ are described here:
 
 .. option:: --base, -b <base url>
 
-    Specify mirror site base url such as  -b 'https://mirrors.ocf.berkeley.edu/qt/'
+    Specify mirror site base url such as  -b ``https://mirrors.ocf.berkeley.edu/qt/``
     where 'online' folder exist.
 
 .. option:: --timeout <timeout(sec)>


### PR DESCRIPTION
This is meant to allow CI builds to run successfully when the mirror link in `cli.rst` is broken. It accomplishes this by changing the link into an html 'code' tag. The link is not meant to be clicked on; it is meant to be typed as a command line argument. This change makes the intention more explicit.

Additionally, this replaces the url with a working URL, in case anyone is tempted to copy it into the terminal.