### PR TITLE
fix: always use gcc_64 as arch_dir for linux

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -384,6 +384,8 @@ class QtRepoProperty:
                 return arch[6:]
         elif host == "mac" and arch == "clang_64":
             return QtRepoProperty.default_mac_desktop_arch_dir(version)
+        elif host == "linux":
+            return QtRepoProperty.default_linux_desktop_arch_dir()
         else:
             return arch
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -51,12 +51,12 @@ def setup_settings():
             ),
         ),
         (
-                TargetConfig("6.7.0", "desktop", "linux_gcc_64", "linux"),
-                re.compile(
-                    r"Updater caused an IO error: .*No such file or directory: "
-                    # '.*' wildcard used to match path separators on windows/*nix
-                    r".*6\.7\.0.*gcc_64.*mkspecs.*qconfig.pri.*"
-                ),
+            TargetConfig("6.7.0", "desktop", "linux_gcc_64", "linux"),
+            re.compile(
+                r"Updater caused an IO error: .*No such file or directory: "
+                # '.*' wildcard used to match path separators on windows/*nix
+                r".*6\.7\.0.*gcc_64.*mkspecs.*qconfig.pri.*"
+            ),
         ),
     ),
 )

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -50,6 +50,14 @@ def setup_settings():
                 r".*6\.1\.1.*clang_64.*mkspecs.*qconfig.pri.*"
             ),
         ),
+        (
+                TargetConfig("6.7.0", "desktop", "linux_gcc_64", "linux"),
+                re.compile(
+                    r"Updater caused an IO error: .*No such file or directory: "
+                    # '.*' wildcard used to match path separators on windows/*nix
+                    r".*6\.7\.0.*gcc_64.*mkspecs.*qconfig.pri.*"
+                ),
+        ),
     ),
 )
 def test_updater_update_license_io_error(monkeypatch, target_config: TargetConfig, expected_err_pattern: re.Pattern):


### PR DESCRIPTION
From Qt 6.7.0, arch keyword is changed to linux_gcc_64 but arch_dir should always be gcc_64. 
The change fixes issue #769 Fails to install Qt6 6.7.0 on Linux/Ubuntu