### PR TITLE
Update Mac CI pipelines to use MacOS-12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,10 +157,10 @@ to make it working well with installed directory.
 
 .. warning::
    If you are using aqtinstall to install the ios version of Qt, please be aware that
-   there are compatibility issues between XCode 13+ and versions of Qt less than 6.2.0.
+   there are compatibility issues between XCode 13+ and versions of Qt less than 6.2.4.
    You may use aqtinstall to install older versions of Qt for ios, but the developers of
    aqtinstall cannot guarantee that older versions will work on the most recent versions of MacOS.
-   Aqtinstall is tested for ios on MacOS 12 with Qt 6.2.0 and greater.
+   Aqtinstall is tested for ios on MacOS 12 with Qt 6.2.4 and greater.
    All earlier versions of Qt are expected not to function.
 
 Testimonies

--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,14 @@ to make it working well with installed directory.
 .. note::
    It is your own task to set some environment variables to fit your platform, such as PATH, QT_PLUGIN_PATH, QML_IMPORT_PATH, and QML2_IMPORT_PATH. aqtinstall will never do it for you, in order not to break the installation of multiple versions.
 
+.. warning::
+   If you are using aqtinstall to install the ios version of Qt, please be aware that
+   there are compatibility issues between XCode 13+ and versions of Qt less than 6.2.0.
+   You may use aqtinstall to install older versions of Qt for ios, but the developers of
+   aqtinstall cannot guarantee that older versions will work on the most recent versions of MacOS.
+   Aqtinstall is tested for ios on MacOS 12 with Qt 6.2.0 and greater.
+   All earlier versions of Qt are expected not to function.
+
 Testimonies
 -----------
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
 - job: Mac
   dependsOn: MatricesGenerator
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-12'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.mac'] ]
   steps:

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -270,7 +270,7 @@ mac_build_jobs.append(
 # mobile SDK
 mac_build_jobs.extend(
     [
-        BuildJob("install-qt", "5.15.2", "mac", "ios", "ios", "ios", is_autodesktop=True),
+        BuildJob("install-qt", "6.4.0", "mac", "ios", "ios", "ios", module="qtsensors", is_autodesktop=True),
         BuildJob("install-qt", "6.2.2", "mac", "ios", "ios", "ios", module="qtsensors", is_autodesktop=False),
         BuildJob("install-qt", "6.1.0", "mac", "android", "android_armv7", "android_armv7", is_autodesktop=True),
     ]

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -271,7 +271,7 @@ mac_build_jobs.append(
 mac_build_jobs.extend(
     [
         BuildJob("install-qt", "6.4.0", "mac", "ios", "ios", "ios", module="qtsensors", is_autodesktop=True),
-        BuildJob("install-qt", "6.2.2", "mac", "ios", "ios", "ios", module="qtsensors", is_autodesktop=False),
+        BuildJob("install-qt", "6.2.4", "mac", "ios", "ios", "ios", module="qtsensors", is_autodesktop=False),
         BuildJob("install-qt", "6.1.0", "mac", "android", "android_armv7", "android_armv7", is_autodesktop=True),
     ]
 )

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -524,6 +524,8 @@ There are various combinations to accept according to Qt version.
 .. describe:: target
 
     desktop, ios, winrt, or android. The type of device for which you are developing Qt programs.
+    If your target is ios, please be aware that versions of Qt older than 6.2 are expected to be
+    non-functional with current versions of XCode (applies to any XCode greater than or equal to 13).
 
 .. describe:: Qt version
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -524,7 +524,7 @@ There are various combinations to accept according to Qt version.
 .. describe:: target
 
     desktop, ios, winrt, or android. The type of device for which you are developing Qt programs.
-    If your target is ios, please be aware that versions of Qt older than 6.2 are expected to be
+    If your target is ios, please be aware that versions of Qt older than 6.2.4 are expected to be
     non-functional with current versions of XCode (applies to any XCode greater than or equal to 13).
 
 .. describe:: Qt version


### PR DESCRIPTION
The MacOS-10.15 CI runners are now deprecated, and will begin brownouts in August. See discussion here: https://github.com/actions/virtual-environments/issues/5583

~MacOS-11 is also available, in case there are any issues with 12.~ There are issues with 12 so I went to 11.

**Update:** Something's wrong with MacOS-11 too: https://dev.azure.com/miurahr/github/_build/results?buildId=5481&view=logs&j=bae13455-f657-522d-e2b4-64495419fb63&t=5c902093-735e-5ee6-b7c8-ba98a93e04e2&l=58

**Update [2021-09-17]:** I have come to the conclusion that it makes no sense to continue to test using Qt < 6.2.4 with ios, because it is not realistic that it will work. The XCode toolchain has changed significantly in the last few years, breaking compatibility with several things that older versions of Qt relied on in the past. Every version of Qt greater than or equal to 6.2.4 works without any trouble in CI on MacOS 12.

Technically, you can modify certain files in Qt versions 6.0-6.2.3 and end up with a successful ios build (install Python 2, change a shebang line in `ios/mkspecs/features/uikit/devices.py`, and modify xml entries in `ios/mkspecs/macx-xcode/WorkspaceSettings.xcsettings`), but I strongly oppose advising our users to do these things, rather than simply using a version that works properly to begin with.