### PR TITLE
fix failing coverage upload

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install tools
       run: |
         pip install -U pip
-        pip install tox tox-gh-actions coveralls
+        pip install tox tox-gh-actions coveralls coverage[toml]
     - name: Check invocation with Python2
       run: |
         ! python2 -m aqt help


### PR DESCRIPTION
Recently, every "Upload Coverage" step fails for me. This should fix it.

Example of failed "Upload Coverage" step: https://github.com/ddalcino/aqtinstall/runs/4122878621?check_suite_focus=true#step:8:31