### PR TITLE
Restrict effect of `--archives` flag to base and debug_info modules

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -316,6 +316,7 @@ class SrcDocExamplesArchives(QtArchives):
         subarchives=None,
         modules=None,
         all_extra=False,
+        is_include_base_package: bool = True,
         timeout=(5, 5),
     ):
         self.flavor = flavor
@@ -332,6 +333,7 @@ class SrcDocExamplesArchives(QtArchives):
             subarchives=subarchives,
             modules=modules,
             all_extra=all_extra,
+            is_include_base_package=is_include_base_package,
             timeout=timeout,
         )
 

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -849,7 +849,8 @@ class Cli:
         subparser.add_argument(
             "--archives",
             nargs="*",
-            help="Specify subset packages to install (Default: all standard and extra modules).",
+            help="Specify subset of archives to install. Affects the base module and the debug_info module. "
+            "(Default: all archives).",
         )
 
     def _set_common_arguments(self, subparser, *, is_legacy: bool, is_target_deprecated: bool = False):

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -117,19 +117,16 @@ steps:
         aqt list-example $(HOST) $(QT_VERSION) --modules                        # print example modules available for host/desktop/version
       fi
       if [[ "$(SUBCOMMAND)" == "install-src" ]]; then
-        python -m aqt $(SUBCOMMAND) $(HOST) $(TARGET) $(QT_VERSION) --archives $(SUBARCHIVES)
-        ls -lh ./$(QT_VERSION)/Src/*/
+        python -m aqt $(SUBCOMMAND) $(HOST) $(QT_VERSION) --archives $(SUBARCHIVES)
+        $(CHECK_OUTPUT_CMD)
       fi
       if [[ "$(SUBCOMMAND)" =~ ^install-(doc|example)$ ]]; then
         opt=""
         if [[ "$(MODULE)" != "" ]]; then
           opt+=" -m $(MODULE)"
         fi
-        python -m aqt $(SUBCOMMAND) $(HOST) $(TARGET) $(QT_VERSION) --archives $(SUBARCHIVES) $opt
-
-        # Docs install to ./Docs/Qt-6.1.0/qtdoc/
-        # Examples install to ./Examples/Qt-6.1.0/demos
-        ls -lh ./*/Qt-$(QT_VERSION)/*/
+        python -m aqt $(SUBCOMMAND) $(HOST) $(QT_VERSION) --archives $(SUBARCHIVES) $opt
+        $(CHECK_OUTPUT_CMD)
       fi
       if [[ "$(SUBCOMMAND)" == "install-tool" ]]; then
         opt=""

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -414,6 +414,7 @@ are described here:
 .. option:: --archives <list of archives>
 
     [Advanced] Specify subset of archives to **limit** installed archives.
+    It will only affect the base Qt installation and the ``debug_info`` module.
     This is advanced option and not recommended to use for general usage.
     Main purpose is speed up CI/CD process by limiting installed modules.
     It can cause broken installation of Qt SDK.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -436,6 +436,7 @@ of archives that it is downloading, extracting, and installing,
 including ``qtbase``, ``qtmultimedia``, ``qt3d``, and ~25 more items.
 We can use the ``--archives`` flag to choose which of these archives we will
 actually install.
+The ``--archives`` flag can only affect two modules: the base Qt installation and the ``debug_info`` module.
 
 .. note::
     In this documentation, **"modules"**, **"archives"**, and **"the base Qt installation"**
@@ -511,72 +512,38 @@ working Qt installation. We can install these archives using this command:
 Installing Modules With Archives Specified
 ``````````````````````````````````````````
 
-Now let's say we need to install the ``qtcharts`` and ``qtlottie`` modules.
-Let's see what archives are part of these modules:
+As of aqt v2.1.0, the ``--archives`` flag will only apply to
+the base Qt installation and to the ``debug_info`` module.
+Previous versions of aqt required that when installing modules with the ``--archives`` flag,
+the user must specify archives for each module, otherwise they would not be installed.
+This behavior has been changed to prevent such mistakes.
+
+Let's say that we need to install the bare minimum Qt 5.15.2, with the modules ``qtcharts`` and ``qtlottie``:
 
 .. code-block:: console
 
-    $ aqt list-qt linux desktop --archives 5.15.2 gcc_64 qtcharts qtlottie
-    qtcharts qtlottie
+    $ aqt install-qt linux desktop 5.15.2 --modules qtcharts qtlottie --archives qtbase
 
-This time, the command only printed two archives.
-The ``qtcharts`` and ``qtlottie`` modules contain one archive per module.
-
-.. note::
-    This command printed all archives associated with the modules we provided it,
-    and it did not print any of the archives associated with the base Qt installation.
-    This happened because we added a list of modules to the ``--archives`` flag.
-
-    .. code-block:: bash
-
-        # Print archives from the base Qt installation
-        aqt list-qt linux desktop --archives 5.15.2 gcc_64
-
-        # Print archives from the specified modules, but not the base Qt installation
-        aqt list-qt linux desktop --archives 5.15.2 gcc_64 qtcharts qtlottie
-
-
-Now let's install Qt with these modules:
-
-.. code-block:: console
-
-    $ aqt install-qt linux desktop 5.15.2 --modules qtcharts qtlottie \
-                                          --archives qtbase qtcharts qtlottie
-
-This command will install the bare minimum Qt, along with the modules ``qtcharts`` and ``qtlottie``.
-
-Remember that when using the ``--archives`` flag, you must specify every archive you
-intend to install.
-
-.. code-block:: bash
-
-    # Ways to misuse the `--archives` flag:
-
-    # This command installs modules without a working Qt installation,
-    # because `--archives` is missing `qtbase`.
-    aqt install-qt linux desktop 5.15.2 --modules qtcharts qtlottie \
-                                        --archives qtcharts qtlottie
-
-    # This command skips installation of the specified modules,
-    # because `--archives` is missing `qtcharts` and `qtlottie`.
-    aqt install-qt linux desktop 5.15.2 --modules qtcharts qtlottie \
-                                        --archives qtbase
-
-    # This command installs qtbase, but neither `qtcharts` nor `qtlottie`,
-    # because `--modules` is missing those names.
-    aqt install-qt linux desktop 5.15.2 --archives qtbase qtcharts qtlottie
+This command will successfully install 3 archives: 1 for ``qtbase``, and one each for the two modules.
+If we had tried to use this command with previous versions of aqt, we would not have
+installed the two modules because we did not specify them in the ``--archives`` list.
 
 .. note::
 
-    If you install modules that depend on archives other than ``qtbase``,
-    and you have not specified those archives after the ``--archives`` flag,
-    those modules will not work when you try to use them.
+    You can still misuse the ``--archives`` flag by omitting the ``qtbase`` archive,
+    or by omitting archives that another archive or module is dependent on.
+    You may not notice that there is a problem until you try to compile a program,
+    and compilation fails.
 
 Installing the ``debug_info`` module
 ````````````````````````````````````
 
-Now let's say we need to install the ``debug_info`` module, which is particularly large.
-We do not want to install all of it, so we can use ``aqt list-qt --archives`` again
+Now let's say we need to install the ``debug_info`` module, which is particularly large: around one gigabyte.
+We do not want to install all of it, so we can use ``aqt install-qt --archives``
+to choose which archives we want to install. Remember that the ``--archives`` flag
+
+
+``aqt list-qt --archives``
 to print which archives are part of the ``debug_info`` module:
 
 .. code-block:: console

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -4,11 +4,11 @@ import posixpath
 import re
 from itertools import groupby
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List, Set
 
 import pytest
 
-from aqt.archives import ModuleToPackage, QtArchives, QtPackage, ToolArchives
+from aqt.archives import ModuleToPackage, QtArchives, QtPackage, SrcDocExamplesArchives, ToolArchives
 from aqt.exceptions import ArchiveListError, NoPackageFound
 from aqt.helper import Settings
 from aqt.metadata import Version
@@ -286,3 +286,166 @@ def test_module_to_package():
     for package_name in qtcharts_names:
         assert not mapping.has_package(package_name), "None of the qtcharts packages may remain after removal"
     assert len(mapping) == 0, "There must be no remaining module names"
+
+
+qt_5140_xml_weird_module = """
+<Updates>
+ <PackageUpdate>
+  <Name>qt.qt5.5140.qtcharts.win32_mingw73</Name>
+  <DisplayName>Qt Charts</DisplayName>
+  <Description>blah blah blah</Description>
+  <Version>5.14.0-0-201912110700</Version>
+  <ReleaseDate>2019-12-11</ReleaseDate>
+  <Dependencies>qt.qt5.5140.doc.qtcharts, qt.qt5.5140.examples.qtcharts</Dependencies>
+  <AutoDependOn/>
+  <DownloadableArchives>weird-qtcharts.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="791213" OS="Any" UncompressedSize="8196243"/>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.qt5.5140.win32_mingw73</Name>
+  <DisplayName>Mingw 32-bit</DisplayName>
+  <Description>blah blah blah</Description>
+  <Version>5.14.0-0-201912110700</Version>
+  <ReleaseDate>2019-12-11</ReleaseDate>
+  <Dependencies>qt.tools.qtcreator, qt.qt5.5140.doc, qt.qt5.5140.examples</Dependencies>
+  <AutoDependOn/>
+  <DownloadableArchives>qtbase-mingw.7z, other-mingw.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="81303586" OS="Any" UncompressedSize="540178217"/>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.qt5.5140.debug_info.win32_mingw73</Name>
+  <DisplayName>Desktop Mingw 32-bit debug information files</DisplayName>
+  <Description>Qt 5.14.0 debug information files for Desktop Mingw 32-bit</Description>
+  <Version>5.14.0-0-201912110700</Version>
+  <ReleaseDate>2019-12-11</ReleaseDate>
+  <AutoDependOn>qt.qt5.5140.debug_info, qt.qt5.5140.win32_mingw73</AutoDependOn>
+  <Dependencies>qt.qt5.5140.win32_mingw73</Dependencies>
+  <DownloadableArchives>qtbase-debug_info.7z, weird-debug_info.7z, somethingELSE-debug_info.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="459720623" OS="Any" UncompressedSize="3579147640"/>
+ </PackageUpdate>
+</Updates>
+"""
+qt_doc_5152_xml_weird_module = """
+<Updates>
+ <PackageUpdate>
+  <Name>qt.qt5.5152.doc.qtcharts</Name>
+  <DisplayName>Documentation for Qt 5.15.2 GPLv3 components (QtCharts)</DisplayName>
+  <Description>Documentation for Qt 5.15.2 GPLv3 components (QtCharts)</Description>
+  <Version>5.15.2-0-202011130724</Version>
+  <ReleaseDate>2020-11-13</ReleaseDate>
+  <DownloadableArchives>weird-qtcharts-docs.7z</DownloadableArchives>
+  <UpdateFile UncompressedSize="16802053" OS="Any" CompressedSize="8714357"/>
+ </PackageUpdate>
+ <PackageUpdate>
+  <Name>qt.qt5.5152.doc</Name>
+  <DisplayName>Qt 5.15.2 Documentation</DisplayName>
+  <Description>Qt 5.15.2 documentation</Description>
+  <Version>5.15.2-0-202011130724</Version>
+  <ReleaseDate>2020-11-13</ReleaseDate>
+  <Dependencies>qt.tools</Dependencies>
+  <DownloadableArchives>tqtc-docs.7z, other-docs.7z</DownloadableArchives>
+  <UpdateFile UncompressedSize="402906410" OS="Any" CompressedSize="134528625"/>
+ </PackageUpdate>
+</Updates>
+"""
+
+
+def make_qt_archives(subarchives, modules, is_include_base) -> QtArchives:
+    return QtArchives(
+        "mac",
+        "desktop",
+        "5.14.0",
+        "win32_mingw73",
+        "www.example.com",
+        subarchives,
+        modules,
+        "all" in modules,
+        is_include_base,
+    )
+
+
+def make_doc_archives(subarchives, modules, is_include_base) -> SrcDocExamplesArchives:
+    return SrcDocExamplesArchives(
+        flavor="doc",
+        os_name="mac",
+        target="desktop",
+        version="5.15.2",
+        base="www.example.com",
+        subarchives=subarchives,
+        modules=modules,
+        all_extra="all" in modules,
+        is_include_base_package=is_include_base,
+    )
+
+
+@pytest.mark.parametrize(
+    "subarchives, modules, is_include_base, xml, make_archives_fn, expect_archives",
+    (
+        (["qtbase"], [], True, qt_5140_xml_weird_module, make_qt_archives, {"qtbase-mingw.7z"}),
+        # --archives should apply to debug_info and base, but not qtcharts module
+        (
+            ["qtbase"],
+            ["all"],
+            True,
+            qt_5140_xml_weird_module,
+            make_qt_archives,
+            {"qtbase-mingw.7z", "qtbase-debug_info.7z", "weird-qtcharts.7z"},
+        ),
+        # don't allow archives from debug_info
+        (
+            ["qtbase"],
+            ["qtcharts"],
+            True,
+            qt_5140_xml_weird_module,
+            make_qt_archives,
+            {"qtbase-mingw.7z", "weird-qtcharts.7z"},
+        ),
+        # don't include anything from base module
+        (["qtbase"], [], False, qt_5140_xml_weird_module, make_qt_archives, set()),
+        # --archives should apply to debug_info
+        (
+            ["qtbase"],
+            ["all"],
+            False,
+            qt_5140_xml_weird_module,
+            make_qt_archives,
+            {"qtbase-debug_info.7z", "weird-qtcharts.7z"},
+        ),
+        # don't allow archives from debug_info
+        (["qtbase"], ["qtcharts"], False, qt_5140_xml_weird_module, make_qt_archives, {"weird-qtcharts.7z"}),
+        (["tqtc"], [], True, qt_doc_5152_xml_weird_module, make_doc_archives, {"tqtc-docs.7z"}),
+        (
+            ["tqtc"],
+            ["all"],
+            True,
+            qt_doc_5152_xml_weird_module,
+            make_doc_archives,
+            {"tqtc-docs.7z", "weird-qtcharts-docs.7z"},
+        ),
+        (
+            ["tqtc"],
+            ["qtcharts"],
+            True,
+            qt_doc_5152_xml_weird_module,
+            make_doc_archives,
+            {"tqtc-docs.7z", "weird-qtcharts-docs.7z"},
+        ),
+        (["tqtc"], [], False, qt_doc_5152_xml_weird_module, make_doc_archives, set()),
+        (["tqtc"], ["all"], False, qt_doc_5152_xml_weird_module, make_doc_archives, {"weird-qtcharts-docs.7z"}),
+        (["tqtc"], ["qtcharts"], False, qt_doc_5152_xml_weird_module, make_doc_archives, {"weird-qtcharts-docs.7z"}),
+    ),
+)
+def test_archives_weird_module_7z_name(
+    monkeypatch,
+    subarchives: List[str],
+    modules: List[str],
+    is_include_base: bool,
+    xml: str,
+    make_archives_fn,
+    expect_archives: Set[str],
+):
+    monkeypatch.setattr("aqt.archives.getUrl", lambda *args: xml)
+
+    qt_archives = make_archives_fn(subarchives, modules, is_include_base)
+    archives = {pkg.archive for pkg in qt_archives.archives}
+    assert archives == expect_archives


### PR DESCRIPTION
This changes the behavior of `--archives` so that it will affect the base module and the debug_info module, but no other modules.

Without this change, the following commands would fail to install the requested modules, and would not generate error messages. This change would allow these command to install the requested modules without a problem.

```bash
aqt install-qt linux desktop 5.15.2 --modules qtcharts --archives qtbase           # did not specify archive `qtcharts`
aqt install-doc linux desktop 6.1.0 --modules qtlottie --archives qtdoc qtlottie   # wrong archive name for qtlottie
                                                                   # the correct archive name is `qtlottieanimation`
```

Fix #457