### PR TITLE
refactor: remove legacy subcommand syntax

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,10 +28,6 @@ jobs:
       run: |
         pip install -U pip
         pip install tox tox-gh-actions coveralls coverage[toml]
-    - name: Check invocation with Python2
-      run: |
-        ! python2 -m aqt help
-        [[ $(python2 -m aqt help) == "aqtinstall requires python 3!" ]]
     - name: Check
       run: tox
       env:

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -32,7 +32,7 @@ jobs:
             py: "3.10"
             qtver: 6.1.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 20
           fetch-tags: true
@@ -88,24 +88,24 @@ jobs:
               bin_path = str(github_workspace / "dist" / "aqt.exe")
             else:
               bin_path = (github_workspace / "dist" / "aqt").as_posix()
-            prefix = [bin_path, "install"]
+            prefix = [bin_path, "install-qt"]
           else:
-            prefix = ["python", "-m", "aqt", "install"]
+            prefix = ["python", "-m", "aqt", "install-qt"]
           command_line = []
           command_line.extend(prefix)
           if platform == "windows-latest":
             if qtver.startswith('5.15'):
-              args = [qtver, "windows", "desktop", "win64_msvc2019_64"]
+              args = ["windows", "desktop", qtver, "win64_msvc2019_64"]
             elif qtver.startswith('5.14'):
-              args = [qtver, "windows", "desktop", "win64_msvc2017_64"]
+              args = ["windows", "desktop", qtver, "win64_msvc2017_64"]
             elif qtver.startswith('6'):
-              args = [qtver, "windows", "desktop", "win64_mingw81"]
+              args = ["windows", "desktop", qtver, "win64_mingw81"]
             else:
-              args = [qtver, "windows", "desktop", "win64_msvc2015_64"]
+              args = ["windows", "desktop", qtver, "win64_msvc2015_64"]
           elif platform == "macOS-latest":
-            args = [qtver, "mac", "desktop", "clang_64"]
+            args = ["mac", "desktop", qtver, "clang_64"]
           else:
-            args = [qtver, "linux", "desktop", "gcc_64"]
+            args = ["linux", "desktop", qtver, "gcc_64"]
           command_line.extend(args)
           command_line.extend(["--archives", "qtbase", "icu", "qt"])
           env["AQT_CONFIG"] = (github_workspace / "ci" / "settings.ini").as_posix()
@@ -120,13 +120,13 @@ jobs:
             command_line6 = []
             command_line6.extend(prefix)
             if platform.startswith("ubuntu"):
-              command_line6.extend([qtver, "linux", "android", "android_armv7"])
+              command_line6.extend(["linux", "android", qtver, "android_armv7"])
               timeout = 360
             elif platform.startswith("macOS"):
-              command_line6.extend([qtver, "mac", "ios", "ios"])
+              command_line6.extend(["mac", "ios", qtver, "ios"])
               timeout = 360
             else:
-              command_line6.extend([qtver, "windows", "android", "android_armv7"])
+              command_line6.extend(["windows", "android", qtver, "android_armv7"])
               timeout = 360
             print("Execute: {}".format(command_line6))
             try:
@@ -186,7 +186,7 @@ jobs:
               print('PREFIX {}'.format(result))
         shell: python
         working-directory: ${{ github.workspace }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: matrix.artifact == 'binary'
         with:
           name: aqt-${{ matrix.os }}-standalone

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -167,8 +167,7 @@ class Cli:
             title="subcommands",
             description="aqt accepts several subcommands:\n"
             "install-* subcommands are commands that install components\n"
-            "list-* subcommands are commands that show available components\n\n"
-            "commands {install|tool|src|examples|doc} are deprecated and marked for removal\n",
+            "list-* subcommands are commands that show available components\n",
             help="Please refer to each help message by using '--help' with each subcommand",
         )
         self._make_all_parsers(subparsers)

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -721,7 +721,6 @@ class Cli:
         )
 
     def _make_all_parsers(self, subparsers: argparse._SubParsersAction) -> None:
-        deprecated_msg = "This command is deprecated and marked for removal in a future version of aqt."
 
         def make_parser_it(cmd: str, desc: str, set_parser_cmd, formatter_class):
             kwargs = {"formatter_class": formatter_class} if formatter_class else {}

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (C) 2018 Linus Jahn <lnj@kaidan.im>
-# Copyright (C) 2019-2021,2024 Hiroshi Miura <miurahr@linux.com>
+# Copyright (C) 2019-2024 Hiroshi Miura <miurahr@linux.com>
 # Copyright (C) 2020, Aurélien Gâteau
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -778,16 +778,6 @@ You should use the :ref:`List-Tool command` to display what tools and tool varia
 
 See `common options`_.
 
