### PR TITLE
Pass settings.ini file path to child process

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -496,6 +496,5 @@ Settings = SettingsClass()
 def setup_logging(env_key="LOG_CFG"):
     config = os.getenv(env_key, None)
     if config is not None and os.path.exists(config):
-        logging.config.fileConfig(config)
-    else:
-        logging.config.fileConfig(Settings.loggingconf)
+        Settings.loggingconf = config
+    logging.config.fileConfig(Settings.loggingconf)

--- a/ci/settings.ini
+++ b/ci/settings.ini
@@ -9,7 +9,10 @@ baseurl: https://download.qt.io
 connection_timeout: 30
 response_timeout: 30
 max_retries: 5
+max_retries_on_connection_error: 5
 retry_backoff: 0.1
+max_retries_on_checksum_error: 5
+max_retries_to_retrieve_hash: 5
 
 [mirrors]
 blacklist:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1215,6 +1215,8 @@ def test_install_installer_archive_extraction_err(monkeypatch):
             command="some_nonexistent_7z_extractor",
             queue=MockMultiprocessingManager.Queue(),
             archive_dest=Path(temp_dir),
+            settings_ini=Settings.configfile,
+            keep=False,
         )
     assert err.type == ArchiveExtractionError
     err_msg = format(err.value).rstrip()


### PR DESCRIPTION
- Change Settings class as Borg
- Pass settings values for multiprocessing target function `installer` as arguments
- Avoid loading Settings in `installer` process
- Fix #609 