### PR TITLE
Allow retry of download on checksum error

### DIFF
--- a/aqt/exceptions.py
+++ b/aqt/exceptions.py
@@ -43,6 +43,10 @@ class ArchiveDownloadError(AqtException):
     pass
 
 
+class ArchiveChecksumError(ArchiveDownloadError):
+    pass
+
+
 class ArchiveConnectionError(AqtException):
     pass
 

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -77,7 +77,7 @@ def getUrl(url: str, timeout) -> str:
     return result
 
 
-def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: str, timeout):
+def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: bytes, timeout):
     logger = getLogger("aqt.helper")
     filename = Path(url).name
     with requests.Session() as session:
@@ -109,7 +109,8 @@ def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: str, timeout):
             if exp is not None and hash.digest() != exp:
                 raise ArchiveChecksumError(
                     f"Downloaded file {filename} is corrupted! Detect checksum error.\n"
-                    f"Expected {exp}, Actual {hash.digest()}"
+                    f"Expect {exp.hex()}: {url}\n"
+                    f"Actual {hash.digest().hex()}: {out}"
                 )
 
 

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -50,7 +50,9 @@ def _check_content_type(ct: str) -> bool:
 def getUrl(url: str, timeout) -> str:
     logger = getLogger("aqt.helper")
     with requests.Session() as session:
-        retries = requests.adapters.Retry(total=Settings.max_retries, backoff_factor=Settings.backoff_factor)
+        retries = requests.adapters.Retry(
+            total=Settings.max_retries_on_connection_error, backoff_factor=Settings.backoff_factor
+        )
         adapter = requests.adapters.HTTPAdapter(max_retries=retries)
         session.mount("http://", adapter)
         session.mount("https://", adapter)
@@ -81,7 +83,9 @@ def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: bytes, timeout):
     logger = getLogger("aqt.helper")
     filename = Path(url).name
     with requests.Session() as session:
-        retries = requests.adapters.Retry(total=Settings.max_retries, backoff_factor=Settings.backoff_factor)
+        retries = requests.adapters.Retry(
+            total=Settings.max_retries_on_connection_error, backoff_factor=Settings.backoff_factor
+        )
         adapter = requests.adapters.HTTPAdapter(max_retries=retries)
         session.mount("http://", adapter)
         session.mount("https://", adapter)
@@ -333,7 +337,12 @@ class SettingsClass:
 
     @property
     def max_retries(self):
+        """Deprecated: please use `max_retries_on_connection_error` and `max_retries_on_checksum_error` instead!"""
         return self.config.getfloat("requests", "max_retries", fallback=5)
+
+    @property
+    def max_retries_on_connection_error(self):
+        return self.config.getfloat("requests", "max_retries_on_connection_error", fallback=self.max_retries)
 
     @property
     def max_retries_on_checksum_error(self):

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -9,7 +9,7 @@ print_stacktrace_on_error: False
 [requests]
 connection_timeout: 3.5
 response_timeout: 30
-max_retries: 5
+max_retries_on_connection_error: 5
 retry_backoff: 0.1
 max_retries_on_checksum_error: 5
 

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -11,6 +11,7 @@ connection_timeout: 3.5
 response_timeout: 30
 max_retries: 5
 retry_backoff: 0.1
+max_retries_on_checksum_error: 5
 
 [mirrors]
 blacklist:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -17,10 +17,16 @@ A file is like as follows:
 
     [aqt]
     concurrency: 4
-    connection_timeout: 3.5
-    response_timeout: 30
     baseurl: https://download.qt.io
     7zcmd: 7z
+    print_stacktrace_on_error: False
+
+    [requests]
+    connection_timeout: 3.5
+    response_timeout: 30
+    max_retries_on_connection_error: 5
+    retry_backoff: 0.1
+    max_retries_on_checksum_error: 5
 
     [mirrors]
     blacklist:
@@ -33,23 +39,19 @@ A file is like as follows:
         http://ftp1.nluug.nl/languages/qt
         https://mirrors.dotsrc.org/qtproject
 
