### PR TITLE
Log a warning when aqtinstall falls back to an external 7z extraction tool

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -233,10 +233,11 @@ class Cli:
             "This may not install properly, but we will try our best."
         )
 
-    def _set_sevenzip(self, external: Optional[str], fallback: str, is_p7zr_missing: bool) -> Optional[str]:
+    def _set_sevenzip(self, external: Optional[str]) -> Optional[str]:
         sevenzip = external
+        fallback = Settings.zipcmd
         if not sevenzip:
-            if is_p7zr_missing:
+            if EXT7Z:
                 self.logger.warning(f"The py7zr module failed to load. Falling back to '{fallback}' for .7z extraction.")
                 self.logger.warning(f"You can use the  '--external | -E' flags to select your own extraction tool.")
                 sevenzip = fallback
@@ -363,9 +364,6 @@ class Cli:
             timeout = (Settings.connection_timeout, Settings.response_timeout)
         modules = args.modules
         sevenzip = self._set_sevenzip(args.external)
-        if EXT7Z and sevenzip is None:
-            # override when py7zr is not exist
-            sevenzip = self._set_sevenzip("7z")
         if args.base is not None:
             if not self._check_mirror(args.base):
                 raise CliInputError(
@@ -480,9 +478,6 @@ class Cli:
         else:
             timeout = (Settings.connection_timeout, Settings.response_timeout)
         sevenzip = self._set_sevenzip(args.external)
-        if EXT7Z and sevenzip is None:
-            # override when py7zr is not exist
-            sevenzip = self._set_sevenzip(Settings.zipcmd)
         modules = getattr(args, "modules", None)  # `--modules` is invalid for `install-src`
         archives = args.archives
         all_extra = True if modules is not None and "all" in modules else False
@@ -554,9 +549,6 @@ class Cli:
         else:
             base_dir = output_dir
         sevenzip = self._set_sevenzip(args.external)
-        if EXT7Z and sevenzip is None:
-            # override when py7zr is not exist
-            sevenzip = self._set_sevenzip(Settings.zipcmd)
         version = getattr(args, "version", None)
         if version is not None:
             Cli._validate_version_str(version, allow_minus=True)

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -236,7 +236,7 @@ class Cli:
     def _set_sevenzip(self, external: Optional[str]) -> Optional[str]:
         sevenzip = external
         fallback = Settings.zipcmd
-        if not sevenzip:
+        if sevenzip is None:
             if EXT7Z:
                 self.logger.warning(f"The py7zr module failed to load. Falling back to '{fallback}' for .7z extraction.")
                 self.logger.warning(f"You can use the  '--external | -E' flags to select your own extraction tool.")

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -239,7 +239,7 @@ class Cli:
         if sevenzip is None:
             if EXT7Z:
                 self.logger.warning(f"The py7zr module failed to load. Falling back to '{fallback}' for .7z extraction.")
-                self.logger.warning(f"You can use the  '--external | -E' flags to select your own extraction tool.")
+                self.logger.warning("You can use the  '--external | -E' flags to select your own extraction tool.")
                 sevenzip = fallback
             else:
                 # Just use py7zr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import re
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 import pytest
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -388,6 +388,7 @@ def test_set_7zip_checks_external_tool_when_specified(monkeypatch, capsys, exter
     cli = Cli()
     cli._setup_settings()
     external = "my_7z_extractor"
+
     def mock_subprocess_run(args, **kwargs):
         assert args[0] == external
         if not external_tool_exists:
@@ -401,7 +402,7 @@ def test_set_7zip_checks_external_tool_when_specified(monkeypatch, capsys, exter
         with pytest.raises(CliInputError) as err:
             cli._set_sevenzip(external)
         assert format(err.value) == format(f"Specified 7zip command executable does not exist: '{external}'")
-    assert capsys.readouterr()[1] == ''
+    assert capsys.readouterr()[1] == ""
 
 
 @pytest.mark.parametrize("fallback_exists", (True, False))
@@ -409,6 +410,7 @@ def test_set_7zip_uses_fallback_when_py7zr_missing(monkeypatch, capsys, fallback
     cli = Cli()
     cli._setup_settings()
     external, fallback = None, Settings.zipcmd
+
     def mock_subprocess_run(args, **kwargs):
         assert args[0] == fallback
         if not fallback_exists:
@@ -437,7 +439,7 @@ def test_set_7zip_chooses_p7zr_when_ext_missing(monkeypatch, capsys, fallback_ex
     monkeypatch.setattr("aqt.installer.subprocess.run", mock_subprocess_run)
     monkeypatch.setattr("aqt.installer.EXT7Z", False)
     assert cli._set_sevenzip(external) is None
-    assert capsys.readouterr()[1] == ''
+    assert capsys.readouterr()[1] == ""
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -383,15 +383,6 @@ def test_cli_unexpected_error(monkeypatch, capsys):
     )
 
 
-def test_cli_set_7zip_nonexistent(monkeypatch):
-    cli = Cli()
-    cli._setup_settings()
-    with pytest.raises(CliInputError) as err:
-        cli._set_sevenzip("some_nonexistent_binary")
-    assert err.type == CliInputError
-    assert format(err.value) == "Specified 7zip command executable does not exist: 'some_nonexistent_binary'"
-
-
 @pytest.mark.parametrize("external_tool_exists", (True, False))
 def test_set_7zip_checks_external_tool_when_specified(monkeypatch, capsys, external_tool_exists: bool):
     cli = Cli()


### PR DESCRIPTION
Inspired by https://github.com/miurahr/aqtinstall/issues/696#issuecomment-1651026317. That comment suggested a place to add a log message, but I was unable to log the message there without disregarding the user’s selected log settings, which are not available until the `Cli` object is built.

When `aqtinstall` fails to load the `py7zr` module, it falls back to whatever 7z extraction tool the user has specified in the `settings.ini` file, without notifying the user. This PR adds the following log message when that happens:

```
WARNING: The py7zr module failed to load. Falling back to '7z' for .7z extraction.
WARNING: You can use the  '--external | -E' flags to select your own extraction tool.
```

This PR also does a little refactoring of the `Cli._set_sevenzip` method to improve readability.

**Side effect**
There was an existing bug here, where the `install-qt` subcommand (but none of the other commands) would ignore the `7zcmd` parameter in the `settings.ini` file, and use the hardcoded `"7z"` instead. I'm pretty sure this was a bug; if not I can change it back.

https://github.com/miurahr/aqtinstall/blob/72da54f4b0156a1bbd0aea09c621992817f963f8/aqt/installer.py#L361-L363