### PR TITLE
Add tests for sdktool: install-tool and list-tool

### DIFF
--- a/tests/data/linux-desktop-expect.json
+++ b/tests/data/linux-desktop-expect.json
@@ -79,6 +79,7 @@
     "tools_ifw",
     "tools_generic",
     "tools_conan",
-    "tools_cmake"
+    "tools_cmake",
+    "sdktool"
   ]
 }

--- a/tests/data/linux-desktop.html
+++ b/tests/data/linux-desktop.html
@@ -38,6 +38,7 @@
 <tr><td valign="top">&nbsp;</td><td><a href="tools_generic/">tools_generic/</a></td><td align="right">13-Apr-2021 14:39  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="tools_conan/">tools_conan/</a></td><td align="right">15-Feb-2021 12:14  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="tools_cmake/">tools_cmake/</a></td><td align="right">07-Jan-2021 14:22  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="sdktool/">sdktool/</a></td><td align="right">05-May-2023 10:53  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_wasm_singlethread/">qt6_650_wasm_singlethread/</a></td><td align="right">01-Jan-2023 00:00 </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_wasm_multithread/">qt6_650_wasm_multithread/</a></td><td align="right">01-Jan-2023 00:00   </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_src_doc_examples/">qt6_650_src_doc_examples/</a></td><td align="right">01-Jan-2023 00:00   </td><td align="right">  - </td><td>&nbsp;</td></tr>

--- a/tests/data/mac-desktop-expect.json
+++ b/tests/data/mac-desktop-expect.json
@@ -80,6 +80,7 @@
     "tools_ifw",
     "tools_generic",
     "tools_conan",
-    "tools_cmake"
+    "tools_cmake",
+    "sdktool"
   ]
 }

--- a/tests/data/mac-desktop-sdktool-expect.json
+++ b/tests/data/mac-desktop-sdktool-expect.json
@@ -1,0 +1,14 @@
+{
+  "modules": [
+    "qt.tools.qtcreator"
+  ],
+  "long_listing": [
+    [
+      "qt.tools.qtcreator",
+      "10.0.1-0-202305050734",
+      "2023-05-05",
+      "SDKTool",
+      "SDKTool"
+    ]
+  ]
+}

--- a/tests/data/mac-desktop-sdktool-update.xml
+++ b/tests/data/mac-desktop-sdktool-update.xml
@@ -1,0 +1,20 @@
+<Updates>
+ <ApplicationName>{AnyApplication}</ApplicationName>
+ <ApplicationVersion>1.0.0</ApplicationVersion>
+ <Checksum>true</Checksum>
+ <PackageUpdate>
+  <Name>qt.tools.qtcreator</Name>
+  <DisplayName>SDKTool</DisplayName>
+  <Description>SDKTool</Description>
+  <Version>10.0.1-0-202305050734</Version>
+  <ReleaseDate>2023-05-05</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <Virtual>true</Virtual>
+  <ForcedInstallation>true</ForcedInstallation>
+  <DownloadableArchives>qtcreator_sdktool.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="1821889" UncompressedSize="6058248" OS="Any"/>
+  <SHA1>450d20347716f794124272a38d7cf46df9c50169</SHA1>
+ </PackageUpdate>
+ <SHA1>c6d6c9ff8b3c0a75f1bb1804eb4955a6409ac867</SHA1>
+ <MetadataName>2023-05-05-0734_meta.7z</MetadataName>
+</Updates>

--- a/tests/data/mac-desktop.html
+++ b/tests/data/mac-desktop.html
@@ -38,6 +38,7 @@
 <tr><td valign="top">&nbsp;</td><td><a href="tools_generic/">tools_generic/</a></td><td align="right">13-Apr-2021 14:39  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="tools_conan/">tools_conan/</a></td><td align="right">15-Feb-2021 12:15  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="tools_cmake/">tools_cmake/</a></td><td align="right">07-Jan-2021 14:22  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="sdktool/">sdktool/</a></td><td align="right">05-May-2023 10:53  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_wasm_singlethread/">qt6_650_wasm_singlethread/</a></td><td align="right">01-Jan-2023 00:00 </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_wasm_multithread/">qt6_650_wasm_multithread/</a></td><td align="right">01-Jan-2023 00:00   </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_src_doc_examples/">qt6_650_src_doc_examples/</a></td><td align="right">01-Jan-2023 00:00   </td><td align="right">  - </td><td>&nbsp;</td></tr>

--- a/tests/data/windows-desktop-expect.json
+++ b/tests/data/windows-desktop-expect.json
@@ -91,6 +91,7 @@
     "tools_ifw",
     "tools_generic",
     "tools_conan",
-    "tools_cmake"
+    "tools_cmake",
+    "sdktool"
   ]
 }

--- a/tests/data/windows-desktop.html
+++ b/tests/data/windows-desktop.html
@@ -43,6 +43,7 @@
 <tr><td valign="top">&nbsp;</td><td><a href="tools_generic/">tools_generic/</a></td><td align="right">13-Apr-2021 14:39  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="tools_conan/">tools_conan/</a></td><td align="right">15-Feb-2021 12:15  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="tools_cmake/">tools_cmake/</a></td><td align="right">07-Jan-2021 14:22  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="sdktool/">sdktool/</a></td><td align="right">05-May-2023 10:53  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_wasm_singlethread/">qt6_650_wasm_singlethread/</a></td><td align="right">01-Jan-2023 00:00 </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_wasm_multithread/">qt6_650_wasm_multithread/</a></td><td align="right">01-Jan-2023 00:00   </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="qt6_650_src_doc_examples/">qt6_650_src_doc_examples/</a></td><td align="right">01-Jan-2023 00:00   </td><td align="right">  - </td><td>&nbsp;</td></tr>

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -312,6 +312,23 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
             ),
         ),
         (
+            "install-tool linux desktop sdktool qt.tools.qtcreator".split(),
+            "linux",
+            "desktop",
+            "10.0.1-0-202305050734",
+            {"std": ""},
+            {"std": ""},
+            {"std": "linux_x64/desktop/sdktool/Updates.xml"},
+            {"std": [tool_archive("linux", "sdktool", "qt.tools.qtcreator")]},
+            re.compile(
+                r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
+                r"INFO    : Downloading qt.tools.qtcreator...\n"
+                r"Finished installation of sdktool-linux-qt.tools.qtcreator.7z in .*\n"
+                r"INFO    : Finished installation\n"
+                r"INFO    : Time elapsed: .* second"
+            ),
+        ),
+        (
             "tool linux tools_qtcreator 1.2.3-0-197001020304 qt.tools.qtcreator".split(),
             "linux",
             "desktop",


### PR DESCRIPTION
This adds a few tests for the new functionality added in #677.

This probably won't change our code coverage stats much, if at all. However, I am certain that if we don't have these tests, any attempt to refactor existing code in metadata.py or installer.py will break all the functionality added in #677.