### PR TITLE
Feature: allow user to specify the download location of 7z archives

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -79,7 +79,7 @@ def getUrl(url: str, timeout) -> str:
     return result
 
 
-def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: bytes, timeout):
+def downloadBinaryFile(url: str, out: Path, hash_algo: str, exp: bytes, timeout):
     logger = getLogger("aqt.helper")
     filename = Path(url).name
     with requests.Session() as session:
@@ -114,7 +114,7 @@ def downloadBinaryFile(url: str, out: str, hash_algo: str, exp: bytes, timeout):
                 raise ArchiveChecksumError(
                     f"Downloaded file {filename} is corrupted! Detect checksum error.\n"
                     f"Expect {exp.hex()}: {url}\n"
-                    f"Actual {hash.digest().hex()}: {out}"
+                    f"Actual {hash.digest().hex()}: {out.name}"
                 )
 
 

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -306,6 +306,14 @@ class SettingsClass:
         return result
 
     @property
+    def archive_download_location(self):
+        return self.config.get("aqt", "archive_download_location", fallback=".")
+
+    @property
+    def always_keep_archives(self):
+        return self.config.getboolean("aqt", "always_keep_archives", fallback=False)
+
+    @property
     def concurrency(self):
         """concurrency configuration.
 

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -228,12 +228,13 @@ class Cli:
 
         There are three potential behaviors here:
         1. By default, return a temp directory that will be removed on program exit.
-        2. If the user has asked to keep archives, but has not specified a destination, we return ".".
+        2. If the user has asked to keep archives, but has not specified a destination,
+            we return Settings.archive_download_location ("." by default).
         3. If the user has asked to keep archives and specified a destination,
             we create the destination dir if it doesn't exist, and return that directory.
         """
         if not archive_dest:
-            return Path("." if keep else temp_dir)
+            return Path(Settings.archive_download_location if keep else temp_dir)
         dest = Path(archive_dest)
         dest.mkdir(parents=True, exist_ok=True)
         return dest
@@ -254,7 +255,7 @@ class Cli:
         else:
             qt_version: str = args.qt_version
             Cli._validate_version_str(qt_version)
-        keep: bool = args.keep
+        keep: bool = args.keep or Settings.always_keep_archives
         archive_dest: Optional[str] = args.archive_dest
         output_dir = args.outputdir
         if output_dir is None:
@@ -342,7 +343,7 @@ class Cli:
             base_dir = os.getcwd()
         else:
             base_dir = output_dir
-        keep: bool = args.keep
+        keep: bool = args.keep or Settings.always_keep_archives
         archive_dest: Optional[str] = args.archive_dest
         if args.base is not None:
             base = args.base
@@ -430,7 +431,7 @@ class Cli:
         version = getattr(args, "version", None)
         if version is not None:
             Cli._validate_version_str(version, allow_minus=True)
-        keep: bool = args.keep
+        keep: bool = args.keep or Settings.always_keep_archives
         archive_dest: Optional[str] = args.archive_dest
         if args.base is not None:
             base = args.base

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -5,6 +5,8 @@ concurrency: 4
 baseurl: https://download.qt.io
 7zcmd: 7z
 print_stacktrace_on_error: False
+always_keep_archives: False
+archive_download_location: .
 
 [requests]
 connection_timeout: 3.5

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -239,7 +239,20 @@ are described here:
 
 .. option:: --keep, -k
 
-    Keep downloaded archive when specified, otherwise remove after install
+    Keep downloaded archive when specified, otherwise remove after install.
+    Use ``--archive-dest <path>`` to choose where aqt will place these files.
+    If you do not specify a download destination, aqt will place these files in
+    the current working directory.
+
+.. option:: --archive-dest <path>
+
+    Set the destination path for downloaded archives (temp directory by default).
+    All downloaded archives will be automatically deleted unless you have
+    specified the ``--keep`` option above, or ``aqt`` crashes.
+
+    Note that this option refers to the intermediate ``.7z`` archives that ``aqt``
+    downloads and then extracts to ``--outputdir``.
+    Most users will not need to keep these files.
 
 .. option:: --modules, -m (<list of modules> | all)
 
@@ -295,6 +308,7 @@ install-qt command
         [-E | --external <7zip command>]
         [--internal]
         [-k | --keep]
+        [-d | --archive-dest] <path>
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
         [--noarchives]
@@ -368,6 +382,7 @@ install-src command
         [-E | --external <7zip command>]
         [--internal]
         [-k | --keep]
+        [-d | --archive-dest] <path>
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
         [--kde]
@@ -425,6 +440,7 @@ install-doc command
         [-E | --external <7zip command>]
         [--internal]
         [-k | --keep]
+        [-d | --archive-dest] <path>
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
         <host> <target> (<Qt version> | <spec>)
