### PR TITLE
improve link to report issue

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -121,7 +121,7 @@ class Cli:
                 f"Arguments: `{sys.argv}` Host: `{platform.uname()}`\n"
                 "===========================PLEASE FILE A BUG REPORT===========================\n"
                 "You have discovered a bug in aqt.\n"
-                "Please file a bug report at https://github.com/miurahr/aqtinstall/issues.\n"
+                "Please file a bug report at https://github.com/miurahr/aqtinstall/issues\n"
                 "Please remember to include a copy of this program's output in your report."
             )
             return Cli.UNHANDLED_EXCEPTION_CODE


### PR DESCRIPTION
When we print the link with trailing dot, some automatic log-formaters will add that dot to the link itself.
E.g. when you use Github Actions this link will show up with extra dot and therefore does not work.
By removing the dot, the link is functional also in these cases.