### PR TITLE
Fix legacy commands

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -371,6 +371,7 @@ class ToolArchives(QtArchives):
         self.tool_name = tool_name
         self.os_name = os_name
         self.logger = getLogger("aqt.archives")
+        self.is_require_version_match = version_str is not None
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target=target,
@@ -421,6 +422,9 @@ class ToolArchives(QtArchives):
 
         name = packageupdate.find("Name").text
         named_version = packageupdate.find("Version").text
+        if self.is_require_version_match and named_version != self.version:
+            message = f"The package '{self.arch}' has the version '{named_version}', not the requested '{self.version}'."
+            raise NoPackageFound(message, suggested_action=self.help_msg())
         package_desc = packageupdate.find("Description").text
         downloadable_archives = packageupdate.find("DownloadableArchives").text
         if not downloadable_archives:

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -394,7 +394,8 @@ class Cli:
         if EXT7Z and sevenzip is None:
             # override when py7zr is not exist
             sevenzip = self._set_sevenzip(Settings.zipcmd)
-        version = "0.0.1"  # just store a dummy version
+        version = getattr(args, "version", "0.0.1")  # for legacy aqt tool
+        Cli._validate_version_str(version)
         keep = args.keep
         if args.base is not None:
             base = args.base

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -66,7 +66,7 @@ class Cli:
     def __init__(self):
         parser = argparse.ArgumentParser(
             prog="aqt",
-            description="Another unofficial Qt Installer.\n" "aqt helps you install Qt SDK, tools, examples and others\n",
+            description="Another unofficial Qt Installer.\naqt helps you install Qt SDK, tools, examples and others\n",
             formatter_class=argparse.RawTextHelpFormatter,
             add_help=True,
         )
@@ -84,11 +84,7 @@ class Cli:
             "commands {install|tool|src|examples|doc} are deprecated and marked for removal\n",
             help="Please refer to each help message by using '--help' with each subcommand",
         )
-        self._make_install_parsers(subparsers)
-        self._make_list_qt_parser(subparsers)
-        self._make_list_tool_parser(subparsers)
-        self._make_legacy_parsers(subparsers)
-        self._make_common_parsers(subparsers)
+        self._make_all_parsers(subparsers)
         parser.set_defaults(func=self.show_help)
         self.parser = parser
 
@@ -561,55 +557,47 @@ class Cli:
         )
         self._set_common_options(install_tool_parser)
 
-    def _make_legacy_parsers(self, subparsers: argparse._SubParsersAction):
-        deprecated_msg = "This command is deprecated and marked for removal in a future version of aqt."
-        install_parser = subparsers.add_parser(
-            "install",
-            description=deprecated_msg,
-            formatter_class=argparse.RawTextHelpFormatter,
-        )
-        self._set_install_qt_parser(install_parser, is_legacy=True)
-        tool_parser = subparsers.add_parser("tool")
-        self._set_install_tool_parser(tool_parser, is_legacy=True)
-        #
-        for cmd, f in (
-            ("doc", self.run_install_doc),
-            ("example", self.run_install_example),
-            ("src", self.run_install_src),
-        ):
-            p = subparsers.add_parser(cmd, description=deprecated_msg)
-            p.set_defaults(func=f, is_legacy=True)
-            self._set_common_arguments(p, is_legacy=True)
-            self._set_common_options(p)
-            self._set_module_options(p)
-
     def _warn_on_deprecated_command(self, old_name: str, new_name: str):
         self.logger.warning(
             f"Warning: The command '{old_name}' is deprecated and marked for removal in a future version of aqt.\n"
             f"In the future, please use the command '{new_name}' instead."
         )
 