-
-Legacy subcommands
-------------------
-
-The subcommands ``install``, ``tool``, ``src``, ``doc``, and ``examples`` have
-been deprecated in favor of the newer ``install-*`` commands, but they remain
-in aqt in case you still need to use them. Documentation for these older
-commands is still available at https://aqtinstall.readthedocs.io/en/v1.2.4/
-
-
 Command examples
 ================
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,14 +105,12 @@ def test_cli_invalid_version(capsys, invalid_version):
     cli._setup_settings()
 
     matcher = re.compile(
-      #  r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
+        #  r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
         r"(.*\n)*"
         r"ERROR   :.*Invalid version: '" + invalid_version + r"'! Please use the form '5\.X\.Y'\.\n.*"
     )
 
-    for cmd in (
-        ("list-qt", "mac", "desktop", "--arch", invalid_version),
-    ):
+    for cmd in (("list-qt", "mac", "desktop", "--arch", invalid_version),):
         cli = Cli()
         assert cli.run(cmd) == 1
         out, err = capsys.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,8 +16,7 @@ def expected_help(actual, prefix=None):
     expected = (
         "usage: aqt [-h] [-c CONFIG]\n"
         "           {install-qt,install-tool,install-doc,install-example,install-src,"
-        "list-qt,list-tool,list-doc,list-example,list-src,"
-        "install,tool,doc,examples,src,help,version}\n"
+        "list-qt,list-tool,list-doc,list-example,list-src,help,version}\n"
         "           ...\n"
         "\n"
         "Another unofficial Qt Installer.\n"
@@ -32,13 +31,9 @@ def expected_help(actual, prefix=None):
         "  aqt accepts several subcommands:\n"
         "  install-* subcommands are commands that install components\n"
         "  list-* subcommands are commands that show available components\n"
-        "  \n"
-        "  commands {install|tool|src|examples|doc} are deprecated and marked for "
-        "removal\n"
         "\n"
         "  {install-qt,install-tool,install-doc,install-example,install-src,list-qt,"
-        "list-tool,list-doc,list-example,list-src,"
-        "install,tool,doc,examples,src,help,version}\n"
+        "list-tool,list-doc,list-example,list-src,help,version}\n"
         "                        Please refer to each help message by using '--help' "
         "with each subcommand\n",
     )
@@ -110,14 +105,12 @@ def test_cli_invalid_version(capsys, invalid_version):
     cli._setup_settings()
 
     matcher = re.compile(
-        r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
+      #  r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
         r"(.*\n)*"
         r"ERROR   :.*Invalid version: '" + invalid_version + r"'! Please use the form '5\.X\.Y'\.\n.*"
     )
 
     for cmd in (
-        ("install", invalid_version, "mac", "desktop"),
-        ("doc", invalid_version, "mac", "desktop"),
         ("list-qt", "mac", "desktop", "--arch", invalid_version),
     ):
         cli = Cli()
@@ -234,52 +227,6 @@ def test_cli_input_errors(capsys, cmd, expect_msg, should_show_help):
     assert err.rstrip().endswith(expect_msg)
 
 
