### PR TITLE
Cache PowerShell Modules in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,10 @@ jobs:
     vmImage: 'windows-2019'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.windows'] ]
+  variables:
+    MODULES_FOLDER: '$(System.DefaultWorkingDirectory)\CachedPowershellModules'
+    startYear: $[format('{0:yyyy}', pipeline.startTime)]
+    startMonth: $[format('{0:MM}', pipeline.startTime)]
   steps:
     - template: ci/steps.yml
 

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -179,9 +179,6 @@ steps:
   - task: Cache@2
     inputs:
       key: '"pwsh modules" | "$(startYear)" | "$(startMonth)"'
-      restorekeys: |
-        "pwsh modules" | "$(startYear)"
-        "pwsh modules"
       path: $(MODULES_FOLDER)
       cacheHitVar: PSModules_IsCached
     condition: |

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -175,13 +175,35 @@ steps:
     displayName: Build accelbubble example application to test for android
 
   ##----------------------------------------------------
-  # determine Windows build system
+  # Cache Powershell Modules in $MODULES_FOLDER
+  - task: Cache@2
+    inputs:
+      key: '"pwsh modules" | "$(startYear)" | "$(startMonth)"'
+      restorekeys: |
+        "pwsh modules" | "$(startYear)"
+        "pwsh modules"
+      path: $(MODULES_FOLDER)
+      cacheHitVar: PSModules_IsCached
+    condition: |
+        and(eq(variables['Agent.OS'], 'Windows_NT'), 
+            eq(variables['SUBCOMMAND'], 'install-qt'))
+    displayName: Cache Powershell Modules
+  # On cache miss: Download Powershell Modules to $MODULES_FOLDER
   - powershell: |
       Install-PackageProvider NuGet -Force
       Import-PackageProvider NuGet -Force
       Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-      Install-Module Pscx -AllowClobber -AllowPrerelease
-      Install-Module VSSetup -Scope CurrentUser
+      md -p $(MODULES_FOLDER)   # mkdir
+      Save-Module -Name Pscx -AllowPrerelease -Path $(MODULES_FOLDER)
+    condition: |
+        and(eq(variables['Agent.OS'], 'Windows_NT'), 
+            eq(variables['SUBCOMMAND'], 'install-qt'),
+            ne(variables.PSModules_IsCached, 'true'))
+    displayName: Download Powershell Modules for Windows on cache miss
+
+  ##----------------------------------------------------
+  # determine Windows build system
+  - powershell: |
       if ('$(ARCH)' -like '*msvc*') {
         Write-Host '##vso[task.setvariable variable=TOOLCHAIN]MSVC'
       }
@@ -202,7 +224,9 @@ steps:
       }
       cd $(WIN_QT_BINDIR)
       unzip $(Build.SourcesDirectory)\ci\jom_1_1_3.zip
-    condition: and(eq( variables['Agent.OS'], 'Windows_NT'), eq(variables['SUBCOMMAND'], 'install-qt'))
+    condition: |
+        and(eq(variables['Agent.OS'], 'Windows_NT'), 
+            eq(variables['SUBCOMMAND'], 'install-qt'))
     displayName: Detect toolchain for Windows and update PATH
 
   # When no modules
@@ -217,6 +241,12 @@ steps:
     displayName: Build test with qmake for Linux and macOS w/o extra module
   - powershell: |
       if ( $env:TOOLCHAIN -eq 'MSVC' ) {
+        # Load modules from cache  
+        $Env:PSModulePath = '$(MODULES_FOLDER)', $Env:PSModulePath -join [System.IO.Path]::PathSeparator
+        Write-Host $Env:PSModulePath
+        Import-Module "Pscx"
+        Import-Module "VSSetup"
+
         Import-VisualStudioVars -VisualStudioVersion $(VSVER) -Architecture $(ARCHITECTURE)
         $env:Path += ";$(WIN_QT_BINDIR)"
         mkdir $(Build.BinariesDirectory)\tests
@@ -244,6 +274,12 @@ steps:
     condition: and(eq( variables['Agent.OS'], 'Windows_NT'), eq(variables['MODULE'], ''), eq(variables['SUBCOMMAND'], 'install-qt'))
     displayName: build test with qmake w/o extra module
   - powershell: |
+      # Load modules from cache  
+      $Env:PSModulePath = '$(MODULES_FOLDER)', $Env:PSModulePath -join [System.IO.Path]::PathSeparator
+      Write-Host $Env:PSModulePath
+      Import-Module "Pscx"
+      Import-Module "VSSetup"
+
       Import-VisualStudioVars -VisualStudioVersion $(VSVER) -Architecture $(ARCHITECTURE)
       $env:Path += ";$(WIN_QT_BINDIR)"
       echo Add Qt to PATH: $env:PATH


### PR DESCRIPTION
There are frequent failures in Azure Pipelines builds for Windows, caused by failures to retrieve the the Powershell modules 'Pscx' and 'VSSetup' from the PowerShell Gallery. This PR is intended to cache the Powershell modules required by the Azure pipelines, so that these failures stop occurring. As a side effect, it will also speed up all Windows build jobs by however long it takes to download the powershell modules (expect 1-2 minutes).

Examples of failures:
https://dev.azure.com/miurahr/github/_build/results?buildId=4817&view=logs&j=9f3e9a58-f4d0-59eb-bb9a-f7c4195515fd&t=d65f8022-fa96-505b-389b-6aa2d54135b0&l=27 (from #459)
https://dev.azure.com/miurahr/github/_build/results?buildId=4831&view=logs&j=dcd50a69-7bd8-59f7-72b1-a119e6ffb32f&t=b0305de3-bc12-557b-67f0-1215b8f079d0&l=28 (from #464)

Citation: https://blog.simonw.se/caching-powershell-modules-in-azure-pipelines/