-    def _make_install_parsers(self, subparsers: argparse._SubParsersAction):
-        install_qt_parser = subparsers.add_parser("install-qt", formatter_class=argparse.RawTextHelpFormatter)
-        self._set_install_qt_parser(install_qt_parser, is_legacy=False)
-        tool_parser = subparsers.add_parser("install-tool")
-        self._set_install_tool_parser(tool_parser, is_legacy=False)
-        #
-        for cmd, f in (
-            ("install-doc", self.run_install_doc),
-            ("install-example", self.run_install_example),
-        ):
-            p = subparsers.add_parser(cmd)
-            p.set_defaults(func=f, is_legacy=False)
-            self._set_common_arguments(p, is_legacy=False)
-            self._set_common_options(p)
-            self._set_module_options(p)
-        src_parser = subparsers.add_parser("install-src")
-        src_parser.set_defaults(func=self.run_install_src, is_legacy=False)
-        self._set_common_arguments(src_parser, is_legacy=False)
-        self._set_common_options(src_parser)
-        self._set_module_options(src_parser)
-        src_parser.add_argument("--kde", action="store_true", help="patching with KDE patch kit.")
+    def _make_all_parsers(self, subparsers: argparse._SubParsersAction):
+        deprecated_msg = "This command is deprecated and marked for removal in a future version of aqt."
+
+        def make_parser_it(cmd: str, desc: str, is_legacy: bool, set_parser_cmd, formatter_class):
+            description = f"{desc} {deprecated_msg}" if is_legacy else desc
+            kwargs = {"formatter_class": formatter_class} if formatter_class else {}
+            p = subparsers.add_parser(cmd, description=description, **kwargs)
+            set_parser_cmd(p, is_legacy=is_legacy)
+
+        def make_parser_sde(cmd: str, desc: str, is_legacy: bool, action, is_add_kde: bool):
+            description = f"{desc} {deprecated_msg}" if is_legacy else desc
+            parser = subparsers.add_parser(cmd, description=description)
+            parser.set_defaults(func=action, is_legacy=is_legacy)
+            self._set_common_arguments(parser, is_legacy=is_legacy)
+            self._set_common_options(parser)
+            self._set_module_options(parser)
+            if is_add_kde:
+                parser.add_argument("--kde", action="store_true", help="patching with KDE patch kit.")
+
+        make_parser_it("install-qt", "Install Qt.", False, self._set_install_qt_parser, argparse.RawTextHelpFormatter)
+        make_parser_it("install-tool", "Install tools.", False, self._set_install_tool_parser, None)
+        make_parser_sde("install-doc", "Install documentation.", False, self.run_install_doc, False)
+        make_parser_sde("install-example", "Install examples.", False, self.run_install_example, False)
+        make_parser_sde("install-src", "Install source.", False, self.run_install_src, True)
+
+        self._make_list_qt_parser(subparsers)
+        self._make_list_tool_parser(subparsers)
+
+        make_parser_it("install", "Install Qt.", True, self._set_install_qt_parser, argparse.RawTextHelpFormatter)
+        make_parser_it("tool", "Install tools.", True, self._set_install_tool_parser, None)
+        make_parser_sde("doc", "Install documentation.", True, self.run_install_doc, False)
+        make_parser_sde("examples", "Install examples.", True, self.run_install_example, False)
+        make_parser_sde("src", "Install source.", True, self.run_install_src, True)
+
+        self._make_common_parsers(subparsers)
 
     def _make_list_qt_parser(self, subparsers: argparse._SubParsersAction):
         """Creates a subparser that works with the MetadataFactory, and adds it to the `subparsers` parameter"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from pytest_socket import disable_socket
 
 from aqt.exceptions import ArchiveDownloadError, CliInputError
 from aqt.installer import Cli
@@ -232,7 +231,6 @@ def test_cli_input_errors(capsys, expected_help, cmd, expect_msg, should_show_he
     ),
 )
 def test_cli_legacy_commands_with_wrong_syntax(cmd):
-    disable_socket()
     cli = Cli()
     cli._setup_settings()
     with pytest.raises(SystemExit) as e:
@@ -251,7 +249,6 @@ def test_cli_legacy_tool_new_syntax(monkeypatch, capsys, cmd):
     # These incorrect commands cannot be filtered out directly by argparse because
     # they have the correct number of arguments.
     command = cmd.split()
-    disable_socket()
 
     expected = (
         "Warning: The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
@@ -298,7 +295,6 @@ def test_cli_legacy_commands_with_correct_syntax(monkeypatch, cmd):
     for func in ("run_install_qt", "run_install_src", "run_install_doc", "run_install_example", "run_install_tool"):
         monkeypatch.setattr(Cli, func, lambda *args, **kwargs: 0)
 
-    disable_socket()
     cli = Cli()
     cli._setup_settings()
     assert 0 == cli.run(cmd.split())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from aqt.exceptions import ArchiveDownloadError, CliInputError
+from aqt.exceptions import CliInputError
 from aqt.installer import Cli
 from aqt.metadata import MetadataFactory, SimpleSpec, Version
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,22 +253,8 @@ def test_cli_legacy_tool_new_syntax(monkeypatch, capsys, cmd):
     expected = (
         "Warning: The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
         "In the future, please use the command 'install-tool' instead.\n"
-        f"Specified target combination is not valid: {command[1]} {command[2]} {command[4]}\n"
-        f"Failed to locate XML data for the tool '{command[2]}'.\n"
-        "==============================Suggested follow-up:==============================\n"
-        "* Please use 'aqt list-tool windows desktop' to show tools available.\n"
+        "Invalid version: 'tools_ifw'! Please use the form '5.X.Y'.\n"
     )
-    arch = "x86" if command[1] == "windows" else "x64"
-    expect_url_end = f"{command[1]}_{arch}/desktop/{command[2]}/Updates.xml"
-
-    def mock_get(url: str, *args):
-        assert url.endswith(expect_url_end), "Failure means test is setup wrong"
-        # command[2] is a tool that doesn't exist, so:
-        raise ArchiveDownloadError(
-            f"Failed to retrieve file at {url}\n" f"Server response code: 404, reason: tool {command[2]} does not exist"
-        )
-
-    monkeypatch.setattr("aqt.archives.getUrl", mock_get)
 
     cli = Cli()
     cli._setup_settings()


### PR DESCRIPTION
Fix #413.

This fix will correctly map the legacy v1.* commands to the new v2.* commands, with backwards-compatible syntax.

Where necessary, the new commands should be modified to reproduce the legacy behavior when run in legacy mode. Right now, I think the only place we need to do this is `aqt tool`, where the legacy command would only install a tool if it matches the supplied version.

~~Right now, all I have are tests; implementation will follow.~~

**Edit**: forgot to implement legacy `aqt tool` behavior

**Edit**: implemented legacy `aqt tool` behavior that fails to install the tool when the version numbers don't match. Also re-implemented legacy bug that prevents installation of tools that don't have a valid semantic version. 💩 Hopefully, users who experience this bug will be motivated to use the new `aqt install-tool`.

We can roll back c5b89f6 if you want to keep the bug fixed, but this will remove the "fail on wrong version" behavior.

