### PR TITLE
Fix usage of `disable_socket`

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -64,6 +64,8 @@ class Cli:
 
     __slot__ = ["parser", "combinations", "logger"]
 
+    UNHANDLED_EXCEPTION_CODE = 254
+
     def __init__(self):
         parser = argparse.ArgumentParser(
             prog="aqt",
@@ -112,7 +114,7 @@ class Cli:
                 "Please file a bug report at https://github.com/miurahr/aqtinstall/issues.\n"
                 "Please remember to include a copy of this program's output in your report."
             )
-            return 1
+            return Cli.UNHANDLED_EXCEPTION_CODE
 
     def _check_tools_arg_combination(self, os_name, tool_name, arch):
         for c in Settings.tools_combinations:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+from pytest_socket import disable_socket
+
+
+def pytest_runtest_setup():
+    disable_socket()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,7 +294,7 @@ def test_cli_unexpected_error(monkeypatch, capsys):
 
     cli = Cli()
     cli._setup_settings()
-    assert 1 == cli.run(["install-qt", "mac", "ios", "6.2.0"])
+    assert Cli.UNHANDLED_EXCEPTION_CODE == cli.run(["install-qt", "mac", "ios", "6.2.0"])
     out, err = capsys.readouterr()
     assert err.startswith("Some unexpected error")
     assert err.rstrip().endswith(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,6 +6,7 @@ import pytest
 import aqt
 
 
+@pytest.mark.enable_socket
 @pytest.mark.remote_data
 def test_cli_unknown_version(capsys):
     wrong_version = "5.16.0"

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -6,19 +6,12 @@ from urllib.parse import urlparse
 
 import pytest
 import requests
-from pytest_socket import disable_socket
 from requests.models import Response
 
 from aqt import helper
 from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError
 from aqt.helper import getUrl
 from aqt.metadata import Version
-
-
-@pytest.fixture(autouse=True)
-def disable_sockets():
-    # This blocks all network connections, causing test failure if we used monkeypatch wrong
-    disable_socket()
 
 
 def test_helper_altlink(monkeypatch):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2,18 +2,11 @@ import re
 from tempfile import TemporaryDirectory
 
 import pytest
-from pytest_socket import disable_socket
 
 from aqt.archives import TargetConfig
 from aqt.exceptions import UpdaterError
 from aqt.helper import Settings
 from aqt.updater import Updater
-
-
-@pytest.fixture(autouse=True)
-def disable_sockets():
-    # This blocks all network connections, causing test failure if we used monkeypatch wrong
-    disable_socket()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
In an earlier PR, I added calls to `disable_socket()` from `pytest_socket` where I thought they were needed to prevent some tests from accessing the network, in case they weren't monkeypatched properly. Today, I discovered that `disable_socket()` disables sockets globally for all tests, which means that the tests that use remote data cannot run if they are executed after another test calls `disable_socket()`.

This change calls `disable_socket()` once from `conftest.py`, so that no tests are allowed to use network data unless they are marked as OK to use the network, with `@pytest.mark.enable_socket`. See example of usage in `tests/test_connection.py`.

See [pytest_socket docs](https://github.com/miketheman/pytest-socket).