### PR TITLE
Add python 3.8 & 3.11 to `test-install-qt.yml`

### DIFF
--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        py: ["3.10"]
+        py: ["3.9", "3.10", "3.11"]
         qtver: [5.9.9, 5.12.8, 6.1.0]
         artifact: [standard]
         include:

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        py: ["3.9", "3.10", "3.11"]
+        py: ["3.8", "3.10", "3.11"]
         qtver: [5.9.9, 5.12.8, 6.1.0]
         artifact: [standard]
         include:


### PR DESCRIPTION
Fix #712.

This should increase the number of CI jobs run by `test-install-qt.yml` by 18.

Current number of CI jobs: 
* 1 binary build + 3 OSes * 3 Qt versions= 10

New number of CI jobs: 
* 1 binary build + 3 OSes * 3 Qt versions * 3 Python versions = 28