### PR TITLE
Fix kwargs passed up AqtException inheritance tree

### DIFF
--- a/aqt/exceptions.py
+++ b/aqt/exceptions.py
@@ -18,15 +18,15 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-from typing import List
+from typing import List, Optional
 
 DOCS_CONFIG = "https://aqtinstall.readthedocs.io/en/stable/configuration.html#configuration"
 
 
 class AqtException(Exception):
-    def __init__(self, *args, **kwargs):
-        self.suggested_action: List[str] = kwargs.pop("suggested_action", [])
-        self.should_show_help: bool = kwargs.pop("should_show_help", False)
+    def __init__(self, *args, suggested_action: Optional[List[str]] = None, should_show_help: bool = False, **kwargs):
+        self.suggested_action: List[str] = suggested_action or []
+        self.should_show_help: bool = should_show_help or False
         super(AqtException, self).__init__(*args, **kwargs)
 
     def __format__(self, format_spec) -> str:
@@ -53,16 +53,19 @@ class ArchiveChecksumError(ArchiveDownloadError):
 
 
 class ChecksumDownloadFailure(ArchiveDownloadError):
-    def __init__(self, *args, **kwargs):
-        kwargs["suggested_action"] = kwargs.pop("suggested_action", []).extend(
+    def __init__(self, *args, suggested_action: Optional[List[str]] = None, **kwargs):
+        if suggested_action is None:
+            suggested_action = []
+        suggested_action.extend(
             [
                 "Check your internet connection",
                 "Consider modifying `requests.max_retries_to_retrieve_hash` in settings.ini",
                 f"Consider modifying `mirrors.trusted_mirrors` in settings.ini (see {DOCS_CONFIG})",
             ]
         )
-        kwargs["should_show_help"] = True
-        super(ChecksumDownloadFailure, self).__init__(*args, **kwargs)
+        super(ChecksumDownloadFailure, self).__init__(
+            *args, suggested_action=suggested_action, should_show_help=True, **kwargs
+        )
 
 
 class ArchiveConnectionError(AqtException):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -900,7 +900,7 @@ def test_show_list_bad_connection(monkeypatch, capsys, exception_class, error_ms
 @pytest.mark.parametrize(
     "exception_class, error_msg, source", ((ArchiveConnectionError, "Failure to connect", "aqt.helper.getUrl"),)
 )
-def test_show_list_bad_connection(monkeypatch, capsys, exception_class, error_msg, source):
+def test_show_list_bad_connection_for_checksum(monkeypatch, capsys, exception_class, error_msg, source):
     def mock(*args, **kwargs):
         raise exception_class(error_msg)
 


### PR DESCRIPTION
Fix #546. That stack trace shows that keyword arguments are not being passed from ChecksumDownloadFailure to AqtException as intended. This PR adds a test that recreates the conditions that caused #546 and fixes the root cause of the issue.