### PR TITLE
Drop support for python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Requirements
 ------------
 
 - Minimum Python version:
-    3.6
+    3.7
 
 - Recommended Python version:
     3.9 (frequently tested on)
@@ -66,7 +66,6 @@ Requirements
     py7zr
     texttable
     bs4
-    dataclasses; python_version < "3.7"
     defusedxml
 
 - Operating Systems:

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -35,7 +35,7 @@ from logging import getLogger
 from logging.handlers import QueueHandler
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Tuple
 
 import aqt
 from aqt.archives import QtArchives, QtPackage, SrcDocExamplesArchives, TargetConfig, ToolArchives

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,16 +8,15 @@ Installation
 Requirements
 ------------
 
-- Minimum Python version:  3.6
-- Recommended Python version: 3.7.5 or later
+- Minimum Python version:  3.7.5
 
-- Dependent libraries: requests, py7zr, semantic_version, patch, texttable, bs4
+- Dependencies: requests, py7zr, semantic_version, patch, texttable, bs4, defusedxml, humanize
 
 
 Install by pip command
 ----------------------
 
-Same as usual, it can be installed with `pip`
+Same as usual, it can be installed with ``pip``
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,9 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
     "bs4",
-    "dataclasses;python_version<'3.7'",
     "defusedxml",
     "humanize",
     "patch>=1.16",
@@ -109,7 +108,7 @@ exclude_lines = ["if __name__ == .__main__.:", "pragma: no-cover", "@abstract", 
 
 [tool.black]
 line-length = 125
-target-version = ['py38']
+target-version = ['py39']
 
 [tool.isort]
 line_length = 125
@@ -142,7 +141,7 @@ markers = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = check, docs, py{36,37,38,39,310,311}, py39d, mprof, fil
+envlist = check, docs, py{37,38,39,310,311}, py39d, mprof, fil
 isolated_build = True
 
 [testenv]
@@ -207,7 +206,6 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
     3.8: py38, docs, check
     3.9: py39
     3.10: py310


### PR DESCRIPTION
It is not mandatory, but we will drop support for python 3.6 in future.
