### PR TITLE
Fix for arch win64_msvc2022_arm64_cross_compiled

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1050,7 +1050,9 @@ class Cli:
         """Returns expected_desktop_arch_dir, desktop_arch_to_install"""
         is_wasm = arch.startswith("wasm")
         is_msvc = "msvc" in arch
-        is_win_desktop_msvc_arm64 = host == "windows" and target == "desktop" and is_msvc and arch.endswith("arm64")
+        is_win_desktop_msvc_arm64 = (
+            host == "windows" and target == "desktop" and is_msvc and arch.endswith(("arm64", "arm64_cross_compiled"))
+        )
         if version < Version("6.0.0") or (
             target not in ["ios", "android"] and not is_wasm and not is_win_desktop_msvc_arm64
         ):

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -395,6 +395,8 @@ class QtRepoProperty:
             m = re.match(r"win\d{2}_(?P<msvc>msvc\d{4})_(?P<winrt>winrt_x\d{2})", arch)
             if m:
                 return f"{m.group('winrt')}_{m.group('msvc')}"
+            elif arch.endswith("_cross_compiled"):
+                return arch[6:-15]
             else:
                 return arch[6:]
         elif host == "mac" and arch == "clang_64":
@@ -412,8 +414,10 @@ class QtRepoProperty:
 
     @staticmethod
     def default_win_msvc_desktop_arch_dir(_version: Version) -> str:
-        """_version is unused, but we expect it to matter for future releases"""
-        return "msvc2019_64"
+        if _version >= Version("6.8.0"):
+            return "msvc2022_64"
+        else:
+            return "msvc2019_64"
 
     @staticmethod
     def default_mac_desktop_arch_dir(version: Version) -> str:

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -299,6 +299,7 @@ class Updater:
                 "android_x86",
                 "android_armv7",
                 "win64_msvc2019_arm64",
+                "win64_msvc2022_arm64_cross_compiled",
             ]:  # desktop version
                 updater.make_qtconf(base_dir, version_dir, arch_dir)
                 updater.patch_qmake()


### PR DESCRIPTION
Fixes the issue [described here](https://github.com/miurahr/aqtinstall/issues/825#issuecomment-2400125218).

I was able to test it via [install-qt-action](https://github.com/jurplel/install-qt-action) by specifying `aqtsource` to point to a tag on my forked aqtinstall repo. I can confirm that it's now working properly as evidenced by the "Install Qt" step in [this build log](https://github.com/jdpurcell/qView/actions/runs/11264500863/job/31324610014).