### PR TITLE
Use codeql-action@v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,9 +31,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL Action v1 will be deprecated in December 2022.

See deprecation warnings here: https://github.com/miurahr/aqtinstall/actions/runs/2895457936

See deprecation announcement here: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/