### PR TITLE
Bump dependency py7zr@0.17.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     requests
     semantic_version
     patch>=1.16
-    py7zr>=0.15.1
+    py7zr>=0.17.0
     texttable
     bs4
     dataclasses;python_version<"3.7"


### PR DESCRIPTION
- Resolve symbolic link error (#438)
- Resolve memory error on 32bit python (#436)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>