+    [kde_patches]
+    patches:
+        0001-toolchain.prf-Use-vswhere-to-obtain-VS-installation-.patch
+
 
 Settings
 --------
 
-An ``[aqt]`` section is a configuration for basic behavior.
+The ``[aqt]`` section configures basic behavior.
 
 concurrency:
     ``concurrency`` is a setting how many download concurrently starts.
     It should be a integer value.
-
-connection_timeout:
-    ``connection_timeout`` is a timeout in second for connection.
-    It is passed to ``requests`` library.
-
-response_timeout:
-    ``response_timeout`` is a timeout in second how much time waiting for response.
-    It is passed to ``requests`` library.
 
 baseurl:
     ``baseurl`` is a URL of Qt download site.
@@ -62,8 +64,43 @@ baseurl:
     ``py7zr`` library.
     When ``--external`` option specified, a value is override with option's one.
 
+print_stacktrace_on_error:
+    ``print_stacktrace_on_error`` is either ``True`` or ``False``.
+    The ``True`` setting causes a stack trace to be printed to stderr any time
+    an error occurs that will end the program.
+    The ``False`` setting will hide the stack trace, unless an unhandled
+    exception occurs.
 
-A ``[mirrors]`` section is a configuration for mirror handling.
+
+The ``[requests]`` section controls the way that ``aqt`` makes network requests.
+
+connection_timeout:
+    ``connection_timeout`` is a timeout in second for connection.
+    It is passed to ``requests`` library.
+
+response_timeout:
+    ``response_timeout`` is a timeout in second how much time waiting for response.
+    It is passed to ``requests`` library.
+
+max_retries:
+    Deprecated; please do not use this setting. It has been replaced by the
+
+max_retries_on_connection_error:
+    ``max_retries_on_connection_error`` is an integer that controls how many times
+    ``aqt`` will try to reconnect to the server in the case of a connection error.
+
+retry_backoff:
+    ``retry_backoff`` is a floating point number that controls how long ``aqt``
+    will sleep between failed connection attempts.
+    Setting this value too low will hammer the server, and may result
+    in no successful connections at all.
+
+max_retries_on_checksum_error:
+    This setting controls how many times ``aqt`` will attempt to download a file,
+    in the case of a checksum error.
+
+
+The ``[mirrors]`` section is a configuration for mirror handling.
 
 blacklist:
     It is a list of URL where is a problematic mirror site.

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -129,12 +129,15 @@ def test_helper_downloadBinary_wrong_checksum(tmp_path, monkeypatch):
 
     actual_hash = binascii.unhexlify("1d41a93e4a585bb01e4518d4af431933")
     wrong_hash = binascii.unhexlify("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    expected_err = (
-        f"Downloaded file test.xml is corrupted! Detect checksum error.\nExpected {wrong_hash}, Actual {actual_hash}"
-    )
     out = tmp_path.joinpath("test.xml")
+    url = "http://example.com/test.xml"
+    expected_err = (
+        f"Downloaded file test.xml is corrupted! Detect checksum error."
+        f"\nExpect {wrong_hash.hex()}: {url}"
+        f"\nActual {actual_hash.hex()}: {out}"
+    )
     with pytest.raises(ArchiveChecksumError) as e:
-        helper.downloadBinaryFile("http://example.com/test.xml", out, "md5", wrong_hash, 60)
+        helper.downloadBinaryFile(url, str(out), "md5", wrong_hash, 60)
     assert e.type == ArchiveChecksumError
     assert format(e.value) == expected_err
 


### PR DESCRIPTION
This allows downloads of archives to be retried when checksum errors occur, as discussed in https://github.com/miurahr/aqtinstall/issues/416#issuecomment-932472110. Even after I [turned off my VPN](https://github.com/miurahr/aqtinstall/issues/416#issuecomment-933031438), I am still getting so many checksum errors that it takes me several tries before I can successfully install Qt. If any of our users are having similar trouble, I'm sure that they are extremely frustrated with `aqt`, and I think that this change could be helpful for them.

I'm not certain that this is the best implementation of this feature; please see my notes below.