### PR TITLE
Fix windows standalone binary build

### DIFF
--- a/ci/build_standalone.bat
+++ b/ci/build_standalone.bat
@@ -2,6 +2,7 @@ pip install -U pip
 pip install virtualenv
 virtualenv build_venv
 call build_venv\Scripts\activate.bat
+move pyproject.toml pyproject.toml.bak
 pip install -e .[test,docs,check]
 pip install gravitybee
 gravitybee --with-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,14 +31,15 @@ classifiers =
 [options]
 python_requires = >= 3.6
 install_requires =
-    requests
-    semantic_version
+    bs4
+    dataclasses;python_version<'3.7'
+    defusedxml
+    humanize
     patch>=1.16
     py7zr>=0.18.3
+    requests
+    semantic_version
     texttable
-    bs4
-    dataclasses;python_version<"3.7"
-    defusedxml
 setup_requires =
     setuptools-scm[toml]>=6.4
     setuptools>=61


### PR DESCRIPTION
* update build_standalone.bat to rename pyproject.toml to pyproject.toml.bak to ensure pip installs from setup.cfg
* update dependencies in `setup.cfg`