### PR TITLE
Add `aqt list-qt --long-modules`

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -34,6 +34,7 @@ from typing import Callable, Dict, Generator, List, Optional, Tuple
 from urllib.parse import urlparse
 from xml.etree.ElementTree import Element
 
+import humanize
 import requests
 import requests.adapters
 from defusedxml import ElementTree
@@ -290,7 +291,13 @@ def xml_to_modules(
         name = packageupdate.find("Name").text
         packages[name] = {}
         for child in packageupdate:
-            packages[name][child.tag] = child.text
+            if child.tag == "UpdateFile":
+                for attr in "CompressedSize", "UncompressedSize":
+                    if attr not in child.attrib:
+                        continue
+                    packages[name][attr] = humanize.naturalsize(child.attrib[attr], gnu=True)
+            else:
+                packages[name][child.tag] = child.text
     return packages
 
 

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -493,9 +493,11 @@ class Cli:
         if args.target not in ArchiveId.TARGETS_FOR_HOST[args.host]:
             raise CliInputError("'{0.target}' is not a valid target for host '{0.host}'".format(args))
         if args.modules:
-            modules_ver, modules_query = args.modules[0], tuple(args.modules)
+            modules_ver, modules_query, is_long = args.modules[0], tuple(args.modules), False
+        elif args.long_modules:
+            modules_ver, modules_query, is_long = args.long_modules[0], tuple(args.long_modules), True
         else:
-            modules_ver, modules_query = None, None
+            modules_ver, modules_query, is_long = None, None, False
 
         for version_str in (modules_ver, args.extensions, args.arch, args.archives[0] if args.archives else None):
             Cli._validate_version_str(version_str, allow_latest=True, allow_empty=True)
@@ -517,6 +519,7 @@ class Cli:
             spec=spec,
             is_latest_version=args.latest_version,
             modules_query=modules_query,
+            is_long_listing=is_long,
             extensions_ver=args.extensions,
             architectures_ver=args.arch,
             archives_query=args.archives,
@@ -735,6 +738,16 @@ class Cli:
             help='First arg: Qt version in the format of "5.X.Y", or the keyword "latest". '
             'Second arg: an architecture, which may be printed with the "--arch" flag. '
             "When set, this prints all the modules available for either Qt 5.X.Y or the latest version of Qt.",
+        )
+        output_modifier_exclusive_group.add_argument(
+            "--long-modules",
+            type=str,
+            nargs=2,
+            metavar=("(VERSION | latest)", "ARCHITECTURE"),
+            help='First arg: Qt version in the format of "5.X.Y", or the keyword "latest". '
+            'Second arg: an architecture, which may be printed with the "--arch" flag. '
+            "When set, this prints a table that describes all the modules available "
+            "for either Qt 5.X.Y or the latest version of Qt.",
         )
         output_modifier_exclusive_group.add_argument(
             "--extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,15 @@ classifiers = [
 ]
 requires-python = ">=3.6"
 dependencies = [
-    "requests",
-    "semantic_version",
-    "patch>=1.16",
-    "py7zr>=0.18.3",
-    "texttable",
     "bs4",
     "dataclasses;python_version<'3.7'",
     "defusedxml",
+    "humanize",
+    "patch>=1.16",
+    "py7zr>=0.18.3",
+    "requests",
+    "semantic_version",
+    "texttable",
 ]
 dynamic = ["version", "entry-points"]
 

--- a/tests/data/windows-5140-expect.json
+++ b/tests/data/windows-5140-expect.json
@@ -73,6 +73,403 @@
       "qtwebglplugin"
     ]
   },
