### PR TITLE
Update documentation for `--autodesktop` flag

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -723,8 +723,9 @@ class Cli:
         install_qt_parser.add_argument(
             "--autodesktop",
             action="store_true",
-            help="For Qt6 android, ios, and wasm installations, an additional desktop Qt installation is required. "
-            "When enabled, this option installs the required desktop version automatically.",
+            help="For Qt6 android, ios, wasm, and msvc_arm64 installations, an additional desktop Qt installation is "
+            "required. When enabled, this option installs the required desktop version automatically. "
+            "It has no effect when the desktop installation is not required.",
         )
 
     def _set_install_tool_parser(self, install_tool_parser, *, is_legacy: bool):

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -545,10 +545,10 @@ There are various combinations to accept according to Qt version.
 
 .. option:: --autodesktop
 
-    If you are installing an ios or android version of Qt6, or the WASM version of Qt6,
+    If you are installing an ios, android, WASM, or msvc_arm64 version of Qt6,
     the corresponding desktop version of Qt must be installed alongside of it.
     Turn this option on to install it automatically.
-    This option will have no effect if you are installing Qt5 or a non-WASM desktop version of Qt6.
+    This option will have no effect if the desktop version of Qt is not required.
 
 .. option:: --noarchives
 


### PR DESCRIPTION
Since #711, the documentation for the `--autodesktop` flag has been a little out-of-date. This PR updates the help text and the explanation in the `cli.rst` file for this flag.

This documentation update probably should have been part of #711, but I forgot to add it.