### PR TITLE
[Security] Improve `get_hash`

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -231,9 +231,7 @@ class QtArchives:
 
     def _download_update_xml(self, update_xml_path):
         """Hook for unit test."""
-        xml_hash = binascii.unhexlify(get_hash(update_xml_path, "sha256", self.timeout))
-        if xml_hash == "":
-            raise ChecksumDownloadFailure(f"Checksum for '{update_xml_path}' is empty")
+        xml_hash = get_hash(update_xml_path, "sha256", self.timeout)
         update_xml_text = getUrl(posixpath.join(self.base, update_xml_path), self.timeout, xml_hash)
         self.update_xml_text = update_xml_text
 

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1018,7 +1018,7 @@ def installer(
         timeout = (Settings.connection_timeout, Settings.response_timeout)
     else:
         timeout = (Settings.connection_timeout, response_timeout)
-    hash = binascii.unhexlify(get_hash(qt_package.archive_path, algorithm="sha256", timeout=timeout))
+    hash = get_hash(qt_package.archive_path, algorithm="sha256", timeout=timeout)
 
     def download_bin(_base_url):
         url = posixpath.join(_base_url, qt_package.archive_path)

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -574,7 +574,7 @@ class MetadataFactory:
     @staticmethod
     def fetch_http(rest_of_url: str, is_check_hash: bool = True) -> str:
         timeout = (Settings.connection_timeout, Settings.response_timeout)
-        expected_hash = binascii.unhexlify(get_hash(rest_of_url, "sha256", timeout)) if is_check_hash else None
+        expected_hash = get_hash(rest_of_url, "sha256", timeout) if is_check_hash else None
         base_urls = Settings.baseurl, random.choice(Settings.fallbacks)
         for i, base_url in enumerate(base_urls):
             try:

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -201,6 +201,8 @@ def test_helper_retry_on_error(num_attempts_before_success, num_retries_allowed)
 )
 def test_helper_get_hash_retries(monkeypatch, num_tries_required, num_retries_allowed):
     num_tries = 0
+    expected_hash = "a" * 64
+    rest_of_url = "online/qtsdkrepository/some/path/to/archive.7z"
 
     def mock_getUrl(url, *args, **kwargs):
         nonlocal num_tries
@@ -210,20 +212,44 @@ def test_helper_get_hash_retries(monkeypatch, num_tries_required, num_retries_al
         parsed = urlparse(url)
         base = f"{parsed.scheme}://{parsed.netloc}"
         assert base in Settings.trusted_mirrors
+        # Check that the url was composed properly
+        assert url[len(base):] == f"/{rest_of_url}.sha256"
 
         hash_filename = str(parsed.path.split("/")[-1])
         assert hash_filename == "archive.7z.sha256"
-        return "MOCK_HASH archive.7z"
+        return f"{expected_hash} archive.7z"
 
     monkeypatch.setattr("aqt.helper.getUrl", mock_getUrl)
 
     if num_tries_required > num_retries_allowed:
         with pytest.raises(ChecksumDownloadFailure) as e:
-            result = get_hash("http://insecure.mirror.com/some/path/to/archive.7z", "sha256", (5, 5))
+            get_hash(rest_of_url, "sha256", (5, 5))
         assert e.type == ChecksumDownloadFailure
     else:
-        result = get_hash("http://insecure.mirror.com/some/path/to/archive.7z", "sha256", (5, 5))
-        assert result == "MOCK_HASH"
+        result = get_hash(rest_of_url, "sha256", (5, 5))
+        assert result == binascii.unhexlify(expected_hash)
+
+
+@pytest.mark.parametrize(
+    "received_hash",
+    (
+        "",  # Empty
+        "a" * 40,  # Hash length for sha1 checksums
+        "q" * 64,  # Not a hex digit; you can't unhexlify this
+    ),
+)
+def test_helper_get_hash_bad_hash(monkeypatch, received_hash):
+    def mock_getUrl(url, *args, **kwargs):
+        hash_filename = str(urlparse(url).path.split("/")[-1])
+        assert hash_filename.endswith(".sha256")
+        filename = hash_filename[: -len(".sha256")]
+        return f"{received_hash} {filename}"
+
+    monkeypatch.setattr("aqt.helper.getUrl", mock_getUrl)
+
+    with pytest.raises(ChecksumDownloadFailure) as e:
+        get_hash("online/qtsdkrepository/some/path/to/archive.7z", "sha256", (5, 5))
+    assert e.type == ChecksumDownloadFailure
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This fixes a couple of issues with `get_hash` that I didn't think of when I wrote #493:
* This causes `get_hash` to verify that it's getting a hash that's the proper length and that each digit is in the proper range
* This improves the interface of `get_hash`, so that the caller doesn't have to verify the output. The caller can trust that `get_hash` will always return a useable value, or raise `ChecksumDownloadFailure` if it cannot.