### PR TITLE
Fix WebAssembly (WASM) support for Qt 6.7+

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -361,7 +361,7 @@ class QtArchives:
         return target_packages
 
     def _get_archives(self):
-        if (self.target == "desktop" and self.arch in ("wasm_singlethread", "wasm_multithread")):
+        if self.target == "desktop" and self.version >= Version("6.7.0") and self.arch in ("wasm_singlethread", "wasm_multithread"):
             base_url = "online/qtsdkrepository/all_os/wasm"
             if self.version >= Version("6.8.0"):
                 name = f"qt6_{self._version_str()}/qt6_{self._version_str()}_{self.arch}"

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -232,7 +232,7 @@ class ArchiveId:
         return self.category == "tools"
 
     def to_url(self) -> str:
-        if self.target == "desktop" and self.arch in ("wasm_singlethread", "wasm_multithread"):
+        if self.target == "desktop" and self.host in ("wasm_singlethread", "wasm_multithread") and self.version >= Version("6.7.0"):
             return "online/qtsdkrepository/all_os/wasm/"
         return "online/qtsdkrepository/{os}{arch}/{target}/".format(
             os=self.host,

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -206,7 +206,7 @@ class ArchiveId:
         "mac": ["android", "desktop", "ios"],
         "linux": ["android", "desktop"],
         "linux_arm64": ["desktop"],
-        "all_os": ["qt"],
+        "all_os": ["qt", "wasm"],
     }
     EXTENSIONS_REQUIRED_ANDROID_QT6 = {"x86_64", "x86", "armv7", "arm64_v8a"}
     ALL_EXTENSIONS = {"", "wasm", "src_doc_examples", *EXTENSIONS_REQUIRED_ANDROID_QT6}
@@ -232,6 +232,8 @@ class ArchiveId:
         return self.category == "tools"
 
     def to_url(self) -> str:
+        if self.target == "desktop" and self.arch in ("wasm_singlethread", "wasm_multithread"):
+            return "online/qtsdkrepository/all_os/wasm/"
         return "online/qtsdkrepository/{os}{arch}/{target}/".format(
             os=self.host,
             arch=(
@@ -521,6 +523,8 @@ class QtRepoProperty:
 
     @staticmethod
     def is_in_wasm_range(host: str, version: Version) -> bool:
+        if version >= Version("6.7.0"):
+            return True
         return (
             version in SimpleSpec(">=6.2.0,<6.5.0")
             or (host == "linux" and version in SimpleSpec(">=5.13,<6"))

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -268,7 +268,7 @@ class ArchiveId:
         return self.category == "tools"
 
     def to_url(self) -> str:
-        if self.target == "desktop" and self.host in ("wasm_singlethread", "wasm_multithread") and self.version >= Version("6.7.0"):
+        if self.target == "desktop" and self.host in ("wasm_singlethread", "wasm_multithread"):
             return "online/qtsdkrepository/all_os/wasm/"
         return "online/qtsdkrepository/{os}{arch}/{target}/".format(
             os=self.host,


### PR DESCRIPTION
## Fix WebAssembly (WASM) support for Qt 6.7+

### Description

Adds support for downloading and installing Qt WASM packages for Qt versions 6.7.0 and above, while remaining backward compatible. Starting from Qt 6.7.0, the Qt WebAssembly (WASM) packages have been moved to a new repository structure at `https://download.qt.io/online/qtsdkrepository/all_os/wasm/`.

This PR updates the path handling to properly support:
* Qt 6.7.x: `qt6_67x_wasm_singlethread` and `qt6_67x_wasm_multithread`
* Qt 6.8.x: `qt6_680/qt6_680_wasm_singlethread` and `qt6_680/qt6_680_wasm_multithread`

### Changes

- Added 'wasm' target to `all_os` supported targets
- Updated WASM path construction to handle both Qt 6.7.x and 6.8.x structures
- Updated version detection to properly handle Qt 6.7+ WASM packages
- Added debug logs for easier troubleshooting of the Updates.xml URL generation process

### Example Usage

```bash
aqt install-qt linux desktop 6.7.3 wasm_singlethread --autodesktop --modules qtquick3d qtquicktimeline qtshadertools
```

### About [qt-install-action](https://github.com/marketplace/actions/install-qt)
It works on a `ubuntu-24.04` runner at least, I tested it on a personal project: the wasm arch is downloaded and behave as expected. You just need to specify (at least until the fixes are pushed to master) `aqtsource` as `git+https://github.com/Kidev/aqtinstall.git`:
```yml
      - name: Install Qt
        uses: jurplel/install-qt-action@v4.1.1
        with:
          version: '6.7.3'
          host: 'linux'
          target: 'desktop'
          arch: 'wasm_singlethread'
          modules: 'qtquick3d qtquicktimeline qtshadertools'
          extra: '--autodesktop'
          aqtsource: 'git+https://github.com/Kidev/aqtinstall.git'
```