### PR TITLE
Support linux_gcc_arm64 arch in 6.7.0

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -29,7 +29,7 @@ from defusedxml import ElementTree
 
 from aqt.exceptions import ArchiveDownloadError, ArchiveListError, ChecksumDownloadFailure, NoPackageFound
 from aqt.helper import Settings, get_hash, getUrl, ssplit
-from aqt.metadata import QtRepoProperty, Version
+from aqt.metadata import QtRepoProperty, Version, repository_path_for_os
 
 
 @dataclass
@@ -367,7 +367,7 @@ class QtArchives:
     def _append_depends_tool(self, arch, tool_name):
         os_target_folder = posixpath.join(
             "online/qtsdkrepository",
-            self.os_name + ("_x86" if self.os_name == "windows" else "_x64"),
+            repository_path_for_os(self.os_name, arch),
             self.target,
             tool_name,
         )
@@ -379,7 +379,7 @@ class QtArchives:
     def _get_archives_base(self, name, target_packages):
         os_target_folder = posixpath.join(
             "online/qtsdkrepository",
-            self.os_name + ("_x86" if self.os_name == "windows" else "_x64"),
+            repository_path_for_os(self.os_name, self.arch),
             self.target,
             # tools_ifw/
             name,

--- a/aqt/combinations.json
+++ b/aqt/combinations.json
@@ -435,6 +435,11 @@
         "target": "desktop"
       },
       {
+        "arch": "linux_gcc_arm64",
+        "os_name": "linux",
+        "target": "desktop"
+      },
+      {
         "arch": "wasm_32",
         "os_name": "linux",
         "target": "desktop"

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -261,7 +261,10 @@ class Cli:
         if arch is not None and arch != "":
             return arch
         if os_name == "linux" and target == "desktop":
-            return "gcc_64"
+            if Version(qt_version_or_spec) >= Version("6.7.0"):
+                return "linux_gcc_64"
+            else:
+                return "gcc_64"
         elif os_name == "mac" and target == "desktop":
             return "clang_64"
         elif os_name == "mac" and target == "ios":

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -261,9 +261,12 @@ class Cli:
         if arch is not None and arch != "":
             return arch
         if os_name == "linux" and target == "desktop":
-            if Version(qt_version_or_spec) >= Version("6.7.0"):
-                return "linux_gcc_64"
-            else:
+            try:
+                if Version(qt_version_or_spec) >= Version("6.7.0"):
+                    return "linux_gcc_64"
+                else:
+                    return "gcc_64"
+            except ValueError:
                 return "gcc_64"
         elif os_name == "mac" and target == "desktop":
             return "clang_64"

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -206,7 +206,7 @@ def repository_path_for_os(os_name: str, arch: str) -> str:
         return os_name + "_x64"
 
 
-def repository_paths_for_os(os_name: str, version: Optional[Version] = None) -> tuple[str]:
+def repository_paths_for_os(os_name: str, version: Optional[Version] = None) -> Tuple[str, ...]:
     if os_name == "windows":
         return ("windows_x86",)
     elif os_name == "linux" and (version is None or version >= Version("6.7.0")):
@@ -814,7 +814,9 @@ class MetadataFactory:
         )
         return f"{version.major}{version.minor}{patch}"
 
-    def _fetch_module_metadata(self, folder: str, version : Optional[Version] = None, predicate: Optional[Callable[[Element], bool]] = None):
+    def _fetch_module_metadata(
+        self, folder: str, version: Optional[Version] = None, predicate: Optional[Callable[[Element], bool]] = None
+    ):
         xmls = (
             self.fetch_http(rest_of_url) if not Settings.ignore_hash else self.fetch_http(rest_of_url, False)
             for rest_of_url in (posixpath.join(url, folder, "Updates.xml") for url in self.archive_id.to_urls(version))

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -206,10 +206,10 @@ def repository_path_for_os(os_name: str, arch: str) -> str:
         return os_name + "_x64"
 
 
-def repository_paths_for_os(os_name: str, version: Optional[Version] = None) -> Tuple[str, ...]:
+def repository_paths_for_os(os_name: str, target: str, version: Optional[Version] = None) -> Tuple[str, ...]:
     if os_name == "windows":
         return ("windows_x86",)
-    elif os_name == "linux" and (version is None or version >= Version("6.7.0")):
+    elif os_name == "linux" and target == "desktop" and (version is None or version >= Version("6.7.0")):
         return ("linux_x64", "linux_arm64")
     else:
         return (os_name + "_x64",)
@@ -252,7 +252,7 @@ class ArchiveId:
                 os_path=os_path,
                 target=self.target,
             )
