### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 =============
 
+Deprecated
+----------
+* Drop support for python 3.7
+
 Fixed
 -----
 - Patch ``*.prl`` and ``*.pc`` for mingw (#640, #739)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Installation
 Requirements
 ------------
 
-- Minimum Python version:  3.7.5
+- Minimum Python version:  3.8.10
 
 - Dependencies: requests, py7zr, semantic_version, patch, texttable, bs4, defusedxml, humanize
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "bs4",  # canonical name is beautifulsoup4
     "defusedxml",
@@ -174,7 +174,7 @@ markers = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = check, docs, py{37,38,39,310,311}, py39d, mprof, fil, mypy
+envlist = check, docs, py{38,39,310,311,312}, py39d, mprof, fil, mypy
 isolated_build = True
 
 [testenv]
@@ -248,4 +248,5 @@ python =
     3.9: py39, docs, check, mypy
     3.10: py310
     3.11: py311
+    3.12: py312
 """


### PR DESCRIPTION
- Minimum required python version to be 3.8.10, a last version which got regular bug fixes.
- tox: drop 3.7 and add 3.12
- Next aqtinstall release will be version 3.2.0

Note: when merged,  should update `docs/SECURITY.rst` to make 3.0.x unsupported, and 3.1.x to be security fix only.