### PR TITLE
search for modules in extensions directory

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -405,25 +405,28 @@ class QtArchives:
         update_xml_url = posixpath.join(os_target_folder, "Updates.xml")
         update_xml_text = self._download_update_xml(update_xml_url)
         update_xmls = [UpdateXmls(os_target_folder, update_xml_text)]
-        arch = self.arch
-        if self.os_name == "windows":
-            arch = self.arch.replace("win64_", "", 1) 
-        elif self.os_name == "linux":
-            arch = "x86_64"
-        elif self.os_name == "linux_arm64":
-            arch = "arm64"
-        for ext in ["qtwebengine", "qtpdf"]:
-            extensions_target_folder = posixpath.join(
-                "online/qtsdkrepository",
-                os_name,
-                "extensions",
-                ext,
-                self._version_str(),
-                arch
-            )
-            extensions_xml_url = posixpath.join(extensions_target_folder, "Updates.xml")
-            extensions_xml_text = self._download_update_xml(extensions_xml_url)
-            update_xmls.append(UpdateXmls(extensions_target_folder, extensions_xml_text))
+
+        if self.version >= Version("6.8.0"):
+            arch = self.arch
+            if self.os_name == "windows":
+                arch = self.arch.replace("win64_", "", 1) 
+            elif self.os_name == "linux":
+                arch = "x86_64"
+            elif self.os_name == "linux_arm64":
+                arch = "arm64"
+            for ext in ["qtwebengine", "qtpdf"]:
+                extensions_target_folder = posixpath.join(
+                    "online/qtsdkrepository",
+                    os_name,
+                    "extensions",
+                    ext,
+                    self._version_str(),
+                    arch
+                )
+                extensions_xml_url = posixpath.join(extensions_target_folder, "Updates.xml")
+                extensions_xml_text = self._download_update_xml(extensions_xml_url)
+                update_xmls.append(UpdateXmls(extensions_target_folder, extensions_xml_text))
+
         self._parse_update_xmls(update_xmls, target_packages)
 
     def _download_update_xml(self, update_xml_path):

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -481,6 +481,8 @@ class QtArchives:
                 )
 
     def _parse_update_xmls(self, update_xmls, target_packages: Optional[ModuleToPackage]):
+        if not target_packages:
+            target_packages = ModuleToPackage({})
         for update_xml in update_xmls:
             self._parse_update_xml(update_xml.target_folder, update_xml.xml_text, target_packages)
         # if we have located every requested package, then target_packages will be empty

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -404,6 +404,7 @@ class QtArchives:
         )
         update_xml_url = posixpath.join(os_target_folder, "Updates.xml")
         update_xml_text = self._download_update_xml(update_xml_url)
+        update_xmls = [UpdateXmls(os_target_folder, update_xml_text)]
         arch = self.arch
         if self.os_name == "windows":
             arch = self.arch.replace("win64_", "", 1) 
@@ -411,16 +412,18 @@ class QtArchives:
             arch = "x86_64"
         elif self.os_name == "linux_arm64":
             arch = "arm64"
-        extensions_target_folder = posixpath.join(
-            "online/qtsdkrepository",
-            os_name,
-            "extensions/qtwebengine",
-            self._version_str(),
-            arch
-        )
-        extensions_xml_url = posixpath.join(extensions_target_folder, "Updates.xml")
-        extensions_xml_text = self._download_update_xml(extensions_xml_url)
-        update_xmls = [UpdateXmls(os_target_folder, update_xml_text), UpdateXmls(extensions_target_folder, extensions_xml_text) ]
+        for ext in ["qtwebengine", "qtpdf"]:
+            extensions_target_folder = posixpath.join(
+                "online/qtsdkrepository",
+                os_name,
+                "extensions",
+                ext,
+                self._version_str(),
+                arch
+            )
+            extensions_xml_url = posixpath.join(extensions_target_folder, "Updates.xml")
+            extensions_xml_text = self._download_update_xml(extensions_xml_url)
+            update_xmls.append(UpdateXmls(extensions_target_folder, extensions_xml_text))
         self._parse_update_xmls(update_xmls, target_packages)
 
     def _download_update_xml(self, update_xml_path):

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -31,10 +31,12 @@ from aqt.exceptions import ArchiveDownloadError, ArchiveListError, ChecksumDownl
 from aqt.helper import Settings, get_hash, getUrl, ssplit
 from aqt.metadata import QtRepoProperty, Version
 
+
 @dataclass
 class UpdateXmls:
     target_folder: str
     xml_text: str
+
 
 @dataclass
 class TargetConfig:
@@ -409,19 +411,14 @@ class QtArchives:
         if self.version >= Version("6.8.0"):
             arch = self.arch
             if self.os_name == "windows":
-                arch = self.arch.replace("win64_", "", 1) 
+                arch = self.arch.replace("win64_", "", 1)
             elif self.os_name == "linux":
                 arch = "x86_64"
             elif self.os_name == "linux_arm64":
                 arch = "arm64"
             for ext in ["qtwebengine", "qtpdf"]:
                 extensions_target_folder = posixpath.join(
-                    "online/qtsdkrepository",
-                    os_name,
-                    "extensions",
-                    ext,
-                    self._version_str(),
-                    arch
+                    "online/qtsdkrepository", os_name, "extensions", ext, self._version_str(), arch
                 )
                 extensions_xml_url = posixpath.join(extensions_target_folder, "Updates.xml")
                 extensions_xml_text = self._download_update_xml(extensions_xml_url)

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -231,7 +231,7 @@ class ArchiveId:
     def is_tools(self) -> bool:
         return self.category == "tools"
 
-    def to_os_arch(self):
+    def to_os_arch(self) -> str:
         return "{os}{arch}".format(
             os=self.host,
             arch=(

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -244,7 +244,7 @@ class ArchiveId:
     def to_extension_folder(self, module, version, arch) -> str:
         extarch = arch
         if self.host == "windows":
-            extarch = arch.replace("win64_", "", 1) 
+            extarch = arch.replace("win64_", "", 1)
         elif self.host == "linux":
             extarch = "x86_64"
         elif self.host == "linux_arm64":
@@ -929,14 +929,7 @@ class MetadataFactory:
 
         # Examples: extensions.qtwebengine.680.debug_information
         #           extensions.qtwebengine.680.win64_msvc2022_64
-        ext_pattern = re.compile(
-            r"^extensions\."
-            + r"(?P<module>[^.]+)\."
-            + qt_ver_str
-            + r"\."
-            + arch
-            + r"$"
-        )
+        ext_pattern = re.compile(r"^extensions\." + r"(?P<module>[^.]+)\." + qt_ver_str + r"\." + arch + r"$")
         if version >= Version("6.8.0"):
             for ext in self.fetch_extensions():
                 ext_meta = self._fetch_extension_metadata(self.archive_id.to_extension_folder(ext, qt_ver_str, arch))


### PR DESCRIPTION
This allows install-qt to find and install qtwebengine on mac, windows, linux, linux_arm64 with 6.8.0.  It may work with qtpdf as well.

However, list-qt doesn't find qtwebengine.  I suspect there are other deficiencies.

This is related to #803, #818, #824.

I don't expect this PR to be merged as is, but I offer it

- in the spirit of #818 
- in desperation to get CI running with 6.8.0 for https://github/GPSBabel/gpsbabel.git

Note that 6.8.1 is expected to release in a few days.