### PR TITLE
fix: remove a mirror that can be error

### DIFF
--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -27,7 +27,6 @@ blacklist:
 fallbacks:
     https://qtproject.mirror.liquidtelecom.com/
     https://mirrors.aliyun.com/qt/
-    https://mirrors.sjtug.sjtu.edu.cn/qt/
     https://mirrors.ustc.edu.cn/qtproject/
     https://ftp.jaist.ac.jp/pub/qtproject/
     https://ftp.yz.yamagata-u.ac.jp/pub/qtproject/


### PR DESCRIPTION
- remove https://mirrors.sjtug.sjtu.edu.cn/qt/ from fallbacks
- Adjust from report #687