### PR TITLE
[SECURITY] Use HTTPS for mirror site

### DIFF
--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -20,7 +20,7 @@ blacklist:
     http://mirrors.geekpie.club
 fallbacks:
     https://ftp.jaist.ac.jp/pub/qtproject
-    http://ftp1.nluug.nl/languages/qt
+    https://ftp1.nluug.nl/languages/qt
     https://mirrors.dotsrc.org/qtproject
 
 [kde_patches]


### PR DESCRIPTION
I noticed a non-TLS mirror in our list of fallback mirrors. I checked the site, and an HTTPS version exists: https://ftp1.nluug.nl/languages/qt/

Since this is a security issue, I think we should backport this change to aqt v1.2 as well.