### PR TITLE
Update deprecated MacOS build in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
 - job: Mac
   dependsOn: MatricesGenerator
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.mac'] ]
   steps:


### PR DESCRIPTION
Azure Pipelines has deprecated macOS-10.14 builds, and it looks like they will remove that OS on December 10, 2021.

This PR updates the macOS build to macOS-10.15.

We could also use `macOS-latest` for this instead; that would ensure that the OS never gets deprecated. 

See: https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/