### PR TITLE
chore: remove deprecated configuration for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,6 @@ python:
         path: .
         extra_requirements:
            - docs
-   system_packages: false
 
 build:
   os: ubuntu-22.04

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'aqtinstall'
-copyright = u'2019-2021, Hiroshi Miura'
+copyright = u'2019-2023, Hiroshi Miura'
 author = u'Hiroshi Miura'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ check = [
     "packaging",
 ]
 docs = [
-    "sphinx>=5.0",
-    "sphinx_rtd_theme",
-    "sphinx-py3doc-enhanced-theme",
+    "sphinx>=7.0",
+    "sphinx_rtd_theme>=1.3",
+    "sphinx-py3doc-enhanced-theme>=2.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
Read the docs service deprecated a configuration `python.system-package` from Aug. 29, 2023.
https://blog.readthedocs.com/drop-support-system-packages/