-# These commands use the new syntax with the legacy commands
-@pytest.mark.parametrize(
-    "cmd",
-    (
-        "install linux desktop 5.10.0",
-        "install linux desktop 5.10.0 gcc_64",
-        "src linux desktop 5.10.0",
-        "doc linux desktop 5.10.0",
-        "example linux desktop 5.10.0",
-        "tool windows desktop tools_ifw",
-    ),
-)
-def test_cli_legacy_commands_with_wrong_syntax(cmd):
-    cli = Cli()
-    cli._setup_settings()
-    with pytest.raises(SystemExit) as e:
-        cli.run(cmd.split())
-    assert e.type == SystemExit
-
-
-@pytest.mark.parametrize(
-    "cmd",
-    (
-        "tool windows desktop tools_ifw qt.tools.ifw.31",  # New syntax
-        "tool windows desktop tools_ifw 1.2.3",
-    ),
-)
-def test_cli_legacy_tool_new_syntax(monkeypatch, capsys, cmd):
-    # These incorrect commands cannot be filtered out directly by argparse because
-    # they have the correct number of arguments.
-    command = cmd.split()
-
-    expected = (
-        "WARNING : The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
-        "In the future, please use the command 'install-tool' instead.\n"
-        "ERROR   : Invalid version: 'tools_ifw'! Please use the form '5.X.Y'.\n"
-    )
-
-    cli = Cli()
-    cli._setup_settings()
-    assert 1 == cli.run(command)
-    out, err = capsys.readouterr()
-    actual = err[err.index("\n") + 1 :]
-    assert actual == expected
-
-
 @pytest.mark.parametrize(
     "cmd, expect_err",
     (
@@ -306,28 +253,6 @@ def test_cli_list_qt_deprecated_flags(capsys, cmd: str, expect_err: str):
     assert 0 == cli.run(cmd.split())
     out, err = capsys.readouterr()
     assert err == expect_err
-
-
-# These commands come directly from examples in the legacy documentation
-@pytest.mark.parametrize(
-    "cmd",
-    (
-        "install 5.10.0 linux desktop",  # default arch
-        "install 5.10.2 linux android android_armv7",
-        "src 5.15.2 windows desktop --archives qtbase --kde",
-        "doc 5.15.2 windows desktop -m qtcharts qtnetworkauth",
-        "examples 5.15.2 windows desktop -m qtcharts qtnetworkauth",
-        "tool linux tools_ifw 4.0 qt.tools.ifw.40",
-    ),
-)
-def test_cli_legacy_commands_with_correct_syntax(monkeypatch, cmd):
-    # Pretend to install correctly when any command is run
-    for func in ("run_install_qt", "run_install_src", "run_install_doc", "run_install_example", "run_install_tool"):
-        monkeypatch.setattr(Cli, func, lambda *args, **kwargs: 0)
-
-    cli = Cli()
-    cli._setup_settings()
-    assert 0 == cli.run(cmd.split())
 
 
 def test_cli_unexpected_error(monkeypatch, capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -354,45 +354,6 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 r"INFO    : Time elapsed: .* second"
             ),
         ),
-        (
-            "tool linux tools_qtcreator 1.2.3-0-197001020304 qt.tools.qtcreator".split(),
-            "linux",
-            "desktop",
-            "1.2.3",
-            {"std": ""},
-            {"std": ""},
-            {"std": "linux_x64/desktop/tools_qtcreator/Updates.xml"},
-            {"std": [tool_archive("linux", "tools_qtcreator", "qt.tools.qtcreator", datetime(1970, 1, 2, 3, 4, 5, 6))]},
-            re.compile(
-                r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"WARNING : The command 'tool' is deprecated and marked for removal in a future version of aqt.\n"
-                r"In the future, please use the command 'install-tool' instead.\n"
-                r"INFO    : Downloading qt.tools.qtcreator...\n"
-                r"Finished installation of tools_qtcreator-linux-qt.tools.qtcreator.7z in .*\n"
-                r"INFO    : Finished installation\n"
-                r"INFO    : Time elapsed: .* second"
-            ),
-        ),
-        (
-            "install 5.14.0 windows desktop win32_mingw73".split(),
-            "windows",
-            "desktop",
-            "5.14.0",
-            {"std": "win32_mingw73"},
-            {"std": "mingw73_32"},
-            {"std": "windows_x86/desktop/qt5_5140/Updates.xml"},
-            {"std": [plain_qtbase_archive("qt.qt5.5140.win32_mingw73", "win32_mingw73")]},
-            re.compile(
-                r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"WARNING : The command 'install' is deprecated"
-                r" and marked for removal in a future version of aqt.\n"
-                r"In the future, please use the command 'install-qt' instead.\n"
-                r"INFO    : Downloading qtbase...\n"
-                r"Finished installation of qtbase-windows-win32_mingw73.7z in .*\n"
-                r"INFO    : Finished installation\n"
-                r"INFO    : Time elapsed: .* second"
-            ),
-        ),
         (  # Mixing --modules with --archives
             "install-qt windows desktop 5.14.0 win32_mingw73 -m qtcharts --archives qtbase".split(),
             "windows",
@@ -527,26 +488,6 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                 r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
                 r"INFO    : Downloading qtbase\.\.\.\n"
                 r"Finished installation of qtbase-everywhere-src-5\.14\.2\.7z in .*\n"
-                r"INFO    : Finished installation\n"
-                r"INFO    : Time elapsed: .* second"
-            ),
-        ),
-        (
-            "install 5.9.0 windows desktop win32_mingw53".split(),
-            "windows",
-            "desktop",
-            "5.9.0",
-            {"std": "win32_mingw53"},
-            {"std": "mingw53_32"},
-            {"std": "windows_x86/desktop/qt5_59/Updates.xml"},
-            {"std": [plain_qtbase_archive("qt.59.win32_mingw53", "win32_mingw53")]},
-            re.compile(
-                r"^INFO    : aqtinstall\(aqt\) v.* on Python 3.*\n"
-                r"WARNING : The command 'install' is deprecated"
-                r" and marked for removal in a future version of aqt.\n"
-                r"In the future, please use the command 'install-qt' instead.\n"
-                r"INFO    : Downloading qtbase...\n"
-                r"Finished installation of qtbase-windows-win32_mingw53.7z in .*\n"
                 r"INFO    : Finished installation\n"
                 r"INFO    : Time elapsed: .* second"
             ),


### PR DESCRIPTION
- Drop CI test for legacy commands
- Drop test cases for legacy commands
- Drop logics for legacy commands