### PR TITLE
Actions: bump versions

### DIFF
--- a/.github/workflows/check-combinations.yml
+++ b/.github/workflows/check-combinations.yml
@@ -26,10 +26,11 @@ jobs:
         branchtomerge: "origin/master"
         branch: "update-combinations"
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.9'
+        cache: 'pip'
 
     - name: Build and install
       run: |

--- a/.github/workflows/check-combinations.yml
+++ b/.github/workflows/check-combinations.yml
@@ -30,7 +30,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-        cache: 'pip'
 
     - name: Build and install
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-        cache: 'pip'
     - name: Install tools
       run: |
         pip install -U pip

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,9 +21,10 @@ jobs:
         fetch-depth: 20
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.9'
+        cache: 'pip'
     - name: Install tools
       run: |
         pip install -U pip

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,9 +21,10 @@ jobs:
       - name: Fetch release tag
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python 3.7🐍
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.9'
+          cache: 'pip'
       - name: Install build and twine
         run: python -m pip install build twine --user
       - name: Build release assets
@@ -32,12 +33,12 @@ jobs:
         run: python -m twine check dist/*
       - name: Publish distribution 📦 to Test PyPI when releases branch
         if: ${{ startsWith(github.event.ref, 'refs/heads/releases') }}
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.testpypi_password }}
           repository_url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: ${{ startsWith(github.event.ref, 'refs/tags') }}
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-          cache: 'pip'
       - name: Install build and twine
         run: python -m pip install build twine --user
       - name: Build release assets

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py }}
-          cache: 'pip'
       - name: Run pytest
         run: |
           python -m pip install tox-gh-actions build

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -30,9 +30,10 @@ jobs:
           fetch-depth: 20
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py }}
+          cache: 'pip'
       - name: Run pytest
         run: |
           python -m pip install tox-gh-actions build

--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -1,10 +1,10 @@
-# This will only run automatically when releases have been created, 
+# This will only run automatically when releases have been created,
 # and will only upload binaries to previously-created releases.
 # When run manually, it will overwrite the previous reelease binary
 
 name: Upload release artifacts
 
-on: 
+on:
   release:
     types:
       - created
@@ -24,11 +24,11 @@ jobs:
           fetch-depth: 20
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py }}
           architecture: ${{ matrix.arch }}
-
+          cache: 'pip'
       - name: Build standalone binary
         run: |
           python -m venv venv
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload to Release
         uses: svenstaro/upload-release-action@v2
-        with: 
+        with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: .gravitybee\dist\latest\aqt.exe
           tag: ${{ github.ref }}
@@ -49,12 +49,11 @@ jobs:
 
       - name: Upload to Release for all architectures
         uses: svenstaro/upload-release-action@v2
-        with: 
+        with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: .gravitybee\dist\latest\aqt_${{ matrix.arch }}.exe
           tag: ${{ github.ref }}
           overwrite: true
-          
       - name: Update continuous build
         uses: svenstaro/upload-release-action@v2
         with:
@@ -64,7 +63,6 @@ jobs:
           tag: Continuous
           file: .gravitybee\dist\latest\aqt.exe
         if: matrix.arch=='x64'
-          
       - name: Update continuous build for all architectures
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
           architecture: ${{ matrix.arch }}
-          cache: 'pip'
       - name: Build standalone binary
         run: |
           python -m venv venv


### PR DESCRIPTION
- actions/setup-python@v4
- Use pypa/gh-action-pypi-publish@v1 this fix a warning: You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes.
- Change line-end terminator to LF for upload-release-artifacts.yml

Signed-off-by: Hiroshi Miura <miurahr@linux.com>