### PR TITLE
Fix test for QtIFW

### DIFF
--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -293,7 +293,7 @@ linux_build_jobs.extend(
 
 qt_creator_bin_path = "./Tools/QtCreator/bin/"
 qt_creator_mac_bin_path = "./Qt Creator.app/Contents/MacOS/"
-qt_ifw_bin_path = "./Tools/QtInstallerFramework/4.1/bin/"
+qt_ifw_bin_path = "./Tools/QtInstallerFramework/*/bin/"
 tool_options = {
     "TOOL1_ARGS": "tools_qtcreator qt.tools.qtcreator",
     "LIST_TOOL1_CMD": f"ls {qt_creator_bin_path}",


### PR DESCRIPTION
The current CI test for QtIFW assumes that QtIFW will always be version 4.1. The [last run of the Azure Pipeline](https://dev.azure.com/miurahr/github/_build/results?buildId=4735&view=results) demonstrated what happens when the Qt repo updates QtIFW to the next version: The test fails.

This change should make the CI test resilient to version updates, by using a `*` glob instead of a version number.