### PR TITLE
Add `humanize` to `setup.cfg` install requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     bs4
     dataclasses;python_version<"3.7"
     defusedxml
+    humanize
 setup_requires =
     setuptools-scm[toml]>=6.4
     setuptools>=61


### PR DESCRIPTION
This is an attempt to fix a failure in `ci/build_standalone.bat`. I suspect that this may be caused by my failure to add the `humanize` library to `setup.cfg` in #547. I'm not certain how to debug this.

From the logs in a failed windows build, after #547 was merged:
https://github.com/miurahr/aqtinstall/runs/7807796241?check_suite_focus=true#step:7:348
```
2022-08-12 14:14:30,503 - gravitybee - INFO - script_path: None
```

From the logs in a successful windows build, before #547 was merged:
https://github.com/miurahr/aqtinstall/runs/7739405867?check_suite_focus=true#step:5:439
```
2022-08-09 05:02:38,233 - gravitybee - INFO - script_path: D:\a\aqtinstall\aqtinstall\build_venv\Scripts\aqt-script.py
```