### PR TITLE
Fix failing `aqt install-tool tools_ifw` test on Ubuntu

### DIFF
--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -11,6 +11,9 @@ steps:
   - bash: |
       sudo apt-get update
       sudo apt-get install -y libgl1-mesa-dev libxkbcommon-x11-0
+      if [[ "$(SUBCOMMAND)" == "install-tool" ]]; then
+        sudo apt-get install -y libxcb-{icccm4,image0,keysyms1,randr0,render-util0,shape0,sync1,xfixes0,xinerama0,xkb1}
+      fi
     condition: and(eq(variables['TARGET'], 'desktop'), eq(variables['Agent.OS'], 'Linux'))
     displayName: install test dependency for Linux
 


### PR DESCRIPTION
The test for `aqt install-tool tools_ifw` recently broke (see https://dev.azure.com/miurahr/github/_build/results?buildId=4989&view=logs&j=bb161906-9c9f-5a9b-90ad-afa0705db589&t=391c2a88-2bdd-5aba-6df6-88fd685f0fd3&l=78) because `archivegen` now requires some x11/libxcb dependencies that it did not require before. This PR adds all of those dependencies so the test will not fail. It does not affect any of the other builds that do not require these dependencies.