### PR TITLE
Pin checkout at `v3` in all workflows

### DIFF
--- a/.github/workflows/check-combinations.yml
+++ b/.github/workflows/check-combinations.yml
@@ -14,7 +14,7 @@ jobs:
   check_combinations:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 20
       

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check packaging 📦
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 20
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Fetch release tag

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -7,7 +7,7 @@ jobs:
   create-release-notes:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Create Release Notes
       uses: docker://decathlon/release-notes-generator-action:2.0.0
       env:

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -25,7 +25,7 @@ jobs:
             py: "3.10"
             qtver: 6.1.0
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 20
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -19,7 +19,7 @@ jobs:
         py: [3.9]
         arch: [x86, x64]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 20
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*


### PR DESCRIPTION
This fixes some CI warnings about using obsolete versions of NodeJS. NodeJS 12 (from `actions/checkout@2`) is at EOL, and CI warnings recommend using NodeJS 16. The docs for actions/checkout recommend pinning at v3.

Some of these workflows were using `checkout@master`, and were thereby already using NodeJS 16. I'm not sure that it's necessary to use v3 for these instead of master. However, the docs suggest using v3. If at some point the authors decide to rename the `master` branch to `main`, then we may be glad we made this change.