### PR TITLE
security: CVE-2023-32681: bump requests@2.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "humanize",
     "patch>=1.16",
     "py7zr>=0.20.6",
-    "requests>2.20.0",
+    "requests>=2.31.0",
     "semantic-version",
     "texttable",
 ]


### PR DESCRIPTION
- Versions of Requests between v2.3.0 and v2.30.0 are vulnerable to potential forwarding of Proxy-Authorization headers to destination servers when following HTTPS redirects.

Details at [Github Advisory](https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q)