### PR TITLE
[Security] Use SHA-256 checksums from trusted mirrors only

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -48,7 +48,6 @@ class QtPackage:
     archive_url: str
     archive: str
     package_desc: str
-    hashurl: str
     pkg_update_name: str
     version: Optional[Version] = field(default=None)
 
@@ -61,7 +60,7 @@ class QtPackage:
         return (
             f"QtPackage(name={self.name}, url={self.archive_url}, "
             f"archive={self.archive}, desc={self.package_desc}"
-            f"hashurl={self.hashurl}{v_info})"
+            f"{v_info})"
         )
 
 
@@ -278,14 +277,12 @@ class QtArchives:
                     # 5.15.0-0-202005140804qtbase-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z
                     full_version + archive,
                 )
-                hashurl = package_url + ".sha1"
                 self.archives.append(
                     QtPackage(
                         name=archive_name,
                         archive_url=package_url,
                         archive=archive,
                         package_desc=package_desc,
-                        hashurl=hashurl,
                         pkg_update_name=pkg_name,  # For testing purposes
                     )
                 )
@@ -480,14 +477,12 @@ class ToolArchives(QtArchives):
                 #  4.1.1-202105261130ifw-linux-x64.7z
                 f"{named_version}{archive}",
             )
-            hashurl = package_url + ".sha1"
             self.archives.append(
                 QtPackage(
                     name=name,
                     archive_url=package_url,
                     archive=archive,
                     package_desc=package_desc,
-                    hashurl=hashurl,
                     pkg_update_name=name,  # Redundant
                 )
             )

--- a/aqt/exceptions.py
+++ b/aqt/exceptions.py
@@ -47,6 +47,10 @@ class ArchiveChecksumError(ArchiveDownloadError):
     pass
 
 
+class ChecksumDownloadFailure(ArchiveDownloadError):
+    pass
+
+
 class ArchiveConnectionError(AqtException):
     pass
 

--- a/aqt/exceptions.py
+++ b/aqt/exceptions.py
@@ -20,6 +20,8 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from typing import Iterable
 
+DOCS_CONFIG = "https://aqtinstall.readthedocs.io/en/stable/configuration.html#configuration"
+
 
 class AqtException(Exception):
     def __init__(self, *args, **kwargs):
@@ -48,7 +50,16 @@ class ArchiveChecksumError(ArchiveDownloadError):
 
 
 class ChecksumDownloadFailure(ArchiveDownloadError):
-    pass
+    def __init__(self, *args, **kwargs):
+        kwargs["suggested_action"] = kwargs.pop("suggested_action", []).extend(
+            [
+                "Check your internet connection",
+                "Consider modifying `requests.max_retries_to_retrieve_hash` in settings.ini",
+                f"Consider modifying `mirrors.trusted_mirrors` in settings.ini (see {DOCS_CONFIG})",
+            ]
+        )
+        kwargs["should_show_help"] = True
+        super(ChecksumDownloadFailure, self).__init__(*args, **kwargs)
 
 
 class ArchiveConnectionError(AqtException):

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -362,8 +362,16 @@ class SettingsClass:
         return self.config.getint("requests", "max_retries_on_checksum_error", fallback=int(self.max_retries))
 
     @property
+    def max_retries_to_retrieve_hash(self):
+        return self.config.getint("requests", "max_retries_to_retrieve_hash", fallback=int(self.max_retries))
+
+    @property
     def backoff_factor(self):
         return self.config.getfloat("requests", "retry_backoff", fallback=0.1)
