### PR TITLE
Add debug message when fallback url used in `metadata.py`

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -576,6 +576,10 @@ class MetadataFactory:
             except (ArchiveDownloadError, ArchiveConnectionError) as e:
                 if i == len(base_urls) - 1:
                     raise e from e
+                else:
+                    getLogger("aqt.metadata").debug(
+                        f"Connection to '{base_url}' failed. Retrying with fallback '{base_urls[i + 1]}'."
+                    )
 
     @staticmethod
     def iterate_folders(html_doc: str, filter_category: str = "") -> Generator[str, None, None]:


### PR DESCRIPTION
This change allows the MetadataFactory unit to log a debug message when a fallback url is used. This should help us to debug problems like those seen in these `aqt list-*` runs: https://dev.azure.com/miurahr/github/_build/results?buildId=4662&view=logs&j=696704cc-6fef-57a3-ea36-f27779b8cd5e.

Inspired by https://github.com/miurahr/aqtinstall/pull/432#issuecomment-953486111