### PR TITLE
Fix crash when target architecture was missing

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -517,6 +517,7 @@ class Cli:
         self._set_common_options(install_qt_parser)
         install_qt_parser.add_argument(
             "arch",
+            default="",
             nargs="?",
             help="\ntarget linux/desktop: gcc_64, wasm_32"
             "\ntarget mac/desktop:   clang_64, wasm_32"


### PR DESCRIPTION
This command would trigger a crash:
`aqt install-qt linux desktop 6.2.* --archives qtbase`
This is due to the `arch` argument was missing and it defaults to `NoneType`, however follow-up function calls expect it is a string and results in a crash. This patch changed the default value to an empty string.