+
+    @property
+    def trusted_mirrors(self):
+        return self.config.getlist("mirrors", "trusted_mirrors", fallback=[self.baseurl])
 
     @property
     def fallbacks(self):

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -283,7 +283,9 @@ def xml_to_modules(
 
 class MyConfigParser(configparser.ConfigParser):
     def getlist(self, section: str, option: str, fallback=[]) -> List[str]:
-        value = self.get(section, option)
+        value = self.get(section, option, fallback=None)
+        if value is None:
+            return fallback
         try:
             result = list(filter(None, (x.strip() for x in value.splitlines())))
         except Exception:

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -25,7 +25,7 @@ import json
 import logging.config
 import os
 import posixpath
-import random
+import secrets
 import sys
 import xml.etree.ElementTree as ElementTree
 from logging import getLogger
@@ -144,7 +144,7 @@ def retry_on_errors(action: Callable[[], any], acceptable_errors: Tuple, num_ret
 
 def retry_on_bad_connection(function: Callable[[str], any], base_url: str):
     logger = getLogger("aqt.helper")
-    fallback_url = random.choice(Settings.fallbacks)
+    fallback_url = secrets.choice(Settings.fallbacks)
     try:
         return function(base_url)
     except ArchiveConnectionError:

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -51,7 +51,7 @@ from aqt.exceptions import (
     CliKeyboardInterrupt,
     OutOfMemory,
 )
-from aqt.helper import MyQueueListener, Settings, downloadBinaryFile, getUrl, retry_on_errors, setup_logging
+from aqt.helper import MyQueueListener, Settings, downloadBinaryFile, get_hash, retry_on_errors, setup_logging
 from aqt.metadata import ArchiveId, MetadataFactory, QtRepoProperty, SimpleSpec, Version, show_list, suggested_follow_up
 from aqt.updater import Updater
 
@@ -1002,7 +1002,6 @@ def installer(
     """
     name = qt_archive.name
     url = qt_archive.archive_url
-    hashurl = qt_archive.hashurl
     archive: Path = archive_dest / qt_archive.archive
     start_time = time.perf_counter()
     # set defaults
@@ -1021,9 +1020,9 @@ def installer(
         timeout = (Settings.connection_timeout, Settings.response_timeout)
     else:
         timeout = (Settings.connection_timeout, response_timeout)
-    hash = binascii.unhexlify(getUrl(hashurl, timeout))
+    hash = binascii.unhexlify(get_hash(url, algorithm="sha256", timeout=timeout))
     retry_on_errors(
-        action=lambda: downloadBinaryFile(url, archive, "sha1", hash, timeout),
+        action=lambda: downloadBinaryFile(url, archive, "sha256", hash, timeout),
         acceptable_errors=(ArchiveChecksumError,),
         num_retries=Settings.max_retries_on_checksum_error,
         name=f"Downloading {name}",

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -452,7 +452,7 @@ class MetadataFactory:
 
     def fetch_extensions(self, version: Version) -> List[str]:
         versions_extensions = MetadataFactory.get_versions_extensions(
-            self.fetch_http(self.archive_id.to_url()), self.archive_id.category
+            self.fetch_http(self.archive_id.to_url(), False), self.archive_id.category
         )
         filtered = filter(
             lambda ver_ext: ver_ext[0] == version and ver_ext[1],
@@ -469,7 +469,7 @@ class MetadataFactory:
             return ver_ext[0]
 
         versions_extensions = MetadataFactory.get_versions_extensions(
-            self.fetch_http(self.archive_id.to_url()), self.archive_id.category
+            self.fetch_http(self.archive_id.to_url(), False), self.archive_id.category
         )
         versions = sorted(filter(None, map(get_version, filter(filter_by, versions_extensions))))
         iterables = itertools.groupby(versions, lambda version: version.minor)
@@ -479,7 +479,7 @@ class MetadataFactory:
         return self.fetch_versions().latest()
 
     def fetch_tools(self) -> List[str]:
-        html_doc = self.fetch_http(self.archive_id.to_url())
+        html_doc = self.fetch_http(self.archive_id.to_url(), False)
         return list(MetadataFactory.iterate_folders(html_doc, "tools"))
 
     def fetch_tool_modules(self, tool_name: str) -> List[str]:
@@ -572,9 +572,9 @@ class MetadataFactory:
         return version
 
     @staticmethod
-    def fetch_http(rest_of_url: str) -> str:
+    def fetch_http(rest_of_url: str, is_check_hash: bool = True) -> str:
         timeout = (Settings.connection_timeout, Settings.response_timeout)
-        expected_hash = binascii.unhexlify(get_hash(rest_of_url, "sha256", timeout))
+        expected_hash = binascii.unhexlify(get_hash(rest_of_url, "sha256", timeout)) if is_check_hash else None
         base_urls = Settings.baseurl, random.choice(Settings.fallbacks)
         for i, base_url in enumerate(base_urls):
             try:

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -15,8 +15,11 @@ response_timeout: 30
 max_retries_on_connection_error: 5
 retry_backoff: 0.1
 max_retries_on_checksum_error: 5
+max_retries_to_retrieve_hash: 5
 
 [mirrors]
+trusted_mirrors:
+    https://download.qt.io
 blacklist:
     http://mirrors.ocf.berkeley.edu
     http://mirrors.tuna.tsinghua.edu.cn

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -30,8 +30,11 @@ A file is like as follows:
     max_retries_on_connection_error: 5
     retry_backoff: 0.1
     max_retries_on_checksum_error: 5
+    max_retries_to_retrieve_hash: 5
 
     [mirrors]
+    trusted_mirrors:
+        https://download.qt.io
     blacklist:
         http://mirrors.ustc.edu.cn
         http://mirrors.tuna.tsinghua.edu.cn
@@ -129,6 +132,24 @@ max_retries_on_checksum_error:
 
 
 The ``[mirrors]`` section is a configuration for mirror handling.
+
+trusted_mirrors:
+    ``trusted_mirrors`` is a list of URLs that you trust to provide accurate
+    checksums for all downloaded archives.
+    This is a security feature; please do not change this value unless you know
+    what you're doing!
+
+    ``aqtinstall`` downloads all checksums from mirrors in this list.
+    These checksums are used to verify that every other file that ``aqtinstall``
+    downloads is, in fact, the correct file, and not a corrupt or malicious copy
+    of the file.
+    You may need to modify this list if the default mirrors are unreachable,
+    or if you do not trust that they have not been compromised.
+
+    ``aqtinstall`` can safely download archive files from the fallback mirror
+    list, and ensure that they are not malicious files, by checking them against
+    the checksums downloaded from the ``trusted_mirrors`` list.
+    ``aqtinstall`` uses the SHA-256 algorithm to perform this check.
 
 blacklist:
     It is a list of URL where is a problematic mirror site.

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -447,6 +447,7 @@ def test_archives_weird_module_7z_name(
     expect_archives: Set[str],
 ):
     monkeypatch.setattr("aqt.archives.getUrl", lambda *args: xml)
+    monkeypatch.setattr("aqt.archives.get_hash", lambda *args, **kwargs: hashlib.sha256(bytes(xml, "utf-8")).hexdigest())
 
     qt_archives = make_archives_fn(subarchives, modules, is_include_base)
     archives = {pkg.archive for pkg in qt_archives.archives}

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -139,7 +139,6 @@ def test_qt_archives_modules(monkeypatch, arch, requested_module_names, has_none
             assert url_match
             mod_name, archive_name = url_match.groups()
             assert pkg.archive == archive_name
-            assert pkg.hashurl == pkg.archive_url + ".sha1"
             assert archive_name in expected_7z_files
             expected_7z_files.remove(archive_name)
         assert len(expected_7z_files) == 0, "Actual number of packages was fewer than expected"
@@ -227,7 +226,6 @@ def test_tools_variants(monkeypatch, tool_name, tool_variant_name, is_expect_fai
         actual_variant_name, archive_name = url_match.groups()
         assert actual_variant_name == tool_variant_name
         assert pkg.archive == archive_name
-        assert pkg.hashurl == pkg.archive_url + ".sha1"
         assert archive_name in expected_7z_files
         expected_7z_files.remove(archive_name)
     assert len(expected_7z_files) == 0, f"Failed to produce QtPackages for {expected_7z_files}"

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import re
@@ -73,7 +74,10 @@ def corrupt_xmlfile():
     ),
 )
 def test_qtarchive_parse_corrupt_xmlfile(monkeypatch, corrupt_xmlfile, archives_class, init_args):
-    monkeypatch.setattr("aqt.archives.getUrl", lambda self, url: corrupt_xmlfile)
+    monkeypatch.setattr("aqt.archives.getUrl", lambda *args, **kwargs: corrupt_xmlfile)
+    monkeypatch.setattr(
+        "aqt.archives.get_hash", lambda *args, **kwargs: hashlib.sha256(bytes(corrupt_xmlfile, "utf-8")).hexdigest()
+    )
 
     with pytest.raises(ArchiveListError) as error:
         archives_class(*init_args)

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -1,6 +1,5 @@
 import json
 import os
-import posixpath
 import re
 from itertools import groupby
 from pathlib import Path
@@ -50,8 +49,8 @@ def test_parse_update_xml(monkeypatch, os_name, version, arch, datafile):
     assert qt_archives_all_modules.archives is not None
 
     # Extract all urls
-    url_list = [item.archive_url for item in qt_archives.archives]
-    url_all_modules_list = [item.archive_url for item in qt_archives_all_modules.archives]
+    url_list = [item.archive_path for item in qt_archives.archives]
+    url_all_modules_list = [item.archive_path for item in qt_archives_all_modules.archives]
 
     # Check the difference list contains only extra modules urls for target specified
     list_diff = [item for item in url_all_modules_list if item not in url_list]
@@ -124,7 +123,7 @@ def test_qt_archives_modules(monkeypatch, arch, requested_module_names, has_none
         # https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5140/
         # qt.qt5.5140.qtcharts.win32_mingw73/5.14.0-0-202108190846qtcharts-windows-win32_mingw73.7z
 
-        url_begin = posixpath.join(base, "online/qtsdkrepository/windows_x86/desktop/qt5_5140")
+        url_begin = "online/qtsdkrepository/windows_x86/desktop/qt5_5140"
         expected_archive_url_pattern = re.compile(
             r"^" + re.escape(url_begin) + "/(" + expect["Name"] + ")/" + re.escape(expect["Version"]) + r"(.+\.7z)$"
         )
@@ -135,7 +134,7 @@ def test_qt_archives_modules(monkeypatch, arch, requested_module_names, has_none
                 assert not pkg.package_desc
             else:
                 assert pkg.package_desc == expect["Description"]
-            url_match = expected_archive_url_pattern.match(pkg.archive_url)
+            url_match = expected_archive_url_pattern.match(pkg.archive_path)
             assert url_match
             mod_name, archive_name = url_match.groups()
             assert pkg.archive == archive_name
@@ -211,7 +210,7 @@ def test_tools_variants(monkeypatch, tool_name, tool_variant_name, is_expect_fai
     expect = next(filter(lambda x: x["Name"] == tool_variant_name, expect_json["variants_metadata"]))
     expected_7z_files = set(expect["DownloadableArchives"])
     qt_pkgs = ToolArchives(host, target, tool_name, base, arch=tool_variant_name).archives
-    url_begin = posixpath.join(base, f"online/qtsdkrepository/mac_x64/{target}/{tool_name}")
+    url_begin = f"online/qtsdkrepository/mac_x64/{target}/{tool_name}"
     expected_archive_url_pattern = re.compile(
         r"^" + re.escape(url_begin) + "/(" + expect["Name"] + ")/" + re.escape(expect["Version"]) + r"(.+\.7z)$"
     )
@@ -221,7 +220,7 @@ def test_tools_variants(monkeypatch, tool_name, tool_variant_name, is_expect_fai
             assert not pkg.package_desc
         else:
             assert pkg.package_desc == expect["Description"]
-        url_match = expected_archive_url_pattern.match(pkg.archive_url)
+        url_match = expected_archive_url_pattern.match(pkg.archive_path)
         assert url_match
         actual_variant_name, archive_name = url_match.groups()
         assert actual_variant_name == tool_variant_name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,7 +96,7 @@ def test_cli_determine_qt_version(
     monkeypatch, host, target, arch, version_or_spec: str, expected_version: Version, is_bad_spec: bool
 ):
     _html = (Path(__file__).parent / "data" / f"{host}-{target}.html").read_text("utf-8")
-    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _html)
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda *args, **kwargs: _html)
     cli = Cli()
     cli._setup_settings()
 

--- a/tests/test_doc_archives.py
+++ b/tests/test_doc_archives.py
@@ -41,8 +41,8 @@ def test_parse_update_xml(monkeypatch, os_name, version, flavor, datafile):
     assert qt_archives_all_modules.archives is not None
 
     # Extract all urls
-    url_list = [item.archive_url for item in qt_archives.archives]
-    url_all_modules_list = [item.archive_url for item in qt_archives_all_modules.archives]
+    url_list = [item.archive_path for item in qt_archives.archives]
+    url_all_modules_list = [item.archive_path for item in qt_archives_all_modules.archives]
 
     # Check the difference list contains only extra modules urls for target specified
     list_diff = [item for item in url_all_modules_list if item not in url_list]

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -14,6 +14,13 @@ from aqt.helper import Settings, get_hash, getUrl, retry_on_errors
 from aqt.metadata import Version
 
 
+@pytest.fixture(autouse=True)
+def load_default_settings(use_defaults: bool = True):
+    """For each test, first load the default settings file, unless marked otherwise"""
+    if use_defaults:
+        helper.Settings.load_settings()
+
+
 def test_helper_altlink(monkeypatch):
     class Message:
         headers = {"content-type": "text/plain", "length": 300}
@@ -56,6 +63,7 @@ def test_helper_altlink(monkeypatch):
     assert newurl.startswith("http://ftp.jaist.ac.jp/")
 
 
+@pytest.mark.load_default_settings(False)
 def test_settings(tmp_path):
     helper.Settings.load_settings(os.path.join(os.path.dirname(__file__), "data", "settings.ini"))
     assert helper.Settings.concurrency == 3

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -331,3 +331,12 @@ def test_helper_getUrl_conn_error(monkeypatch):
         getUrl(url, timeout)
     assert e.type == ArchiveConnectionError
     assert expect_re.match(format(e.value))
+
+
+def test_helper_getUrl_checksum_error(monkeypatch):
+    mocked_get, mocked_session_get = mock_get_redirect(0)
+    monkeypatch.setattr(requests, "get", mocked_get)
+    monkeypatch.setattr(requests.Session, "get", mocked_session_get)
+    with pytest.raises(ArchiveChecksumError) as e:
+        getUrl("some_url", timeout=(5, 5), expected_hash=b"AAAAAAAAAAA")
+    assert e.type == ArchiveChecksumError

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -9,8 +9,8 @@ import requests
 from requests.models import Response
 
 from aqt import helper
-from aqt.exceptions import ArchiveChecksumError, ArchiveConnectionError, ArchiveDownloadError
-from aqt.helper import getUrl, retry_on_errors
+from aqt.exceptions import ArchiveChecksumError, ArchiveConnectionError, ArchiveDownloadError, ChecksumDownloadFailure
+from aqt.helper import Settings, get_hash, getUrl, retry_on_errors
 from aqt.metadata import Version
 
 
@@ -181,6 +181,41 @@ def test_helper_retry_on_error(num_attempts_before_success, num_retries_allowed)
         assert e.type == RuntimeError
     else:
         assert retry_on_errors(action, (RuntimeError,), num_retries_allowed, "do something")
+
+
+@pytest.mark.parametrize(
+    "num_tries_required, num_retries_allowed",
+    (
+        (2, 5),
+        (5, 5),
+        (6, 5),
+    ),
+)
+def test_helper_get_hash_retries(monkeypatch, num_tries_required, num_retries_allowed):
+    num_tries = 0
+
+    def mock_getUrl(url, *args, **kwargs):
+        nonlocal num_tries
+        num_tries += 1
+        if num_tries < num_tries_required:
+            raise ArchiveConnectionError(f"Must retry {num_tries_required - num_tries} more times before success")
+        parsed = urlparse(url)
+        base = f"{parsed.scheme}://{parsed.netloc}"
+        assert base in Settings.trusted_mirrors
+
+        hash_filename = str(parsed.path.split("/")[-1])
+        assert hash_filename == "archive.7z.sha256"
+        return "MOCK_HASH archive.7z"
+
+    monkeypatch.setattr("aqt.helper.getUrl", mock_getUrl)
+
+    if num_tries_required > num_retries_allowed:
+        with pytest.raises(ChecksumDownloadFailure) as e:
+            result = get_hash("http://insecure.mirror.com/some/path/to/archive.7z", "sha256", (5, 5))
+        assert e.type == ChecksumDownloadFailure
+    else:
+        result = get_hash("http://insecure.mirror.com/some/path/to/archive.7z", "sha256", (5, 5))
+        assert result == "MOCK_HASH"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -137,7 +137,7 @@ def make_mock_geturl_download_archive(
     def mock_getUrl(url: str, *args) -> str:
         if url.endswith(updates_url):
             return "<Updates>\n{}\n</Updates>".format("\n".join([archive.xml_package_update() for archive in archives]))
-        elif url.endswith(".sha1"):
+        elif url.endswith(".sha256"):
             return ""  # Skip the checksum
         assert False
 
@@ -598,7 +598,7 @@ def test_install(
 
     mock_get_url, mock_download_archive = make_mock_geturl_download_archive(archives, arch, host, updates_url)
     monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)
-    monkeypatch.setattr("aqt.installer.getUrl", mock_get_url)
+    monkeypatch.setattr("aqt.helper.getUrl", mock_get_url)
     monkeypatch.setattr("aqt.installer.downloadBinaryFile", mock_download_archive)
 
     with TemporaryDirectory() as output_dir:
@@ -713,7 +713,7 @@ def test_install_nonexistent_archives(monkeypatch, capsys, cmd, xml_file: Option
         return (Path(__file__).parent / "data" / xml_file).read_text("utf-8")
 
     monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)
-    monkeypatch.setattr("aqt.installer.getUrl", mock_get_url)
+    monkeypatch.setattr("aqt.helper.getUrl", mock_get_url)
     monkeypatch.setattr("aqt.metadata.getUrl", mock_get_url)
 
     cli = Cli()
@@ -779,7 +779,7 @@ def test_install_pool_exception(monkeypatch, capsys, make_exception, settings_fi
     cmd = ["install-qt", host, target, ver, arch]
     mock_get_url, mock_download_archive = make_mock_geturl_download_archive(archives, arch, host, updates_url)
     monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)
-    monkeypatch.setattr("aqt.installer.getUrl", mock_get_url)
+    monkeypatch.setattr("aqt.helper.getUrl", mock_get_url)
     monkeypatch.setattr("aqt.installer.installer", mock_installer_func)
 
     Settings.load_settings(str(Path(__file__).parent / settings_file))
@@ -793,7 +793,7 @@ def test_install_installer_archive_extraction_err(monkeypatch):
     def mock_extractor_that_fails(*args, **kwargs):
         raise subprocess.CalledProcessError(returncode=1, cmd="some command", output="out", stderr="err")
 
-    monkeypatch.setattr("aqt.installer.getUrl", lambda *args: "")
+    monkeypatch.setattr("aqt.installer.get_hash", lambda *args, **kwargs: "")
     monkeypatch.setattr("aqt.installer.downloadBinaryFile", lambda *args: None)
     monkeypatch.setattr("aqt.installer.subprocess.run", mock_extractor_that_fails)
 
@@ -804,7 +804,6 @@ def test_install_installer_archive_extraction_err(monkeypatch):
                 "archive-url",
                 "archive",
                 "package_desc",
-                "hashurl",
                 "pkg_update_name",
             ),
             base_dir=temp_dir,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -799,9 +799,10 @@ def test_install_installer_archive_extraction_err(monkeypatch):
 
     with pytest.raises(ArchiveExtractionError) as err, TemporaryDirectory() as temp_dir:
         installer(
-            qt_archive=QtPackage(
+            qt_package=QtPackage(
                 "name",
-                "archive-url",
+                "base_url",
+                "archive_path",
                 "archive",
                 "package_desc",
                 "pkg_update_name",

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -132,7 +132,7 @@ def spec_regex():
 )
 def test_list_versions_tools(monkeypatch, spec_regex, os_name, target, in_file, expect_out_file):
     _html = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
-    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _html)
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda *args, **kwargs: _html)
 
     expected = json.loads((Path(__file__).parent / "data" / expect_out_file).read_text("utf-8"))
 
@@ -434,7 +434,7 @@ def test_list_qt_cli(
         expect_set = expect
     assert isinstance(expect_set, set)
 
-    def _mock_fetch_http(_, rest_of_url: str) -> str:
+    def _mock_fetch_http(_, rest_of_url, *args, **kwargs: str) -> str:
         htmltext = (Path(__file__).parent / "data" / htmlfile).read_text("utf-8")
         if not rest_of_url.endswith("Updates.xml"):
             return htmltext
@@ -723,7 +723,7 @@ def test_list_describe_filters(meta: MetadataFactory, expect: str):
 )
 def test_list_to_version(monkeypatch, archive_id, spec, version_str, expect):
     _html = (Path(__file__).parent / "data" / "mac-desktop.html").read_text("utf-8")
-    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _html)
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda *args, **kwargs: _html)
 
     if isinstance(expect, Exception):
         with pytest.raises(CliInputError) as error:
@@ -847,7 +847,7 @@ def test_show_list_versions(monkeypatch, capsys):
 
 def test_show_list_tools(monkeypatch, capsys):
     page = (Path(__file__).parent / "data" / "mac-desktop.html").read_text("utf-8")
-    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: page)
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda *args, **kwargs: page)
 
     expect_file = Path(__file__).parent / "data" / "mac-desktop-expect.json"
     expect = "\n".join(json.loads(expect_file.read_text("utf-8"))["tools"]) + "\n"
@@ -918,7 +918,7 @@ def test_list_tool_cli(monkeypatch, capsys, host: str, target: str, tool_name: s
     xml_data = json.loads(xmljson)
     expected_tool_modules = set(xml_data["modules"])
 
-    def _mock_fetch_http(_, rest_of_url: str) -> str:
+    def _mock_fetch_http(_, rest_of_url, *args, **kwargs: str) -> str:
         if not rest_of_url.endswith("Updates.xml"):
             return htmltext
         folder = urlparse(rest_of_url).path.split("/")[-2]


### PR DESCRIPTION
This change causes `aqt` to use SHA-256 checksums for all downloads, and only download them from a list of trusted mirrors. By default, this list includes only https://download.qt.io, but the settings.ini file may be used to modify this list. The settings.ini file can also be used to set the number of times to retry the failed download of a checksum.

Partially addresses #488

Todo:

- [x] Require checksums for Updates.xml files