### PR TITLE
Fix failing documentation builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ check = [
     "packaging",
 ]
 docs = [
-    "sphinx>=5.0",
-    "sphinx_rtd_theme",
+    "sphinx>=7.0",
+    "sphinx_rtd_theme>=1.3",
     "sphinx-py3doc-enhanced-theme",
 ]
 


### PR DESCRIPTION
There's a version resolution issue with sphinx and sphinx_rtd_theme; sphinx_rtd_theme just added support for sphinx 7 last week. For some reason, recent docs builds are installing sphinx<2 and sphinx_rtd_theme<0.5, and then installing and running sphinx 7.2.3 and running it with sphinx_rtd_theme 0.4.3.

The version mismatch causes this exception, causing the build to fail:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/cmd/build.py", line 298, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/application.py", line 355, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 293, in build_update
    self.build(to_build,
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 363, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 571, in write
    self._write_serial(sorted(docnames))
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 581, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 655, in write_doc
    self.handle_page(docname, ctx, event_arg=doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/aqtinstall/envs/705/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 1128, in handle_page
    raise ThemeError(__("An error happened in rendering the page %s.\nReason: %r") %
sphinx.errors.ThemeError: An error happened in rendering the page CHANGELOG.
Reason: UndefinedError("'style' is undefined")

Theme error:
An error happened in rendering the page CHANGELOG.
Reason: UndefinedError("'style' is undefined")
```
Link to example build from #705: https://readthedocs.org/projects/aqtinstall/builds/21735283/

Hopefully, requesting newer versions in the pyproject.toml file will fix this.

Failing build that pairs sphinx 7 with sphinx_rtd_theme 0.4.3: https://readthedocs.org/projects/aqtinstall/builds/21735283/