### PR TITLE
Fix failed CI runs in test-install-qt.yml

### DIFF
--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -112,10 +112,10 @@ jobs:
           if qtver.startswith('6'):
             command_line6 = []
             command_line6.extend(prefix)
-            if platform == 'ubuntu-20.04':
+            if platform.startswith("ubuntu"):
               command_line6.extend([qtver, "linux", "android", "android_armv7"])
               timeout = 360
-            elif platform == "macOS-latest":
+            elif platform.startswith("macOS"):
               command_line6.extend([qtver, "mac", "ios", "ios"])
               timeout = 360
             else:

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -1,6 +1,6 @@
 name: Test on GH actions environment
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -121,6 +121,7 @@ jobs:
             else:
               command_line6.extend([qtver, "windows", "android", "android_armv7"])
               timeout = 360
+            print("Execute: {}".format(command_line6))
             try:
               res = subprocess.run(command_line6, timeout=timeout, check=True)
             except subprocess.CalledProcessError as cpe:


### PR DESCRIPTION
This does 3 things:
* Add a debug statement to print what aqtinstall commands are being run
* Fix the command that checks which OS to use. See https://github.com/miurahr/aqtinstall/pull/715#issuecomment-1722505571 for explanation of what was broken.
* Run this workflow on pull requests as well as pushes, so we can more easily see when it breaks.