@@ -473,6 +489,7 @@ install-example command
         [-E | --external <7zip command>]
         [--internal]
         [-k | --keep]
+        [-d | --archive-dest] <path>
         [-m | --modules (all | <module> [<module>...])]
         [--archives <archive> [<archive>...]]
         <host> <target> (<Qt version> | <spec>)
@@ -525,6 +542,7 @@ install-tool command
         [-E | --external <7zip command>]
         [--internal]
         [-k | --keep]
+        [-d | --archive-dest] <path>
         <host> <target> <tool name> [<tool variant name>]
 
 Install tools like QtIFW, mingw, Cmake, Conan, and vcredist.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,6 +20,8 @@ A file is like as follows:
     baseurl: https://download.qt.io
     7zcmd: 7z
     print_stacktrace_on_error: False
+    always_keep_archives: False
+    archive_download_location: .
 
     [requests]
     connection_timeout: 3.5
@@ -70,6 +72,18 @@ print_stacktrace_on_error:
     an error occurs that will end the program.
     The ``False`` setting will hide the stack trace, unless an unhandled
     exception occurs.
+
+always_keep_archives:
+    This is either ``True`` or ``False``.
+    The ``True`` setting turns on the ``--keep`` option every time you run aqt,
+    and cannot be overridden by command line options.
+    The ``False`` setting will require you to set ``--keep`` manually every time
+    you run aqt, unless you don't want to keep ``.7z`` archives.
+
+archive_download_location:
+    This is the relative or absolute path to the location in which ``.7z`` archives
+    will be downloaded, when ``--keep`` is turned on.
+    You can override this location with the ``--archives-dest`` option.
 
 
 The ``[requests]`` section controls the way that ``aqt`` makes network requests.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,3 +351,26 @@ def test_cli_set_7zip(monkeypatch):
         cli._set_sevenzip("some_nonexistent_binary")
     assert err.type == CliInputError
     assert format(err.value) == "Specified 7zip command executable does not exist: 'some_nonexistent_binary'"
+
+
+@pytest.mark.parametrize(
+    "archive_dest, keep, temp_dir, expect, should_make_dir",
+    (
+        (None, False, "temp", "temp", False),
+        (None, True, "temp", ".", False),
+        ("my_archives", False, "temp", "my_archives", True),
+        ("my_archives", True, "temp", "my_archives", True),
+    ),
+)
+def test_cli_choose_archive_dest(
+    monkeypatch, archive_dest: Optional[str], keep: bool, temp_dir: str, expect: str, should_make_dir: bool
+):
+    enclosed = {"made_dir": False}
+
+    def mock_mkdir(*args, **kwargs):
+        enclosed["made_dir"] = True
+
+    monkeypatch.setattr("aqt.installer.Path.mkdir", mock_mkdir)
+
+    assert Cli.choose_archive_dest(archive_dest, keep, temp_dir) == Path(expect)
+    assert enclosed["made_dir"] == should_make_dir

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -127,10 +127,10 @@ def test_helper_downloadBinary_wrong_checksum(tmp_path, monkeypatch):
     expected_err = (
         f"Downloaded file test.xml is corrupted! Detect checksum error."
         f"\nExpect {wrong_hash.hex()}: {url}"
-        f"\nActual {actual_hash.hex()}: {out}"
+        f"\nActual {actual_hash.hex()}: {out.name}"
     )
     with pytest.raises(ArchiveChecksumError) as e:
-        helper.downloadBinaryFile(url, str(out), "md5", wrong_hash, 60)
+        helper.downloadBinaryFile(url, out, "md5", wrong_hash, 60)
     assert e.type == ArchiveChecksumError
     assert format(e.value) == expected_err
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -146,11 +146,11 @@ def make_mock_geturl_download_archive(
 
         def locate_archive() -> MockArchive:
             for arc in archives:
-                if out == arc.filename_7z:
+                if Path(out).name == arc.filename_7z:
                     return arc
             assert False, "Requested an archive that was not mocked"
 
-        locate_archive().write_compressed_archive(Path("./"))
+        locate_archive().write_compressed_archive(Path(out).parent)
 
     return mock_getUrl, mock_download_archive
 
@@ -731,6 +731,7 @@ def test_install_installer_archive_extraction_err(monkeypatch):
             base_dir=temp_dir,
             command="some_nonexistent_7z_extractor",
             queue=MockMultiprocessingManager.Queue(),
+            archive_dest=Path(temp_dir),
         )
     assert err.type == ArchiveExtractionError
     err_msg = format(err.value).rstrip()


### PR DESCRIPTION
Adds the option `--archive-dest <path>`.

For convenience/readability, this will also turn any reference to the downloaded file in `helper.py` and `installer.py` into a `pathlib.Path` object. This makes it easier to ensure that the file ends up in the right location.

This also adds items in `settings.ini` that control the default behavior of `--keep` and `--archive-dest`.

Fix #421