### PR TITLE
Fix ci warnings/failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "dataclasses;python_version<'3.7'",
     "defusedxml",
 ]
-dynamic = ["version"]
+dynamic = ["version", "entry-points"]
 
 [project.scripts]
 aqt = "aqt.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "pympler",
 ]
 check = [
-    "flake8",
+    "flake8<5",
     "flake8-black",
     "flake8-colors",
     "flake8-isort",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ test = [
     "pytest-cov",
     "pytest-socket",
     "pytest-leaks",
+    "pytest-timeout",
     "pympler",
 ]
 check = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,9 @@ from pytest_socket import disable_socket
 
 def pytest_runtest_setup():
     disable_socket()
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "load_default_settings(use_defaults): mark test not to load from the default settings.ini file"
+    )


### PR DESCRIPTION
This PR addresses several warnings I found while trying to debug a failing build in CI:

1. Tox complains about the `entry-points` entry in `pyproject.toml` being dynamic when it is not marked as such. This marks it as dynamic.
2. Pytest complains that one of the custom markers we are using, `load_default_settings`, is not registered. This registers the marker.
3. Pytest complains that 'timeout' is not a valid key in the `pyproject.toml` file. This adds the dependency that provides that key. 
4. Flake8 5.0.0 was released today, and now it is incompatible with flake8-isort. Any attempt to run flake8 results in a failure, because it failed to import flake8-isort properly. This pins flake8 at the highest version below 5.0.0.

Item 4 should probably be reverted after flake8 and flake8-isort sort out whatever is going wrong here.