### PR TITLE
Update fallback mirror list

### DIFF
--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -23,21 +23,20 @@ blacklist:
     http://mirrors.geekpie.club
 fallbacks:
     https://qtproject.mirror.liquidtelecom.com/
+    https://mirrors.aliyun.com/qt/
     https://mirrors.sjtug.sjtu.edu.cn/qt/
     https://mirrors.ustc.edu.cn/qtproject/
     https://ftp.jaist.ac.jp/pub/qtproject/
     https://ftp.yz.yamagata-u.ac.jp/pub/qtproject/
     https://qt-mirror.dannhauer.de/
     https://ftp.fau.de/qtproject/
+    https://mirror.netcologne.de/qtproject/
     https://mirrors.dotsrc.org/qtproject/
     https://www.nic.funet.fi/pub/mirrors/download.qt-project.org/
     https://master.qt.io/
     https://mirrors.ukfast.co.uk/sites/qt.io/
-    https://www.mirrorservice.org/sites/download.qt-project.org/
     https://ftp2.nluug.nl/languages/qt/
     https://ftp1.nluug.nl/languages/qt/
-    https://ftp.acc.umu.se/mirror/qt.io/qtproject/
-    https://mirror.csclub.uwaterloo.ca/qtproject/
     https://qt.mirror.constant.com/
 
 [kde_patches]


### PR DESCRIPTION
Some of the currently listed mirrors are no longer part of the official mirror list by qt.io, some return 404, some don't fully mirror the tree (especially `online/`).

The updated list has been generated via the following one-liner:
```bash
for mirror in $(curl -s https://download.qt.io/static/mirrorlist/ | grep -oP 'href="\K(http.*)(?=">HTTP</a>)' | sed -re 's|^http:|https:|; s|([^/])$|\1/|'); do code=$(curl -I "${mirror}online/qtsdkrepository/windows_x86/desktop/qt6_623/qt.qt6.623.win64_msvc2019_64/6.2.3-0-202201260729qtbase-Windows-Windows_10_21H2-MSVC2019-Windows-Windows_10_21H2-X86_64.7z" --write-out '%{response_code}' --silent -o /dev/null); [[ $code == 200 ]] && echo "    ${mirror}"; done
```