### PR TITLE
Patch *.la and *.pc files when they exist

### DIFF
--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -97,7 +97,7 @@ class Updater:
                 return True
         return False
 
-    def patch_pkgconfig(self, oldvalue, os_name):
+    def patch_pkgconfig(self, oldvalue: str, os_name: str):
         for pcfile in self.prefix.joinpath("lib", "pkgconfig").glob("*.pc"):
             self.logger.info("Patching {}".format(pcfile))
             self._patch_textfile(
@@ -112,7 +112,7 @@ class Updater:
                     "-F{}".format(os.path.join(str(self.prefix), "lib")),
                 )
 
-    def patch_libtool(self, oldvalue, os_name):
+    def patch_libtool(self, oldvalue: str, os_name: str):
         for lafile in self.prefix.joinpath("lib").glob("*.la"):
             self.logger.info("Patching {}".format(lafile))
             self._patch_textfile(
@@ -256,6 +256,15 @@ class Updater:
             prefix = base_path / version_dir / arch_dir
             updater = Updater(prefix, logger)
             updater.set_license(base_dir, version_dir, arch_dir)
+
+            # Patch all pkgconfig and libtool files, if they exist
+            if target.os_name == "linux":
+                updater.patch_pkgconfig("/home/qt/work/install", target.os_name)
+                updater.patch_libtool("/home/qt/work/install/lib", target.os_name)
+            elif target.os_name == "mac":
+                updater.patch_pkgconfig("/Users/qt/work/install", target.os_name)
+                updater.patch_libtool("/Users/qt/work/install/lib", target.os_name)
+
             if target.arch not in [
                 "ios",
                 "android",
@@ -267,13 +276,7 @@ class Updater:
             ]:  # desktop version
                 updater.make_qtconf(base_dir, version_dir, arch_dir)
                 updater.patch_qmake()
-                if target.os_name == "linux":
-                    updater.patch_pkgconfig("/home/qt/work/install", target.os_name)
-                    updater.patch_libtool("/home/qt/work/install/lib", target.os_name)
-                elif target.os_name == "mac":
-                    updater.patch_pkgconfig("/Users/qt/work/install", target.os_name)
-                    updater.patch_libtool("/Users/qt/work/install/lib", target.os_name)
-                elif target.os_name == "windows":
+                if target.os_name == "windows":
                     updater.make_qtenv2(base_dir, version_dir, arch_dir)
                 if version < Version("5.14.0"):
                     updater.patch_qtcore(target)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -614,7 +614,7 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                         filename_7z="qtbase-linux-android_arm64_v8a.7z",
                         update_xml_name="qt.qt6.630.android_arm64_v8a",
                         contents=(
-                            # Qt 6 non-desktop should patch qconfig.pri, qmake script and target_qt.conf
+                            # Qt 6 non-desktop should patch qconfig.pri, qmake script, target_qt.conf, and pkgconfig/*.pc
                             PatchedFile(
                                 filename="mkspecs/qconfig.pri",
                                 unpatched_content="... blah blah blah ...\n"
@@ -644,6 +644,16 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                                 "{base_dir}/6.3.0/gcc_64/bin\n"
                                 "... blah blah blah ...\n",
                             ),
+                            PatchedFile(
+                                filename="lib/pkgconfig/Qt5Core_armeabi-v7a.pc",
+                                unpatched_content="prefix=/home/qt/work/install\n... blah blah blah ...\n",
+                                patched_content="prefix={base_dir}/6.3.0/android_arm64_v8a\n... blah blah blah ...\n",
+                            ),
+                            PatchedFile(
+                                filename="lib/libQt5Core_armeabi-v7a.la",
+                                unpatched_content="libdir='=/home/qt/work/install/lib'\n... blah blah blah ...\n",
+                                patched_content="libdir='={base_dir}/6.3.0/android_arm64_v8a/lib'\n... blah blah blah ...\n",
+                            ),
                         ),
                     ),
                 ]
@@ -655,6 +665,8 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 r"          `aqt install-qt linux desktop 6\.3\.0 gcc_64`\n"
                 r"INFO    : Downloading qtbase...\n"
                 r"Finished installation of qtbase-linux-android_arm64_v8a.7z in .*\n"
+                r"INFO    : Patching .*6\.3\.0[/\\]android_arm64_v8a[/\\]lib[/\\]pkgconfig[/\\]Qt5Core_armeabi-v7a\.pc\n"
+                r"INFO    : Patching .*6\.3\.0[/\\]android_arm64_v8a[/\\]lib[/\\]libQt5Core_armeabi-v7a\.la\n"
                 r"INFO    : Patching .*6\.3\.0[/\\]android_arm64_v8a[/\\]bin[/\\]qmake\n"
                 r"INFO    : Finished installation\n"
                 r"INFO    : Time elapsed: .* second"


### PR DESCRIPTION
Fix #560

This patches all files in lib/pkgconfig/*.pc and lib/*.la, on all targets, when those files exist. This will only apply to Linux and Mac hosts; I'm not sure that these files exist on Windows.

Before making this change, you could run this to count unpatched instances of "/Users/qt/work/install":
```console
$ python -m aqt install-qt mac android 5.15.2 android
$ grep "/Users/qt/work/install" 5.15.2/android/**/* 2>/dev/null | wc -l
779
```
After making this change, the number of unpatched instances of "/Users/qt/work/install" drops from 779 to 13:
* 5/13 remaining unpatched files are binary shared objects; we probably should not touch those.
* 8/13 remaining unpatched instances are in the lib/pkgconfig/*.pc files; here's an example in Qt5OpenGLExtensions_x86.pc: `Libs.private: /Users/qt/work/install/lib/libQt5Gui_x86.so /Users/qt/work/install/lib/libQt5Core_x86.so -lGLESv2  -llog -lz -lm -ldl -lc`

I'm not sure what to do about the remaining unpatched .pc files yet.