### PR TITLE
Reduce memory consumption on 32bit python

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -933,7 +933,7 @@ def run_installer(archives: List[QtPackage], base_dir: str, sevenzip: Optional[s
     for arc in archives:
         tasks.append((arc, base_dir, sevenzip, queue, archive_dest, keep))
     ctx = multiprocessing.get_context("spawn")
-    pool = ctx.Pool(Settings.concurrency, init_worker_sh)
+    pool = ctx.Pool(Settings.concurrency, init_worker_sh, maxtasksperchild=1)
 
     def close_worker_pool_on_exception(exception: BaseException):
         logger = getLogger("aqt.installer")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ ensure_newline_before_comments = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = check, docs, py{36,37,38,39,310}, py39d, mprof
+envlist = check, docs, py{36,37,38,39,310}, py39d, mprof, fil
 
 [testenv]
 passenv =
@@ -65,7 +65,7 @@ commands =
 basepython = python3.9d
 extras = test
 commands =
-    python -m pytest -v --no-cov -R : -k "test_install"
+    python3.9-dbg -m pytest -v --no-cov -R : -k "test_install"
 deps =
     pytest
     pytest-leaks
@@ -81,6 +81,13 @@ commands =
 deps =
     memory_profiler
     matplotlib
+
+[testenv:fil]
+basepython = python3.8
+commands =
+    fil-profile run -m aqt install-qt -O /tmp -d /tmp linux desktop 6.2.1
+deps =
+    filprofiler
 
 [testenv:coveralls]
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ deps =
 [testenv:mprof]
 basepython = python3.8
 commands =
-    mprof run --include-children python -m aqt install-qt -O /tmp -d /tmp linux desktop 6.2.1
+    mprof run --multiprocess python -m aqt install-qt -O /tmp -d /tmp linux desktop 6.2.1
     mprof plot --output memory-profile.png
 deps =
     memory_profiler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,9 @@ deps =
 
 [testenv:mprof]
 basepython = python3.8
-commands = mprof run python -m aqt install -O /tmp linux desktop 6.2.1
+commands =
+    mprof run --include-children python -m aqt install-qt -O /tmp -d /tmp linux desktop 6.2.1
+    mprof plot --output memory-profile.png
 deps =
     memory_profiler
     matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ ensure_newline_before_comments = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = check, docs, py{36,37,38,39,310}
+envlist = check, docs, py{36,37,38,39,310}, py39d
 
 [testenv]
 passenv =
@@ -60,6 +60,18 @@ extras = docs
 commands =
     sphinx-build {posargs:-E} -W -b html docs build/docs
     sphinx-build -W -b linkcheck docs build/docs
+
+[testenv:py39d]
+basepython = python3.9d
+extras = test
+commands =
+    python -m pytest -v --no-cov -R : -k "test_install"
+deps =
+    pytest
+    pytest-leaks
+    pytest-remotedata
+    pytest-socket
+    pytest-cov
 
 [testenv:coveralls]
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ ensure_newline_before_comments = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = check, docs, py{36,37,38,39,310}, py39d
+envlist = check, docs, py{36,37,38,39,310}, py39d, mprof
 
 [testenv]
 passenv =
@@ -72,6 +72,13 @@ deps =
     pytest-remotedata
     pytest-socket
     pytest-cov
+
+[testenv:mprof]
+basepython = python3.8
+commands = mprof run python -m aqt install -O /tmp linux desktop 6.2.1
+deps =
+    memory_profiler
+    matplotlib
 
 [testenv:coveralls]
 deps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ test =
     pytest-cov
     pytest-socket
     pytest-leaks
+    pympler
 check =
     flake8
     flake8-black

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ test =
     pytest-remotedata
     pytest-cov
     pytest-socket
+    pytest-leaks
 check =
     flake8
     flake8-black


### PR DESCRIPTION
by running `tox -e py39d`

```
================================ leaks summary =================================
tests/test_install.py::test_install[cmd0-linux-desktop-1.2.3-0-197001020304---linux_x64/desktop/tools_qtcreator/Updates.xml-archives0-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qt.tools.qtcreator...\\nFinished installation of tools_qtcreator-linux-qt.tools.qtcreator.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [42, 43, 44, 45], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd1-linux-desktop-1.2.3---linux_x64/desktop/tools_qtcreator/Updates.xml-archives1-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nWarning: The command 'tool' is deprecated and marked for removal in a future version of aqt.\\nIn the future, please use the command 'install-tool' instead.\\nDownloading qt.tools.qtcreator...\\nFinished installation of tools_qtcreator-linux-qt.tools.qtcreator.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [52, 53, 54, 55], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd2-windows-desktop-5.14.0-win32_mingw73-mingw73_32-windows_x86/desktop/qt5_5140/Updates.xml-archives2-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nWarning: The command 'install' is deprecated and marked for removal in a future version of aqt.\\nIn the future, please use the command 'install-qt' instead.\\nDownloading qtbase...\\nFinished installation of qtbase-windows-win32_mingw73.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [62, 63, 64, 65], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd3-windows-desktop-5.14.2---windows_x86/desktop/qt5_5142_src_doc_examples/Updates.xml-archives3-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nWarning: The parameter 'target' with value 'desktop' is deprecated and marked for removal in a future version of aqt\\.\\nIn the future, please omit this parameter\\.\\nDownloading qtbase\\.\\.\\.\\nFinished installation of qtbase-everywhere-src-5\\.14\\.2\\.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [72, 73, 74, 75], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd4-windows-desktop-5.14.2---windows_x86/desktop/qt5_5142_src_doc_examples/Updates.xml-archives4-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qtbase\\.\\.\\.\\nFinished installation of qtbase-everywhere-src-5\\.14\\.2\\.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [82, 83, 84, 85], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd5-windows-desktop-5.9.0-win32_mingw53-mingw53_32-windows_x86/desktop/qt5_59/Updates.xml-archives5-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nWarning: The command 'install' is deprecated and marked for removal in a future version of aqt.\\nIn the future, please use the command 'install-qt' instead.\\nDownloading qtbase...\\nFinished installation of qtbase-windows-win32_mingw53.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [92, 93, 94, 95], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd6-windows-desktop-5.9.0-win32_mingw53-mingw53_32-windows_x86/desktop/qt5_59/Updates.xml-archives6-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qtbase...\\nFinished installation of qtbase-windows-win32_mingw53.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [102, 103, 104, 105], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd7-windows-desktop-5.14.0-win32_mingw73-mingw73_32-windows_x86/desktop/qt5_5140/Updates.xml-archives7-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qtbase...\\nFinished installation of qtbase-windows-win32_mingw73.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [112, 113, 114, 115], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd8-windows-desktop-5.14.0-win64_mingw73-mingw73_64-windows_x86/desktop/qt5_5140/Updates.xml-archives8-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qtbase...\\nFinished installation of qtbase-windows-win64_mingw73.7z in .*\\nDownloading qtcharts...\\nFinished installation of qtcharts-windows-win64_mingw73.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [122, 123, 124, 125], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd9-windows-desktop-6.2.0-win64_mingw73-mingw73_64-windows_x86/desktop/qt6_620/Updates.xml-archives9-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qtlocation...\\nFinished installation of qtlocation-windows-win64_mingw73.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [132, 133, 134, 135], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd10-windows-desktop-6.1.0-win64_mingw81-mingw81_64-windows_x86/desktop/qt6_610/Updates.xml-archives10-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qtbase...\\nFinished installation of qtbase-windows-win64_mingw81.7z in .*\\nDownloading qtcharts...\\nFinished installation of qtcharts-windows-win64_mingw81.7z in .*\\nFinished installation\\nTime elapsed: .* second]: leaked references: [142, 143, 144, 145], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install[cmd11-windows-android-6.1.0-android_armv7-android_armv7-windows_x86/android/qt6_610_armv7/Updates.xml-archives11-^aqtinstall\\(aqt\\) v.* on Python 3.*\\nDownloading qtbase...\\nFinished installation of qtbase-windows-android_armv7.7z in .*\\nPatching .*/bin/qmake.bat\\nFinished installation\\nTime elapsed: .* second]: leaked references: [152, 153, 154, 155], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-qt windows desktop 5.16.0 win32_mingw73-None-Specified Qt version is unknown: 5.16.0.\nFailed to locate XML data for Qt version '5.16.0'.\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-qt windows desktop' to show versions available.\n]: leaked references: [162, 163, 164, 165], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-qt windows desktop 5.15.0 bad_arch-windows-5150-update.xml-Specified target combination is not valid or unknown: windows desktop bad_arch\nThe packages ['qt_base'] were not found while parsing XML of package information!\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-qt windows desktop --arch 5.15.0' to show architectures available.\n]: leaked references: [172, 173, 174, 175], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-qt windows desktop 5.15.0 win32_mingw73 -m nonexistent foo-windows-5150-update.xml-Some of specified modules are unknown.\nThe packages ['foo', 'nonexistent', 'qt_base'] were not found while parsing XML of package information!\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-qt windows desktop --arch 5.15.0' to show architectures available.\n* Please use 'aqt list-qt windows desktop --modules 5.15.0 <arch>' to show modules available.\n]: leaked references: [182, 183, 184, 185], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-doc windows desktop 5.15.0 -m nonexistent foo-windows-5152-src-doc-example-update.xml-Warning: The parameter 'target' with value 'desktop' is deprecated and marked for removal in a future version of aqt.\nIn the future, please omit this parameter.\nThe packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-doc windows 5.15.0 --modules' to show modules available.\n]: leaked references: [192, 193, 194, 195], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-doc windows 5.15.0 -m nonexistent foo-windows-5152-src-doc-example-update.xml-The packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-doc windows 5.15.0 --modules' to show modules available.\n]: leaked references: [202, 203, 204, 205], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-example windows 5.15.0 -m nonexistent foo-windows-5152-src-doc-example-update.xml-The packages ['examples', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-example windows 5.15.0 --modules' to show modules available.\n]: leaked references: [212, 213, 214, 215], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-tool windows desktop tools_vcredist nonexistent-windows-desktop-tools_vcredist-update.xml-Specified target combination is not valid: windows tools_vcredist nonexistent\nThe package 'nonexistent' was not found while parsing XML of package information!\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-tool windows desktop tools_vcredist' to show tool variants available.\n]: leaked references: [222, 223, 224, 225], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-tool windows desktop tools_nonexistent nonexistent-None-Specified target combination is not valid: windows tools_nonexistent nonexistent\nFailed to locate XML data for the tool 'tools_nonexistent'.\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-tool windows desktop' to show tools available.\n]: leaked references: [232, 233, 234, 235], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_nonexistent_archives[install-tool windows desktop tools_nonexistent-None-Failed to locate XML data for the tool 'tools_nonexistent'.\n==============================Suggested follow-up:==============================\n* Please use 'aqt list-tool windows desktop' to check what tools are available.\n]: leaked references: [242, 243, 244, 245], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_pool_exception[RuntimeError()-../aqt/settings.ini-===========================PLEASE FILE A BUG REPORT===========================\nYou have discovered a bug in aqt.\nPlease file a bug report at https://github.com/miurahr/aqtinstall/issues.\nPlease remember to include a copy of this program's output in your report.-254]: leaked references: [252, 253, 254, 255], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_pool_exception[KeyboardInterrupt()-../aqt/settings.ini-Caught KeyboardInterrupt, terminating installer workers\nInstaller halted by keyboard interrupt.-1]: leaked references: [262, 263, 264, 265], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_pool_exception[MemoryError()-../aqt/settings.ini-Caught MemoryError, terminating installer workers\nOut of memory when downloading and extracting archives in parallel.\n==============================Suggested follow-up:==============================\n* Please reduce your 'concurrency' setting (see https://aqtinstall.readthedocs.io/en/stable/configuration.html#configuration)\n* Please try using the '--external' flag to specify an alternate 7z extraction tool (see https://aqtinstall.readthedocs.io/en/latest/cli.html#cmdoption-list-tool-external)-1]: leaked references: [272, 273, 274, 275], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_pool_exception[MemoryError()-data/settings_no_concurrency.ini-Caught MemoryError, terminating installer workers\nOut of memory when downloading and extracting archives.\n==============================Suggested follow-up:==============================\n* Please free up more memory.\n* Please try using the '--external' flag to specify an alternate 7z extraction tool (see https://aqtinstall.readthedocs.io/en/latest/cli.html#cmdoption-list-tool-external)-1]: leaked references: [282, 283, 284, 285], memory blocks: [16, 16, 16, 16]
tests/test_install.py::test_install_installer_archive_extraction_err: leaked references: [292, 293, 294, 295], memory blocks: [16, 16, 16, 16]
===================== 253 deselected, 26 leaked in 59.25s ======================
```

got leaks.


Signed-off-by: Hiroshi Miura <miurahr@linux.com>