### PR TITLE
Bump flake8-isort@>=4.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ check = [
     "flake8<5",
     "flake8-black",
     "flake8-colors",
-    "flake8-isort",
+    "flake8-isort>=4.2.0",
     "flake8-pyi",
     "flake8-typing-imports",
     "docutils",


### PR DESCRIPTION
flake8-isort 4.2.0 supports flake8 version 5

Signed-off-by: Hiroshi Miura <miurahr@linux.com>