-            for os_path in repository_paths_for_os(self.host, version)
+            for os_path in repository_paths_for_os(self.host, self.target, version)
         ]
 
     def to_folder(self, qt_version_no_dots: str, extension: Optional[str] = None) -> str:


### PR DESCRIPTION
Initial support, probably missing some cases.
Fixes #750 

Some interactive testing:
```sh-session
$ aqt list-qt linux desktop
5.9.0 5.9.1 5.9.2 5.9.3 5.9.4 5.9.5 5.9.6 5.9.7 5.9.8 5.9.9
5.10.0 5.10.1
5.11.0 5.11.1 5.11.2 5.11.3
5.12.0 5.12.1 5.12.2 5.12.3 5.12.4 5.12.5 5.12.6 5.12.7 5.12.8 5.12.9 5.12.10 5.12.11 5.12.12
5.13.0 5.13.1 5.13.2
5.14.0 5.14.1 5.14.2
5.15.0 5.15.1 5.15.2
6.0.0 6.0.1 6.0.2 6.0.3 6.0.4
6.1.0 6.1.1 6.1.2 6.1.3
6.2.0 6.2.1 6.2.2 6.2.3 6.2.4
6.3.0 6.3.1 6.3.2
6.4.0 6.4.1 6.4.2 6.4.3
6.5.0 6.5.1 6.5.2 6.5.3
6.6.0 6.6.1 6.6.2
6.7.0 6.7.0

$ aqt list-qt linux desktop --arch 6.7.0
linux_gcc_64 linux_gcc_arm64

$ aqt list-qt linux desktop --arch 6.6.0
gcc_64 wasm_singlethread wasm_multithread

$ aqt install-qt linux desktop 6.7.0 linux_gcc_arm64 --outputdir /tmp/Qt
[...]
INFO    : Finished installation of qtsvg-Linux-Debian_11_6-GCC-Linux-Debian_11_6-AARCH64.7z in 1.31891796
INFO    : Finished installation of qttools-Linux-Debian_11_6-GCC-Linux-Debian_11_6-AARCH64.7z in 1.71985637
INFO    : Downloading qttranslations...
[...]


$ aqt install-qt linux desktop 6.7.0 linux_gcc_64 --outputdir /tmp/Qt
[...]
INFO    : Finished installation of qtsvg-Linux-RHEL_8_8-GCC-Linux-RHEL_8_8-X86_64.7z in 2.46250538
INFO    : Downloading qttranslations...
[...]

$ aqt install-qt linux desktop 6.6.0 gcc_64 --outputdir /tmp/Qt
[...]
INFO    : Finished installation of qtsvg-Linux-RHEL_8_6-GCC-Linux-RHEL_8_6-X86_64.7z in 2.44938992
INFO    : Downloading qttranslations...
[...]

$ aqt install-qt linux desktop 6.6.0 --outputdir /tmp/Qt
[...]
INFO    : Finished installation of qtsvg-Linux-RHEL_8_6-GCC-Linux-RHEL_8_6-X86_64.7z in 3.00820996
INFO    : Downloading qttranslations...
[...]

$ aqt install-qt linux desktop 6.7.0 --outputdir /tmp/Qt
[...]
INFO    : Finished installation of qtsvg-Linux-RHEL_8_8-GCC-Linux-RHEL_8_8-X86_64.7z in 2.25437083
INFO    : Downloading qttranslations...
[...]
```