### PR TITLE
Use 'tar' filter when extracting tarfiles

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1226,7 +1226,12 @@ def installer(
 
     if tarfile.is_tarfile(archive):
         with tarfile.open(archive) as tar_archive:
-            tar_archive.extractall(path=base_dir)
+            if hasattr(tarfile, "data_filter"):
+                tar_archive.extractall(filter="tar", path=base_dir)
+            else:
+                # remove this when the minimum Python version is 3.12
+                logger.warning("Extracting may be unsafe; consider updating Python to 3.11.4 or greater")
+                tar_archive.extractall(path=base_dir)
     elif zipfile.is_zipfile(archive):
         with zipfile.ZipFile(archive) as zip_archive:
             zip_archive.extractall(path=base_dir)


### PR DESCRIPTION
Fix #700.

This is to address a Snyk warning. The new code will only run on Python 3.11.4 and above.

Tested locally with Python 3.11.2 and 3.11.5. Although we can't see it in the code coverage with a single version of Python, I can confirm personally that both arms of the conditional are being entered.