### PR TITLE
Add `ignore_hash` option in `settings.ini`

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -27,7 +27,7 @@ from xml.etree.ElementTree import Element  # noqa
 
 from defusedxml import ElementTree
 
-from aqt.exceptions import ArchiveDownloadError, ArchiveListError, NoPackageFound
+from aqt.exceptions import ArchiveDownloadError, ArchiveListError, ChecksumDownloadFailure, NoPackageFound
 from aqt.helper import Settings, get_hash, getUrl, ssplit
 from aqt.metadata import QtRepoProperty, Version
 
@@ -390,7 +390,16 @@ class QtArchives:
 
     def _download_update_xml(self, update_xml_path):
         """Hook for unit test."""
-        xml_hash = get_hash(update_xml_path, Settings.hash_algorithm, self.timeout) if not Settings.ignore_hash else None
+        if not Settings.ignore_hash:
+            try:
+                xml_hash = get_hash(update_xml_path, Settings.hash_algorithm, self.timeout)
+            except ChecksumDownloadFailure:
+                self.logger.warning(
+                    "Failed to download checksum for the file 'Updates.xml'. This may happen on unofficial mirrors."
+                )
+                xml_hash = None
+        else:
+            xml_hash = None
         return getUrl(posixpath.join(self.base, update_xml_path), self.timeout, xml_hash)
 
     def _parse_update_xml(self, os_target_folder, update_xml_text, target_packages: Optional[ModuleToPackage]):

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -390,7 +390,7 @@ class QtArchives:
 
     def _download_update_xml(self, update_xml_path):
         """Hook for unit test."""
-        xml_hash = get_hash(update_xml_path, "sha256", self.timeout) if not Settings.ignore_hash else None
+        xml_hash = get_hash(update_xml_path, Settings.hash_algorithm, self.timeout) if not Settings.ignore_hash else None
         return getUrl(posixpath.join(self.base, update_xml_path), self.timeout, xml_hash)
 
     def _parse_update_xml(self, os_target_folder, update_xml_text, target_packages: Optional[ModuleToPackage]):

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -390,8 +390,7 @@ class QtArchives:
 
     def _download_update_xml(self, update_xml_path):
         """Hook for unit test."""
