### PR TITLE
Fix `test_install` that fails on Python<3.11.4

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -486,6 +486,7 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 r"and marked for removal in a future version of aqt\.\n"
                 r"In the future, please omit this parameter\.\n"
                 r"INFO    : Downloading qtbase\.\.\.\n"
+                r"([^\n]*Extracting may be unsafe; consider updating Python to 3.11.4 or greater\n)?"
                 r"Finished installation of qtbase-everywhere-src-6\.5\.0\.tar\.xz in .*\n"
                 r"INFO    : Finished installation\n"
                 r"INFO    : Time elapsed: .* second"


### PR DESCRIPTION
The tarfile test does not permit the new warning, "Extracting may be unsafe; consider updating Python to 3.11.4 or greater". This change should allow the test to succeed when running on 3.11.4 and below.

Failure that would be fixed by this PR: https://github.com/miurahr/aqtinstall/actions/runs/5997958636/workflow

It looks like the failing tests are in test-install-qt.yml, which runs on every push, but I didn't see it before because it isn't linked from the PR page.