### PR TITLE
Fix installation of win64_msvc2019_arm64 arch

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,6 @@ python:
         path: .
         extra_requirements:
            - docs
-   system_packages: false
 
 build:
   os: ubuntu-22.04

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -293,6 +293,7 @@ class Updater:
                 "android_arm64_v8a",
                 "android_x86",
                 "android_armv7",
+                "win64_msvc2019_arm64",
             ]:  # desktop version
                 updater.make_qtconf(base_dir, version_dir, arch_dir)
                 updater.patch_qmake()
@@ -308,13 +309,13 @@ class Updater:
                     updater.patch_qtcore(target)
             elif version in SimpleSpec(">=5.0,<6.0"):
                 updater.patch_qmake()
-            else:  # qt6 mobile or wasm
+            else:  # qt6 mobile, wasm, or msvc-arm64
                 if installed_desktop_arch_dir is not None:
                     desktop_arch_dir = installed_desktop_arch_dir
                 else:
                     # Use MetadataFactory to check what the default architecture should be
                     meta = MetadataFactory(ArchiveId("qt", os_name, "desktop"))
-                    desktop_arch_dir = meta.fetch_default_desktop_arch(version)
+                    desktop_arch_dir = meta.fetch_default_desktop_arch(version, is_msvc="msvc" in target.arch)
 
                 updater.patch_qmake_script(base_dir, version_dir, target.os_name, desktop_arch_dir)
                 updater.patch_target_qt_conf(base_dir, version_dir, arch_dir, target.os_name, desktop_arch_dir)

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -190,6 +190,15 @@ windows_build_jobs.extend(
             mirror=random.choice(MIRRORS),
         ),
         BuildJob(
+            "install-qt",
+            "6.5.2",
+            "windows",
+            "desktop",
+            "win64_msvc2019_arm64",
+            "msvc2019_arm64",
+            is_autodesktop=True,    # Should install win64_msvc2019_arm64 in parallel
+        ),
+        BuildJob(
             # Archives stored as .zip
             "install-src", "6.4.3", "windows", "desktop", "gcc_64", "gcc_64", subarchives="qtlottie",
             # Fail the job if this path does not exist:

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -232,9 +232,7 @@ steps:
       if ('$(ARCH)' -like '*mingw*') {
         Write-Host '##vso[task.setvariable variable=TOOLCHAIN]MINGW'
       }
-      if ('$(ARCH)' -like 'win64_msvc*_arm64') {
-        Write-Host '##vso[task.setvariable variable=ARCHITECTURE]arm64'
-      } elseif ('$(ARCH)' -like 'win64_msvc*') {
+      if ('$(ARCH)' -like 'win64_msvc*') {
         Write-Host '##vso[task.setvariable variable=ARCHITECTURE]amd64'
       } else {
         Write-Host '##vso[task.setvariable variable=ARCHITECTURE]x86'

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -223,7 +223,9 @@ steps:
       if ('$(ARCH)' -like '*mingw*') {
         Write-Host '##vso[task.setvariable variable=TOOLCHAIN]MINGW'
       }
-      if ('$(ARCH)' -like 'win64_msvc*') {
+      if ('$(ARCH)' -like 'win64_msvc*_arm64') {
+        Write-Host '##vso[task.setvariable variable=ARCHITECTURE]arm64'
+      } elseif ('$(ARCH)' -like 'win64_msvc*') {
         Write-Host '##vso[task.setvariable variable=ARCHITECTURE]amd64'
       } else {
         Write-Host '##vso[task.setvariable variable=ARCHITECTURE]x86'

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -172,7 +172,16 @@ steps:
       export PATH=$(QT_BINDIR):$PATH
       qmake $(Build.BinariesDirectory)/tests/accelbubble
       make
-    condition: and(eq(variables['TARGET'], 'android'), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')), ne(variables['SUBCOMMAND'], 'list'), ne(variables['SUBCOMMAND'], 'install-tool'))
+    condition: |
+      and(
+        eq(variables['TARGET'], 'android'),
+        or(
+          eq(variables['Agent.OS'], 'Linux'),
+          eq(variables['Agent.OS'], 'Darwin')
+        ),
+        ne(variables['SUBCOMMAND'], 'list'),
+        ne(variables['SUBCOMMAND'], 'install-tool')
+      )
     displayName: Build accelbubble example application to test for android
 
   ##----------------------------------------------------
@@ -296,7 +305,12 @@ steps:
         qmake $(Build.BinariesDirectory)\tests\helloworld
         mingw32-make
       }
-    condition: and(eq( variables['Agent.OS'], 'Windows_NT'), eq(variables['MODULE'], ''), eq(variables['SUBCOMMAND'], 'install-qt'))
+    condition: |
+      and(
+        eq(variables['Agent.OS'], 'Windows_NT'),
+        eq(variables['MODULE'], ''),
+        eq(variables['SUBCOMMAND'], 'install-qt')
+      )
     displayName: build test with qmake w/o extra module
   - powershell: |
       # Load modules from cache  
@@ -314,7 +328,13 @@ steps:
       cd ..
       qmake $(Build.BinariesDirectory)\tests\redditclient
       nmake
-    condition: and(eq( variables['Agent.OS'], 'Windows_NT'), eq(variables['TOOLCHAIN'], 'MSVC'), ne(variables['MODULE'], ''), ne(variables['VSVER'], '2019'))
+    condition: |
+      and(
+        eq(variables['Agent.OS'], 'Windows_NT'),
+        eq(variables['TOOLCHAIN'], 'MSVC'),
+        ne(variables['MODULE'], ''),
+        ne(variables['VSVER'], '2019')
+      )
     displayName: build test with qmake with MSVC with extra module
   - bash: |
       set -ex
@@ -327,11 +347,15 @@ steps:
       qmake $(Build.BinariesDirectory)/tests/redditclient
       make
     condition: |
-      and(eq( variables['TARGET'], 'desktop'),
-          or(eq(variables['Agent.OS'], 'Linux'),
-          eq(variables['Agent.OS'], 'Darwin')),
-          ne(variables['MODULE'], ''),
-          eq(variables['SUBCOMMAND'], 'install-qt'))
+      and(
+        eq( variables['TARGET'], 'desktop'),
+        or(
+          eq(variables['Agent.OS'], 'Linux'),
+          eq(variables['Agent.OS'], 'Darwin')
+        ),
+        ne(variables['MODULE'], ''),
+        eq(variables['SUBCOMMAND'], 'install-qt')
+      )
     displayName: Build test with qmake for Linux and macOS with extra module
 
   ##----------------------------------------------------


### PR DESCRIPTION
Fix #710.

This fixes the behavior of the `--autodesktop` flag and the updater, when installing `win64_msvc2019_arm64` for desktop targets.

This is work in progress for now, because I think it would be worthwhile to add a CI job to the Azure Pipelines that builds a project using this architecture. I haven't quite figured out how to do that yet.