### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. install `aqt` using this command
+2. run `aqt` with this command
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**`aqt` output**
+Add program output to help explain your problem.
+
+```
+paste program output here
+```
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. windows]
+ - Python version and build info [paste the output from the command `python -VV`]
+ - `aqt` version [paste the output from the command `aqt --version` or `python -m aqt --version`]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
We have had several bug reports come up in the issues section recently that:
- gave little or no context to the problem being reported,
- requested new features, but made the request sound like a bug report, or
- have nothing to do with `aqt`

I think that by adding some issue templates, we can ask our users to put a little more thought into the issues they post. I expect that this will make the issues section more informative and easier to read.