### PR TITLE
restore CI pipeline test for list-* commands

### DIFF
--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -177,8 +177,8 @@ linux_build_jobs.extend(
             check_output_cmd="ls -lh ./Examples/Qt-6.1.3/charts/ ./Examples/Qt-6.1.3/demos/ ./Examples/Qt-6.1.3/tutorials/",
         ),
         # test for list commands
-        BuildJob('list-qt', '6.1.0', 'linux', 'desktop', 'gcc_64', '', spec=">6.0,<6.1.1", list_options={'HAS_WASM': "False"}),
-        BuildJob('list-qt', '6.1.0', 'linux', 'android', 'android_armv7', '', spec=">6.0,<6.1.1", list_options={}),
+        BuildJob('list-*', '6.1.0', 'linux', 'desktop', 'gcc_64', '', spec=">6.0,<6.1.1", list_options={'HAS_WASM': "False"}),
+        BuildJob('list-*', '6.1.0', 'linux', 'android', 'android_armv7', '', spec=">6.0,<6.1.1", list_options={}),
     ]
 )
 

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -81,7 +81,7 @@ steps:
           [[ $($(QT_BINDIR)/qmake -query QT_HOST_PREFIX) == "$(OUTPUT_DIR)/$(QT_VERSION)/$(ARCHDIR)" ]]
         fi
       fi
-      if [[ "$(SUBCOMMAND)" == "list" ]]; then
+      if [[ "$(SUBCOMMAND)" == "list-*" ]]; then
         aqt list-qt $(HOST)                                                     # print all targets for host
         aqt list-tool $(HOST) $(TARGET)                                         # print all tools for host/target
         aqt list-tool $(HOST) $(TARGET) qt3dstudio_runtime_240                  # print all tool variant names for qt3dstudio


### PR DESCRIPTION
Restore CI pipeline test for list-* commands.

See https://github.com/miurahr/aqtinstall/commit/bdf8b4b1f99795d3733bee4b4d0eeaa629637af1#r147631586

I'm slightly concerned about using strings like `list-*` in Bash because of potential issues with wildcard character expansion. As long as these strings are quoted, I think they should be fine though.