### PR TITLE
fix generate_combinations issue with Linux Qt 6.7

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -286,18 +286,15 @@ class TableMetadata(ABC):
 
     @property
     @abstractmethod
-    def short_heading_keys(self) -> Iterable[str]:
-        ...
+    def short_heading_keys(self) -> Iterable[str]: ...
 
     @property
     @abstractmethod
-    def long_heading_keys(self) -> Iterable[str]:
-        ...
+    def long_heading_keys(self) -> Iterable[str]: ...
 
     @property
     @abstractmethod
-    def name_heading(self) -> str:
-        ...
+    def name_heading(self) -> str: ...
 
     def __format__(self, format_spec: str) -> str:
         short = False

--- a/ci/generate_combinations.py
+++ b/ci/generate_combinations.py
@@ -42,7 +42,7 @@ def iter_arches() -> Generator[dict, None, None]:
     logger.info("Fetching arches")
     archive_ids = list(iter_archive_ids(category="qt"))
     for archive_id in tqdm(archive_ids):
-        for version in ("latest", "5.15.2", "5.13.2", "5.9.9"):
+        for version in ("latest", "6.5", "6.2", "5.15.2", "5.13.2", "5.9.9"):
             for arch_name in MetadataFactory(archive_id, architectures_ver=version).getList():
                 yield {
                     "os_name": archive_id.host,
@@ -82,10 +82,12 @@ def iter_modules_for_qt_minor_groups(
 ) -> Generator[Dict, None, None]:
     logger.info("Fetching qt modules for {}/{}".format(host, target))
     for major, minor in tqdm(list(iter_qt_minor_groups(host, target))):
+        use_linux_gcc = (host == "linux" and arch == "gcc_64" and major == 6 and minor >= 7)
+        use_arch = "linux_gcc_64" if use_linux_gcc else arch
         yield {
             "qt_version": f"{major}.{minor}",
             "modules": MetadataFactory(
-                ArchiveId("qt", host, target), modules_query=MetadataFactory.ModulesQuery(f"{major}.{minor}.0", arch)
+                ArchiveId("qt", host, target), modules_query=MetadataFactory.ModulesQuery(f"{major}.{minor}.0", use_arch)
             ).getList(),
         }
 


### PR DESCRIPTION
Fix issues discovered in #751. See https://github.com/miurahr/aqtinstall/pull/751#issuecomment-1935347831

Qt 6.7.0 changes the default arch for Linux from gcc_64 to linux_gcc_64. This allows the generate_combinations.py script to account for that.

Also, Qt 6.7.0 is missing a few architectures that were present in earlier versions of Qt6. This makes sure that the script can pick those up.