### PR TITLE
Add 32 bit binary to release

### DIFF
--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [windows-latest]
         py: [3.9]
+        arch: [x86, x64]
     steps:
       - uses: actions/checkout@v1
         with:
@@ -26,16 +27,27 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.py }}
+          architecture: ${{ matrix.arch }}
 
       - name: Build standalone binary
         run: |
           ci/build_standalone.bat
+          cp .gravitybee\dist\latest\aqt.exe .gravitybee\dist\latest\aqt_${{ matrix.arch }}.exe
 
       - name: Upload to Release
         uses: svenstaro/upload-release-action@v2
         with: 
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: .gravitybee\dist\latest\aqt.exe
+          tag: ${{ github.ref }}
+          overwrite: true
+        if: matrix.arch=='x64'
+
+      - name: Upload to Release for all architectures
+        uses: svenstaro/upload-release-action@v2
+        with: 
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: .gravitybee\dist\latest\aqt_${{ matrix.arch }}.exe
           tag: ${{ github.ref }}
           overwrite: true
           
@@ -47,3 +59,13 @@ jobs:
           prerelease: true
           tag: Continuous
           file: .gravitybee\dist\latest\aqt.exe
+        if: matrix.arch=='x64'
+          
+      - name: Update continuous build for all architectures
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true
+          prerelease: true
+          tag: Continuous
+          file: .gravitybee\dist\latest\aqt_${{ matrix.arch }}.exe


### PR DESCRIPTION
Here is a proposition to release a 32 bit binary (there are still computers of less than 5 years old limited to 32 bit Windows, e.g. Intel Compute Stick, ZOTAC Pico, ASUS Transformer). This would probably simplify also the installation of this [Chocolatey package](https://community.chocolatey.org/packages/qt5-default) by removing the Python dependency.
Separate binaries `aqt_x64.exe` and `aqt_x86.exe` are generated, see https://github.com/lebarsfa/aqtinstall/releases. I do not know if the continuous release `aqt.exe` should be in 64 or 32, at the moment it is left to 64 in that code.