-        check_hash = not Settings.ignore_updates_hash
-        xml_hash = get_hash(update_xml_path, "sha256", self.timeout) if check_hash else None
+        xml_hash = get_hash(update_xml_path, "sha256", self.timeout) if not Settings.ignore_hash else None
         return getUrl(posixpath.join(self.base, update_xml_path), self.timeout, xml_hash)
 
     def _parse_update_xml(self, os_target_folder, update_xml_text, target_packages: Optional[ModuleToPackage]):

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -94,7 +94,14 @@ def getUrl(url: str, timeout: Tuple[float, float], expected_hash: Optional[bytes
                 raise ArchiveDownloadError(msg)
         result: str = r.text
         filename = url.split("/")[-1]
-        actual_hash = hashlib.sha256(bytes(result, "utf-8")).digest()
+        if Settings.hash_algorithm == "sha256":
+            actual_hash = hashlib.sha256(bytes(result, "utf-8")).digest()
+        elif Settings.hash_algorithm == "sha1":
+            actual_hash = hashlib.sha1(bytes(result, "utf-8")).digest()
+        elif Settings.hash_algorithm == "md5":
+            actual_hash = hashlib.md5(bytes(result, "utf-8")).digest()
+        else:
+            raise ArchiveChecksumError(f"Unknown hash algorithm: {Settings.hash_algorithm}.\nPlease check settings.ini")
         if expected_hash is not None and expected_hash != actual_hash:
             raise ArchiveChecksumError(
                 f"Downloaded file {filename} is corrupted! Detect checksum error.\n"
@@ -455,6 +462,10 @@ class SettingsClass:
     @property
     def max_retries_to_retrieve_hash(self):
         return self.config.getint("requests", "max_retries_to_retrieve_hash", fallback=int(self.max_retries))
+
+    @property
+    def hash_algorithm(self):
+        return self.config.get("requests", "hash_algorithm", fallback="sha256")
 
     @property
     def ignore_hash(self):

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -112,7 +112,7 @@ def getUrl(url: str, timeout: Tuple[float, float], expected_hash: Optional[bytes
     return result
 
 
-def downloadBinaryFile(url: str, out: Path, hash_algo: str, exp: bytes, timeout: Tuple[float, float]) -> None:
+def downloadBinaryFile(url: str, out: Path, hash_algo: str, exp: Optional[bytes], timeout: Tuple[float, float]) -> None:
     logger = getLogger("aqt.helper")
     filename = Path(url).name
     with requests.sessions.Session() as session:

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -457,8 +457,8 @@ class SettingsClass:
         return self.config.getint("requests", "max_retries_to_retrieve_hash", fallback=int(self.max_retries))
 
     @property
-    def ignore_updates_hash(self):
-        return self.config.getboolean("requests", "ignore_updates_hash", fallback=False)
+    def ignore_hash(self):
+        return self.config.getboolean("requests", "ignore_hash", fallback=False)
 
     @property
     def backoff_factor(self):

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -458,7 +458,7 @@ class SettingsClass:
 
     @property
     def ignore_hash(self):
-        return self.config.getboolean("requests", "ignore_hash", fallback=False)
+        return self.config.getboolean("requests", "INSECURE_NOT_FOR_PRODUCTION_ignore_hash", fallback=False)
 
     @property
     def backoff_factor(self):

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1209,7 +1209,7 @@ def installer(
     logger.addHandler(qh)
     #
     timeout = (Settings.connection_timeout, Settings.response_timeout)
-    hash = get_hash(qt_package.archive_path, algorithm="sha256", timeout=timeout)
+    hash = get_hash(qt_package.archive_path, algorithm="sha256", timeout=timeout) if not Settings.ignore_hash else None
 
     def download_bin(_base_url):
         url = posixpath.join(_base_url, qt_package.archive_path)

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1209,12 +1209,12 @@ def installer(
     logger.addHandler(qh)
     #
     timeout = (Settings.connection_timeout, Settings.response_timeout)
-    hash = get_hash(qt_package.archive_path, algorithm="sha256", timeout=timeout) if not Settings.ignore_hash else None
+    hash = get_hash(qt_package.archive_path, Settings.hash_algorithm, timeout) if not Settings.ignore_hash else None
 
     def download_bin(_base_url):
         url = posixpath.join(_base_url, qt_package.archive_path)
         logger.debug("Download URL: {}".format(url))
-        return downloadBinaryFile(url, archive, "sha256", hash, timeout)
+        return downloadBinaryFile(url, archive, Settings.hash_algorithm, hash, timeout)
 
     retry_on_errors(
         action=lambda: retry_on_bad_connection(download_bin, base_url),

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -540,7 +540,6 @@ class MetadataFactory:
         self.archive_id = archive_id
         self.spec = spec
         self.base_url = base_url
-        self.ignore_updates_hash = Settings.ignore_updates_hash
 
         if archive_id.is_tools():
             if tool_name is not None:
@@ -785,7 +784,7 @@ class MetadataFactory:
 
     def _fetch_module_metadata(self, folder: str, predicate: Optional[Callable[[Element], bool]] = None):
         rest_of_url = posixpath.join(self.archive_id.to_url(), folder, "Updates.xml")
-        xml = self.fetch_http(rest_of_url, is_check_hash=not self.ignore_updates_hash)
+        xml = self.fetch_http(rest_of_url) if not Settings.ignore_hash else self.fetch_http(rest_of_url, False)
         return xml_to_modules(
             xml,
             predicate=predicate if predicate else MetadataFactory._has_nonempty_downloads,

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -699,7 +699,7 @@ class MetadataFactory:
 
     def fetch_http(self, rest_of_url: str, is_check_hash: bool = True) -> str:
         timeout = (Settings.connection_timeout, Settings.response_timeout)
-        expected_hash = get_hash(rest_of_url, "sha256", timeout) if is_check_hash else None
+        expected_hash = get_hash(rest_of_url, Settings.hash_algorithm, timeout) if is_check_hash else None
         base_urls = self.base_url, random.choice(Settings.fallbacks)
 
         err: BaseException = AssertionError("unraisable")

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -16,7 +16,7 @@ max_retries_on_connection_error: 5
 retry_backoff: 0.1
 max_retries_on_checksum_error: 5
 max_retries_to_retrieve_hash: 5
-ignore_updates_hash: False
+ignore_hash: False
 
 [mirrors]
 trusted_mirrors:

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -16,6 +16,7 @@ max_retries_on_connection_error: 5
 retry_backoff: 0.1
 max_retries_on_checksum_error: 5
 max_retries_to_retrieve_hash: 5
+hash_algorithm: sha256
 INSECURE_NOT_FOR_PRODUCTION_ignore_hash: False
 
 [mirrors]

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -16,6 +16,7 @@ max_retries_on_connection_error: 5
 retry_backoff: 0.1
 max_retries_on_checksum_error: 5
 max_retries_to_retrieve_hash: 5
+ignore_updates_hash: False
 
 [mirrors]
 trusted_mirrors:

--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -16,7 +16,7 @@ max_retries_on_connection_error: 5
 retry_backoff: 0.1
 max_retries_on_checksum_error: 5
 max_retries_to_retrieve_hash: 5
-ignore_hash: False
+INSECURE_NOT_FOR_PRODUCTION_ignore_hash: False
 
 [mirrors]
 trusted_mirrors:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,6 +31,7 @@ A file is like as follows:
     retry_backoff: 0.1
     max_retries_on_checksum_error: 5
     max_retries_to_retrieve_hash: 5
+    hash_algorithm: sha256
     INSECURE_NOT_FOR_PRODUCTION_ignore_hash: False
 
     [mirrors]
@@ -130,6 +131,10 @@ retry_backoff:
 max_retries_on_checksum_error:
     This setting controls how many times ``aqt`` will attempt to download a file,
     in the case of a checksum error.
+
+hash_algorithm:
+    This is either ``sha256``, ``sha1`` or ``md5``. ``sha256`` is the only safe 
+    value to use here. See also ``trusted_mirrors`` setting.
 
 INSECURE_NOT_FOR_PRODUCTION_ignore_hash:
     This is either ``True`` or ``False``.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,6 +31,7 @@ A file is like as follows:
     retry_backoff: 0.1
     max_retries_on_checksum_error: 5
     max_retries_to_retrieve_hash: 5
+    INSECURE_NOT_FOR_PRODUCTION_ignore_hash: False
 
     [mirrors]
     trusted_mirrors:
@@ -129,6 +130,13 @@ retry_backoff:
 max_retries_on_checksum_error:
     This setting controls how many times ``aqt`` will attempt to download a file,
     in the case of a checksum error.
+
+INSECURE_NOT_FOR_PRODUCTION_ignore_hash:
+    This is either ``True`` or ``False``.
+    The ``True`` setting disables hash checking when downloading files. Although
+    this is not recommended, this may help when hashes are not available.
+    The ``False`` setting will enforce hash checking. This is highly recommended
+    to avoid corrupted files.
 
 
 The ``[mirrors]`` section is a configuration for mirror handling.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -134,7 +134,8 @@ max_retries_on_checksum_error:
 
 hash_algorithm:
     This is either ``sha256``, ``sha1`` or ``md5``. ``sha256`` is the only safe 
-    value to use here. See also ``trusted_mirrors`` setting.
+    value to use here. Default is ``sha256`` if not set.
+    See also ``trusted_mirrors`` setting.
 
 INSECURE_NOT_FOR_PRODUCTION_ignore_hash:
     This is either ``True`` or ``False``.


### PR DESCRIPTION
Based on the work of @mardy and as a quick workaround for some problems described in #521 and #224, here is a proposition to add `ignore_hash` option in `settings.ini`. When set to `True`, `sha256` hashes would not be checked.