### PR TITLE
Fix Sphinx error when rendering changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
 
 Fixed
 -----
-* `--noarchives` inconsistency(#429)
+* ``--noarchives`` inconsistency(#429)
 * Allow multiprocessing error propagation(#419)
 * Legacy command behavior, reproduce also old bugs (#414)
 


### PR DESCRIPTION
The last build of the documentation caused this error:

```
  Warning, treated as error:
  CHANGELOG.rst:17:'any' reference target not found: --noarchives
```

This change is meant to convince Sphinx that `--noarchives` is code and not a reference, so that documentation builds succeed again.