### PR TITLE
chore(ci): azure-pipelines bump to macos-14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - job: Mac
   dependsOn: MatricesGenerator
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-14'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.mac'] ]
   steps:


### PR DESCRIPTION
macOS-12 will be deprecated in Dec 2024.
This change bumps the target to macOS-14

see
https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml