### PR TITLE
Change log format for brief

### DIFF
--- a/aqt/logging.ini
+++ b/aqt/logging.ini
@@ -59,7 +59,7 @@ format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
 class=logging.Formatter
 
 [formatter_brief]
-format=%(message)s
+format=%(levelname)s: %(message)s
 class=logging.Formatter
 
 [handlers]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,9 +132,9 @@ def test_cli_invalid_version(capsys, invalid_version):
     cli._setup_settings()
 
     matcher = re.compile(
-        r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
+        r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
         r"(.*\n)*"
-        r".*Invalid version: '" + invalid_version + r"'! Please use the form '5\.X\.Y'\.\n.*"
+        r"ERROR:.*Invalid version: '" + invalid_version + r"'! Please use the form '5\.X\.Y'\.\n.*"
     )
 
     for cmd in (
@@ -290,9 +290,9 @@ def test_cli_legacy_tool_new_syntax(monkeypatch, capsys, cmd):
     command = cmd.split()
 
     expected = (
-        "Warning: The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
+        "WARNING: Warning: The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
         "In the future, please use the command 'install-tool' instead.\n"
-        "Invalid version: 'tools_ifw'! Please use the form '5.X.Y'.\n"
+        "ERROR: Invalid version: 'tools_ifw'! Please use the form '5.X.Y'.\n"
     )
 
     cli = Cli()
@@ -335,7 +335,7 @@ def test_cli_unexpected_error(monkeypatch, capsys):
     cli._setup_settings()
     assert Cli.UNHANDLED_EXCEPTION_CODE == cli.run(["install-qt", "mac", "ios", "6.2.0"])
     out, err = capsys.readouterr()
-    assert err.startswith("Some unexpected error")
+    assert err.startswith("ERROR: Some unexpected error")
     assert err.rstrip().endswith(
         "===========================PLEASE FILE A BUG REPORT===========================\n"
         "You have discovered a bug in aqt.\n"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -330,7 +330,8 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
             ],
             re.compile(
                 r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"WARNING: Warning: The command 'install' is deprecated and marked for removal in a future version of aqt.\n"
+                r"WARNING: Warning: The command 'install' is deprecated"
+                r" and marked for removal in a future version of aqt.\n"
                 r"In the future, please use the command 'install-qt' instead.\n"
                 r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win32_mingw73.7z in .*\n"
@@ -414,7 +415,8 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
             ],
             re.compile(
                 r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"WARNING: Warning: The command 'install' is deprecated and marked for removal in a future version of aqt.\n"
+                r"WARNING: Warning: The command 'install' is deprecated"
+                r" and marked for removal in a future version of aqt.\n"
                 r"In the future, please use the command 'install-qt' instead.\n"
                 r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win32_mingw53.7z in .*\n"
@@ -766,7 +768,8 @@ def test_install(
             "install-qt windows desktop 5.15.0 win32_mingw73 -m nonexistent foo",
             "windows-5150-update.xml",
             "WARNING: Some of specified modules are unknown.\n"
-            "ERROR: The packages ['foo', 'nonexistent', 'qt_base'] were not found while parsing XML of package information!\n"
+            "ERROR: The packages ['foo', 'nonexistent', 'qt_base'] were not found"
+            " while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-qt windows desktop --arch 5.15.0' to show architectures available.\n"
             "* Please use 'aqt list-qt windows desktop --modules 5.15.0 <arch>' to show modules available.\n",
@@ -774,24 +777,28 @@ def test_install(
         (
             "install-doc windows desktop 5.15.0 -m nonexistent foo",
             "windows-5152-src-doc-example-update.xml",
-            "WARNING: Warning: The parameter 'target' with value 'desktop' is deprecated and marked for removal in a future "
+            "WARNING: Warning: The parameter 'target' with value 'desktop' is deprecated"
+            " and marked for removal in a future "
             "version of aqt.\n"
             "In the future, please omit this parameter.\n"
-            "ERROR: The packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
+            "ERROR: The packages ['doc', 'foo', 'nonexistent'] were not found"
+            " while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-doc windows 5.15.0 --modules' to show modules available.\n",
         ),
         (
             "install-doc windows 5.15.0 -m nonexistent foo",
             "windows-5152-src-doc-example-update.xml",
-            "ERROR: The packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
+            "ERROR: The packages ['doc', 'foo', 'nonexistent'] were not found"
+            " while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-doc windows 5.15.0 --modules' to show modules available.\n",
         ),
         (
             "install-example windows 5.15.0 -m nonexistent foo",
             "windows-5152-src-doc-example-update.xml",
-            "ERROR: The packages ['examples', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
+            "ERROR: The packages ['examples', 'foo', 'nonexistent'] were not found"
+            " while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-example windows 5.15.0 --modules' to show modules available.\n",
         ),
@@ -857,7 +864,8 @@ def test_install_nonexistent_archives(monkeypatch, capsys, cmd, xml_file: Option
         (
             KeyboardInterrupt,
             "../aqt/settings.ini",
-            "WARNING: Caught KeyboardInterrupt, terminating installer workers\nERROR: Installer halted by keyboard interrupt.",
+            "WARNING: Caught KeyboardInterrupt, terminating installer workers\n"
+            "ERROR: Installer halted by keyboard interrupt.",
             1,
         ),
         (

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -289,11 +289,11 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 tool_archive("linux", "tools_qtcreator", "qt.tools.qtcreator"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qt.tools.qtcreator...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qt.tools.qtcreator...\n"
                 r"Finished installation of tools_qtcreator-linux-qt.tools.qtcreator.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -308,13 +308,13 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 tool_archive("linux", "tools_qtcreator", "qt.tools.qtcreator", datetime(1970, 1, 2, 3, 4, 5, 6)),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Warning: The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"WARNING: Warning: The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
                 r"In the future, please use the command 'install-tool' instead.\n"
-                r"Downloading qt.tools.qtcreator...\n"
+                r"INFO: Downloading qt.tools.qtcreator...\n"
                 r"Finished installation of tools_qtcreator-linux-qt.tools.qtcreator.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -329,13 +329,13 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 plain_qtbase_archive("qt.qt5.5140.win32_mingw73", "win32_mingw73"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Warning: The command 'install' is deprecated and marked for removal in a future version of aqt.\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"WARNING: Warning: The command 'install' is deprecated and marked for removal in a future version of aqt.\n"
                 r"In the future, please use the command 'install-qt' instead.\n"
-                r"Downloading qtbase...\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win32_mingw73.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -361,14 +361,14 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 ),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Warning: The parameter 'target' with value 'desktop' is deprecated "
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"WARNING: Warning: The parameter 'target' with value 'desktop' is deprecated "
                 r"and marked for removal in a future version of aqt\.\n"
                 r"In the future, please omit this parameter\.\n"
-                r"Downloading qtbase\.\.\.\n"
+                r"INFO: Downloading qtbase\.\.\.\n"
                 r"Finished installation of qtbase-everywhere-src-5\.14\.2\.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -394,11 +394,11 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 ),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase\.\.\.\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase\.\.\.\n"
                 r"Finished installation of qtbase-everywhere-src-5\.14\.2\.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -413,13 +413,13 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 plain_qtbase_archive("qt.59.win32_mingw53", "win32_mingw53"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Warning: The command 'install' is deprecated and marked for removal in a future version of aqt.\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"WARNING: Warning: The command 'install' is deprecated and marked for removal in a future version of aqt.\n"
                 r"In the future, please use the command 'install-qt' instead.\n"
-                r"Downloading qtbase...\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win32_mingw53.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -434,11 +434,11 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 plain_qtbase_archive("qt.59.win32_mingw53", "win32_mingw53"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win32_mingw53.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -453,11 +453,11 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 plain_qtbase_archive("qt.qt5.5140.win32_mingw73", "win32_mingw73"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win32_mingw73.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -473,13 +473,13 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 qtcharts_module("5.14.0", "win64_mingw73"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win64_mingw73.7z in .*\n"
-                r"Downloading qtcharts...\n"
+                r"INFO: Downloading qtcharts...\n"
                 r"Finished installation of qtcharts-windows-win64_mingw73.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -495,11 +495,11 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 qtpositioning_module("6.2.0", "win64_mingw73"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtlocation...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtlocation...\n"
                 r"Finished installation of qtlocation-windows-win64_mingw73.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -515,13 +515,13 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 qtcharts_module("6.1.0", "win64_mingw81"),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-win64_mingw81.7z in .*\n"
-                r"Downloading qtcharts...\n"
+                r"INFO: Downloading qtcharts...\n"
                 r"Finished installation of qtcharts-windows-win64_mingw81.7z in .*\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -571,12 +571,12 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 ),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-windows-android_armv7.7z in .*\n"
-                r"Patching .*6\.1\.0[/\\]android_armv7[/\\]bin[/\\]qmake.bat\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Patching .*6\.1\.0[/\\]android_armv7[/\\]bin[/\\]qmake.bat\n"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -626,12 +626,12 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 ),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-linux-android_arm64_v8a.7z in .*\n"
-                r"Patching .*6\.3\.0[/\\]android_arm64_v8a[/\\]bin[/\\]qmake\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Patching .*6\.3\.0[/\\]android_arm64_v8a[/\\]bin[/\\]qmake\n"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
         (
@@ -681,12 +681,12 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 ),
             ],
             re.compile(
-                r"^aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"Downloading qtbase...\n"
+                r"^INFO: aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO: Downloading qtbase...\n"
                 r"Finished installation of qtbase-mac-ios.7z in .*\n"
-                r"Patching .*6\.1\.2[/\\]ios[/\\]bin[/\\]qmake\n"
-                r"Finished installation\n"
-                r"Time elapsed: .* second"
+                r"INFO: Patching .*6\.1\.2[/\\]ios[/\\]bin[/\\]qmake\n"
+                r"INFO: Finished installation\n"
+                r"INFO: Time elapsed: .* second"
             ),
         ),
     ),
@@ -749,24 +749,24 @@ def test_install(
         (
             "install-qt windows desktop 5.16.0 win32_mingw73",
             None,
-            "Specified Qt version is unknown: 5.16.0.\n"
-            "Failed to locate XML data for Qt version '5.16.0'.\n"
+            "WARNING: Specified Qt version is unknown: 5.16.0.\n"
+            "ERROR: Failed to locate XML data for Qt version '5.16.0'.\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-qt windows desktop' to show versions available.\n",
         ),
         (
             "install-qt windows desktop 5.15.0 bad_arch",
             "windows-5150-update.xml",
-            "Specified target combination is not valid or unknown: windows desktop bad_arch\n"
-            "The packages ['qt_base'] were not found while parsing XML of package information!\n"
+            "WARNING: Specified target combination is not valid or unknown: windows desktop bad_arch\n"
+            "ERROR: The packages ['qt_base'] were not found while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-qt windows desktop --arch 5.15.0' to show architectures available.\n",
         ),
         (
             "install-qt windows desktop 5.15.0 win32_mingw73 -m nonexistent foo",
             "windows-5150-update.xml",
-            "Some of specified modules are unknown.\n"
-            "The packages ['foo', 'nonexistent', 'qt_base'] were not found while parsing XML of package information!\n"
+            "WARNING: Some of specified modules are unknown.\n"
+            "ERROR: The packages ['foo', 'nonexistent', 'qt_base'] were not found while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-qt windows desktop --arch 5.15.0' to show architectures available.\n"
             "* Please use 'aqt list-qt windows desktop --modules 5.15.0 <arch>' to show modules available.\n",
@@ -774,47 +774,47 @@ def test_install(
         (
             "install-doc windows desktop 5.15.0 -m nonexistent foo",
             "windows-5152-src-doc-example-update.xml",
-            "Warning: The parameter 'target' with value 'desktop' is deprecated and marked for removal in a future "
+            "WARNING: Warning: The parameter 'target' with value 'desktop' is deprecated and marked for removal in a future "
             "version of aqt.\n"
             "In the future, please omit this parameter.\n"
-            "The packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
+            "ERROR: The packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-doc windows 5.15.0 --modules' to show modules available.\n",
         ),
         (
             "install-doc windows 5.15.0 -m nonexistent foo",
             "windows-5152-src-doc-example-update.xml",
-            "The packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
+            "ERROR: The packages ['doc', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-doc windows 5.15.0 --modules' to show modules available.\n",
         ),
         (
             "install-example windows 5.15.0 -m nonexistent foo",
             "windows-5152-src-doc-example-update.xml",
-            "The packages ['examples', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
+            "ERROR: The packages ['examples', 'foo', 'nonexistent'] were not found while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-example windows 5.15.0 --modules' to show modules available.\n",
         ),
         (
             "install-tool windows desktop tools_vcredist nonexistent",
             "windows-desktop-tools_vcredist-update.xml",
-            "Specified target combination is not valid: windows tools_vcredist nonexistent\n"
-            "The package 'nonexistent' was not found while parsing XML of package information!\n"
+            "WARNING: Specified target combination is not valid: windows tools_vcredist nonexistent\n"
+            "ERROR: The package 'nonexistent' was not found while parsing XML of package information!\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-tool windows desktop tools_vcredist' to show tool variants available.\n",
         ),
         (
             "install-tool windows desktop tools_nonexistent nonexistent",
             None,
-            "Specified target combination is not valid: windows tools_nonexistent nonexistent\n"
-            "Failed to locate XML data for the tool 'tools_nonexistent'.\n"
+            "WARNING: Specified target combination is not valid: windows tools_nonexistent nonexistent\n"
+            "ERROR: Failed to locate XML data for the tool 'tools_nonexistent'.\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-tool windows desktop' to show tools available.\n",
         ),
         (
             "install-tool windows desktop tools_nonexistent",
             None,
-            "Failed to locate XML data for the tool 'tools_nonexistent'.\n"
+            "ERROR: Failed to locate XML data for the tool 'tools_nonexistent'.\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please use 'aqt list-tool windows desktop' to check what tools are available.\n",
         ),
@@ -857,14 +857,14 @@ def test_install_nonexistent_archives(monkeypatch, capsys, cmd, xml_file: Option
         (
             KeyboardInterrupt,
             "../aqt/settings.ini",
-            "Caught KeyboardInterrupt, terminating installer workers\nInstaller halted by keyboard interrupt.",
+            "WARNING: Caught KeyboardInterrupt, terminating installer workers\nERROR: Installer halted by keyboard interrupt.",
             1,
         ),
         (
             MemoryError,
             "../aqt/settings.ini",
-            "Caught MemoryError, terminating installer workers\n"
-            "Out of memory when downloading and extracting archives in parallel.\n"
+            "WARNING: Caught MemoryError, terminating installer workers\n"
+            "ERROR: Out of memory when downloading and extracting archives in parallel.\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please reduce your 'concurrency' setting (see "
             "https://aqtinstall.readthedocs.io/en/stable/configuration.html#configuration)\n"
@@ -875,8 +875,8 @@ def test_install_nonexistent_archives(monkeypatch, capsys, cmd, xml_file: Option
         (
             MemoryError,
             "data/settings_no_concurrency.ini",
-            "Caught MemoryError, terminating installer workers\n"
-            "Out of memory when downloading and extracting archives.\n"
+            "WARNING: Caught MemoryError, terminating installer workers\n"
+            "ERROR: Out of memory when downloading and extracting archives.\n"
             "==============================Suggested follow-up:==============================\n"
             "* Please free up more memory.\n"
             "* Please try using the '--external' flag to specify an alternate 7z extraction tool "

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -368,7 +368,7 @@ def test_list_archives_insufficient_args(capsys):
     cli = Cli()
     assert 1 == cli.run("list-qt mac desktop --archives 5.14.0".split())
     out, err = capsys.readouterr()
-    assert err.strip() == "The '--archives' flag requires a 'QT_VERSION' and an 'ARCHITECTURE' parameter."
+    assert err.strip() == "ERROR: The '--archives' flag requires a 'QT_VERSION' and an 'ARCHITECTURE' parameter."
 
 
 def test_list_archives_bad_xml(monkeypatch):
@@ -516,7 +516,7 @@ def test_list_targets(capsys, cmd: str, host: str, expect: Set[str]):
     ),
 )
 def test_list_wrong_target(capsys, cmd: str, host: str, target: str):
-    expect = f"'{target}' is not a valid target for host '{host}'"
+    expect = f"ERROR: '{target}' is not a valid target for host '{host}'"
 
     cli = Cli()
     return_code = cli.run([cmd, host, target])
@@ -535,7 +535,7 @@ def test_list_wrong_target(capsys, cmd: str, host: str, target: str):
     ),
 )
 def test_invalid_spec(capsys, cmd: str, spec: str):
-    expect_prefix = f"Invalid version specification: '{spec}'"
+    expect_prefix = f"ERROR: Invalid version specification: '{spec}'"
     host, target = "linux", "desktop"
     cli = Cli()
     return_code = cli.run([cmd, host, target, "--spec", spec])


### PR DESCRIPTION
- Prepend ``%(levelname)s:`` for brief logging format in default configuration
- Implement a feature suggested in #513
- Update test expectations against console logging format change
- This change does not make any effect to CI configuration 

Signed-off-by: Hiroshi Miura <miurahr@linux.com>