+  "modules_long_by_arch": {
+    "win32_mingw73": [
+      [
+        "qtcharts",
+        "Qt Charts for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "772.7K",
+        "7.8M"
+      ],
+      [
+        "qtdatavis3d",
+        "Qt Data Visualization for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "620.2K",
+        "5.0M"
+      ],
+      [
+        "qtlottie",
+        "Qt Lottie Animation for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "153.5K",
+        "968.4K"
+      ],
+      [
+        "qtnetworkauth",
+        "Qt Network Authorization for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "98.7K",
+        "638.6K"
+      ],
+      [
+        "qtpurchasing",
+        "Qt Purchasing for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "50.9K",
+        "306.8K"
+      ],
+      [
+        "qtquick3d",
+        "Qt Quick 3D for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "9.8M",
+        "21.2M"
+      ],
+      [
+        "qtquicktimeline",
+        "Qt Quick Timeline for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "35.3K",
+        "154.1K"
+      ],
+      [
+        "qtscript",
+        "Qt Script for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "1.0M",
+        "5.5M"
+      ],
+      [
+        "qtvirtualkeyboard",
+        "Qt Virtual Keyboard for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "2.1M",
+        "6.8M"
+      ],
+      [
+        "qtwebglplugin",
+        "Qt WebGL Streaming Plugin for MinGW 7.3.0 32-bit",
+        "2019-12-11",
+        "201.7K",
+        "1.0M"
+      ]
+    ],
+    "win32_msvc2017": [
+      [
+        "debug_info",
+        "Desktop MSVC 2017 Debug Information Files",
+        "2019-12-11",
+        "511.2M",
+        "4.1G"
+      ],
+      [
+        "qtcharts",
+        "Qt Charts for MSVC 2017 32-bit",
+        "2019-12-11",
+        "924.7K",
+        "8.7M"
+      ],
+      [
+        "qtdatavis3d",
+        "Qt Data Visualization for MSVC 2017 32-bit",
+        "2019-12-11",
+        "764.6K",
+        "6.1M"
+      ],
+      [
+        "qtlottie",
+        "Qt Lottie Animation for MSVC 2017 32-bit",
+        "2019-12-11",
+        "173.3K",
+        "1.1M"
+      ],
+      [
+        "qtnetworkauth",
+        "Qt Network Authorization for MSVC 2017 32-bit",
+        "2019-12-11",
+        "109.5K",
+        "692.1K"
+      ],
+      [
+        "qtpurchasing",
+        "Qt Purchasing for MSVC 2017 32-bit",
+        "2019-12-11",
+        "62.6K",
+        "381.8K"
+      ],
+      [
+        "qtquick3d",
+        "Qt Quick 3D for MSVC 2017 32-bit",
+        "2019-12-11",
+        "10.4M",
+        "26.2M"
+      ],
+      [
+        "qtquicktimeline",
+        "Qt Quick Timeline for MSVC 2017 32-bit",
+        "2019-12-11",
+        "43.6K",
+        "282.9K"
+      ],
+      [
+        "qtscript",
+        "Qt Script for MSVC 2017 32-bit",
+        "2019-12-11",
+        "1.2M",
+        "10.1M"
+      ],
+      [
+        "qtvirtualkeyboard",
+        "Qt Virtual Keyboard for MSVC 2017 32-bit",
+        "2019-12-11",
+        "2.2M",
+        "12.4M"
+      ],
+      [
+        "qtwebengine",
+        "Qt WebEngine for msvc2017 32-bit",
+        "2019-12-11",
+        "68.6M",
+        "253.1M"
+      ],
+      [
+        "qtwebglplugin",
+        "Qt WebGL Streaming Plugin for MSVC 2017 32-bit",
+        "2019-12-11",
+        "311.5K",
+        "1.6M"
+      ]
+    ],
+    "win64_mingw73": [
+      [
+        "qtcharts",
+        "Qt Charts for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "752.2K",
+        "7.7M"
+      ],
+      [
+        "qtdatavis3d",
+        "Qt Data Visualization for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "623.2K",
+        "5.0M"
+      ],
+      [
+        "qtlottie",
+        "Qt Lottie Animation for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "161.7K",
+        "988.6K"
+      ],
+      [
+        "qtnetworkauth",
+        "Qt Network Authorization for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "96.9K",
+        "624.4K"
+      ],
+      [
+        "qtpurchasing",
+        "Qt Purchasing for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "51.0K",
+        "315.1K"
+      ],
+      [
+        "qtquick3d",
+        "Qt Quick 3D for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "9.8M",
+        "21.1M"
+      ],
+      [
+        "qtquicktimeline",
+        "Qt Quick Timeline for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "35.4K",
+        "160.3K"
+      ],
+      [
+        "qtscript",
+        "Qt Script for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "899.3K",
+        "5.0M"
+      ],
+      [
+        "qtvirtualkeyboard",
+        "Qt Virtual Keyboard for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "2.1M",
+        "6.8M"
+      ],
+      [
+        "qtwebglplugin",
+        "Qt WebGL Streaming Plugin for MinGW 7.3.0 64-bit",
+        "2019-12-11",
+        "192.9K",
+        "1002.4K"
+      ]
+    ],
+    "win64_msvc2015_64": [
+      [
+        "debug_info",
+        "Desktop MSVC 2015 64-bit debug information files",
+        "2019-12-11",
+        "438.4M",
+        "3.3G"
+      ],
+      [
+        "qtcharts",
+        "Qt Charts for MSVC 2015 64-bit",
+        "2019-12-11",
+        "1.0M",
+        "9.7M"
+      ],
+      [
+        "qtdatavis3d",
+        "Qt Data Visualization for MSVC 2015 64-bit",
+        "2019-12-11",
+        "822.6K",
+        "6.6M"
+      ],
+      [
+        "qtlottie",
+        "Qt Lottie Animation for MSVC 2015 64-bit",
+        "2019-12-11",
+        "193.7K",
+        "1.2M"
+      ],
+      [
+        "qtnetworkauth",
+        "Qt Network Authorization for MSVC 2015 64-bit",
+        "2019-12-11",
+        "117.9K",
+        "778.6K"
+      ],
+      [
+        "qtpurchasing",
+        "Qt Purchasing for MSVC 2015 64-bit",
+        "2019-12-11",
+        "66.6K",
+        "436.4K"
+      ],
+      [
+        "qtquick3d",
+        "Qt Quick 3D for MSVC 2015 64-bit",
+        "2019-12-11",
+        "10.9M",
+        "30.6M"
+      ],
+      [
+        "qtquicktimeline",
+        "Qt Quick Timeline for MSVC 2015 64-bit",
+        "2019-12-11",
+        "48.4K",
+        "333.4K"
+      ],
+      [
+        "qtscript",
+        "Qt Script for MSVC 2015 64-bit",
+        "2019-12-11",
+        "1.2M",
+        "9.5M"
+      ],
+      [
+        "qtvirtualkeyboard",
+        "Qt Virtual Keyboard for MSVC 2015 64-bit",
+        "2019-12-11",
+        "2.2M",
+        "12.9M"
+      ],
+      [
+        "qtwebglplugin",
+        "Qt WebGL Streaming Plugin for MSVC 2015 64-bit",
+        "2019-12-11",
+        "301.4K",
+        "1.7M"
+      ]
+    ],
+    "win64_msvc2017_64": [
+      [
+        "debug_info",
+        "Desktop MSVC 2017 64-bit debug information files",
+        "2019-12-11",
+        "834.2M",
+        "6.7G"
+      ],
+      [
+        "qtcharts",
+        "Qt Charts for MSVC 2017 64-bit",
+        "2019-12-11",
+        "1.0M",
+        "9.8M"
+      ],
+      [
+        "qtdatavis3d",
+        "Qt Data Visualization for MSVC 2017 64-bit",
+        "2019-12-11",
+        "857.9K",
+        "6.8M"
+      ],
+      [
+        "qtlottie",
+        "Qt Lottie Animation for MSVC 2017 64-bit",
+        "2019-12-11",
+        "198.4K",
+        "1.2M"
+      ],
+      [
+        "qtnetworkauth",
+        "Qt Network Authentication for MSVC 2017_64-bit",
+        "2019-12-11",
+        "125.1K",
+        "809.2K"
+      ],
+      [
+        "qtpurchasing",
+        "Qt Purchasing for MSVC 2017 64-bit",
+        "2019-12-11",
+        "68.1K",
+        "448.1K"
+      ],
+      [
+        "qtquick3d",
+        "Qt Quick 3D for MSVC 2017 64-bit",
+        "2019-12-11",
+        "10.8M",
+        "30.1M"
+      ],
+      [
+        "qtquicktimeline",
+        "Qt Quick Timeline for MSVC 2017 64-bit",
+        "2019-12-11",
+        "48.9K",
+        "340.9K"
+      ],
+      [
+        "qtscript",
+        "Qt Script for MSVC 2017 64-bit",
+        "2019-12-11",
+        "1.2M",
+        "10.6M"
+      ],
+      [
+        "qtvirtualkeyboard",
+        "Qt Virtual Keyboard for MSVC 2017 64-bit",
+        "2019-12-11",
+        "2.3M",
+        "13.0M"
+      ],
+      [
+        "qtwebengine",
+        "Qt WebEngine for MSVC 2017 64-bit",
+        "2019-12-11",
+        "80.8M",
+        "328.9M"
+      ],
+      [
+        "qtwebglplugin",
+        "Qt WebGL Streaming Plugin for msvc2017_64-bit",
+        "2019-12-11",
+        "355.2K",
+        "1.9M"
+      ]
+    ]
+  },
   "modules_metadata_by_arch": {
     "win32_mingw73": [
       {

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -385,7 +385,7 @@ def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
     assert modules == expect["modules"]
 
     table = MetadataFactory(archive_id, tool_name=tool_name, is_long_listing=True).getList()
-    assert table._rows() == expect["long_listing"]
+    assert table._rows(table.long_heading_keys) == expect["long_listing"]
 
 
 @pytest.fixture

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -388,6 +388,26 @@ def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
     assert table._rows(table.long_heading_keys) == expect["long_listing"]
 
 
+@pytest.mark.parametrize(
+    "host, target, version, arch",
+    [
+        ["windows", "desktop", "5.14.0", arch]
+        for arch in ["win32_mingw73", "win32_msvc2017", "win64_mingw73", "win64_msvc2015_64", "win64_msvc2017_64"]
+    ],
+)
+def test_long_qt_modules(monkeypatch, host: str, target: str, version: str, arch: str):
+    archive_id = ArchiveId("qt", host, target)
+    in_file = f"{host}-{version.replace('.', '')}-update.xml"
+    expect_out_file = f"{host}-{version.replace('.', '')}-expect.json"
+    _xml = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
+    expect = json.loads((Path(__file__).parent / "data" / expect_out_file).read_text("utf-8"))
+
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _xml)
+
+    table = MetadataFactory(archive_id, modules_query=(version, arch), is_long_listing=True).getList()
+    assert table._rows(table.long_heading_keys) == expect["modules_long_by_arch"][arch]
+
+
 @pytest.fixture
 def expected_windows_desktop_5140() -> Dict:
     xmlexpect = "windows-5140-expect.json"
@@ -828,6 +848,71 @@ def test_show_list_tools_long_ifw(capsys, monkeypatch, columns, expect):
     meta = MetadataFactory(
         ArchiveId("tools", "mac", "desktop"),
         tool_name="tools_ifw",
+        is_long_listing=True,
+    )
+    show_list(meta)
+    out, err = capsys.readouterr()
+    sys.stdout.write(out)
+    sys.stderr.write(err)
+    assert out == expect
+
+
+@pytest.mark.parametrize(
+    "columns, expect",
+    (
+        (
+            120,
+            "   Module Name                        Display Name                     Release Date   Download Size   "
+            "Installed Size\n"
+            "======================================================================================================"
+            "==============\n"
+            "qtcharts            Qt Charts for MinGW 7.3.0 32-bit                   2019-12-11     772.7K          "
+            "7.8M          \n"
+            "qtdatavis3d         Qt Data Visualization for MinGW 7.3.0 32-bit       2019-12-11     620.2K          "
+            "5.0M          \n"
+            "qtlottie            Qt Lottie Animation for MinGW 7.3.0 32-bit         2019-12-11     153.5K          "
+            "968.4K        \n"
+            "qtnetworkauth       Qt Network Authorization for MinGW 7.3.0 32-bit    2019-12-11     98.7K           "
+            "638.6K        \n"
+            "qtpurchasing        Qt Purchasing for MinGW 7.3.0 32-bit               2019-12-11     50.9K           "
+            "306.8K        \n"
+            "qtquick3d           Qt Quick 3D for MinGW 7.3.0 32-bit                 2019-12-11     9.8M            "
+            "21.2M         \n"
+            "qtquicktimeline     Qt Quick Timeline for MinGW 7.3.0 32-bit           2019-12-11     35.3K           "
+            "154.1K        \n"
+            "qtscript            Qt Script for MinGW 7.3.0 32-bit                   2019-12-11     1.0M            "
+            "5.5M          \n"
+            "qtvirtualkeyboard   Qt Virtual Keyboard for MinGW 7.3.0 32-bit         2019-12-11     2.1M            "
+            "6.8M          \n"
+            "qtwebglplugin       Qt WebGL Streaming Plugin for MinGW 7.3.0 32-bit   2019-12-11     201.7K          "
+            "1.0M          \n",
+        ),
+        (
+            80,
+            "   Module Name                        Display Name                  \n"
+            "====================================================================\n"
+            "qtcharts            Qt Charts for MinGW 7.3.0 32-bit                \n"
+            "qtdatavis3d         Qt Data Visualization for MinGW 7.3.0 32-bit    \n"
+            "qtlottie            Qt Lottie Animation for MinGW 7.3.0 32-bit      \n"
+            "qtnetworkauth       Qt Network Authorization for MinGW 7.3.0 32-bit \n"
+            "qtpurchasing        Qt Purchasing for MinGW 7.3.0 32-bit            \n"
+            "qtquick3d           Qt Quick 3D for MinGW 7.3.0 32-bit              \n"
+            "qtquicktimeline     Qt Quick Timeline for MinGW 7.3.0 32-bit        \n"
+            "qtscript            Qt Script for MinGW 7.3.0 32-bit                \n"
+            "qtvirtualkeyboard   Qt Virtual Keyboard for MinGW 7.3.0 32-bit      \n"
+            "qtwebglplugin       Qt WebGL Streaming Plugin for MinGW 7.3.0 32-bit\n",
+        ),
+    ),
+)
+def test_show_list_long_qt_modules(capsys, monkeypatch, columns, expect):
+    update_xml = (Path(__file__).parent / "data" / "windows-5140-update.xml").read_text("utf-8")
+    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: update_xml)
+
+    monkeypatch.setattr(shutil, "get_terminal_size", lambda fallback: os.terminal_size((columns, 24)))
+
+    meta = MetadataFactory(
+        ArchiveId("qt", "windows", "desktop"),
+        modules_query=("5.14.0", "win32_mingw73"),
         is_long_listing=True,
     )
     show_list(meta)


### PR DESCRIPTION
Fix #543.

#543 suggests 4 new ways to use `aqt list-qt`, but this PR only implements the first of the 4. After implementing this, it is difficult for me to see any point in implementing the other 3, since this command already prints everything you might want to know about a module.

If there's any demand for `aqt list-qt --display-modules`, or for a version of `aqt list-qt --long-modules` that only describes a single module, please let me know and I'll take another look at this. I think that those commands could be convenient for a user that wants to pipe the output into a bash script.

Sample output:
```
$ python -m aqt list-qt linux desktop --long-modules 5.14.0 gcc_64  
    Module Name                      Display Name                  Release Date   Download Size   Installed Size
================================================================================================================
debug_info            Desktop gcc 64-bit Debug Information Files   2019-12-11     633.9M          3.4G          
qtcharts              Qt Charts for gcc 64-bit                     2019-12-11     635.1K          3.9M          
qtdatavis3d           Qt Data Visualization for gcc 64-bit         2019-12-11     543.4K          2.8M          
qtlottie              Qt Lottie Animation for gcc 64-bit           2019-12-11     136.7K          591.4K        
qtnetworkauth         Qt Network Authorization for gcc 64-bit      2019-12-11     75.3K           343.1K        
qtpurchasing          Qt Purchasing for gcc 64-bit                 2019-12-11     32.7K           169.4K        
qtquick3d             Qt Quick 3D for gcc 64-bit                   2019-12-11     9.4M            16.1M         
qtquicktimeline       Qt Quick Timeline for gcc 64-bit             2019-12-11     22.0K           94.6K         
qtscript              Qt Script for gcc 64-bit                     2019-12-11     1.0M            4.4M          
qtvirtualkeyboard     Qt Virtual Keyboard for gcc 64-bit           2019-12-11     2.0M            5.6M          
qtwaylandcompositor   Qt Wayland Compositor for gcc 64-bit         2019-12-11     620.1K          4.4M          
qtwebengine           Qt WebEngine for Desktop gcc 64-bit          2019-12-11     45.2M           156.9M        
qtwebglplugin         Qt WebGL Streaming Plugin for gcc 64-bit     2019-12-11     248.0K          1.1M    
```