### PR TITLE
Fix WASM support, add extensions support as modules, fix version logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ Qt/
 .eggs
 qtaccount.ini
 .pytest_cache
+.build_standalone.sh
+aqt.spec
+fil-result/
+memory-profile.png
+mprofile_*

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -835,7 +835,9 @@ class SrcDocExamplesArchives(QtArchives):
         update_xml = Updates.fromstring(self.base, update_xml_text)
         base_url = self.base
 
-        if not self.all_extra and len(target_packages) > 0:
+        if self.all_extra:
+            package_updates = update_xml.get_from(self.arch, self.is_include_base_package)
+        else:
             package_updates = update_xml.get_from(self.arch, self.is_include_base_package, target_packages)
             if not package_updates:
                 missing = sorted(list(target_packages.get_modules()))
@@ -843,8 +845,6 @@ class SrcDocExamplesArchives(QtArchives):
                     f"The packages {missing} were not found while parsing XML of package information!",
                     suggested_action=self.help_msg(missing),
                 )
-        else:
-            package_updates = update_xml.get_from(self.arch, self.is_include_base_package)
 
         for packageupdate in package_updates:
             if not self.all_extra:

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -472,11 +472,10 @@ class QtArchives:
                     continue
             raise NoPackageFound(
                 f"The packages ['qt_base'] were not found while parsing XML of package information!",
-                suggested_action=self.help_msg()
+                suggested_action=self.help_msg(),
             )
 
         validate_arch()
-
 
         # Check for WASM paths first
         if (
@@ -836,8 +835,6 @@ class SrcDocExamplesArchives(QtArchives):
         update_xml = Updates.fromstring(self.base, update_xml_text)
         base_url = self.base
 
-        # Update: those tests are failing for bad errror msg basically frustrating
-        # Add this check here:
         if not self.all_extra and len(target_packages) > 0:
             package_updates = update_xml.get_from(self.arch, self.is_include_base_package, target_packages)
             if not package_updates:

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -31,6 +31,7 @@ from aqt.exceptions import ArchiveDownloadError, ArchiveListError, ChecksumDownl
 from aqt.helper import Settings, get_hash, getUrl, ssplit
 from aqt.repository import QtRepoProperty, Version
 
+
 @dataclass
 class TargetConfig:
     version: str
@@ -272,17 +273,17 @@ class QtArchives:
     """
 
     def __init__(
-            self,
-            os_name: str,
-            target: str,
-            version_str: str,
-            arch: str,
-            base: str,
-            subarchives: Optional[Iterable[str]] = None,
-            modules: Optional[Iterable[str]] = None,
-            all_extra: bool = False,
-            is_include_base_package: bool = True,
-            timeout=(5, 5),
+        self,
+        os_name: str,
+        target: str,
+        version_str: str,
+        arch: str,
+        base: str,
+        subarchives: Optional[Iterable[str]] = None,
+        modules: Optional[Iterable[str]] = None,
+        all_extra: bool = False,
+        is_include_base_package: bool = True,
+        timeout=(5, 5),
     ):
         self.version: Version = Version(version_str)
         self.target: str = target
@@ -312,20 +313,16 @@ class QtArchives:
             # Linux x64
             ("linux", "gcc_64"): ("x86_64", "linux_gcc_64"),
             ("linux", "linux_gcc_64"): ("x86_64", "linux_gcc_64"),
-
             # Linux ARM64
             ("linux_arm64", "gcc_arm64"): ("arm64", "linux_gcc_arm64"),
             ("linux_arm64", "linux_gcc_arm64"): ("arm64", "linux_gcc_arm64"),
-
             # Windows
             ("windows", "win64_msvc2022_64"): ("msvc2022_64", "win64_msvc2022_64"),
             ("windows", "win64_mingw"): ("mingw", "win64_mingw"),
             ("windows", "win64_llvm_mingw"): ("llvm_mingw", "win64_llvm_mingw"),
-
             # macOS
             ("mac", "clang_64"): ("clang_64", "clang_64"),
             ("mac", "ios"): ("ios", "ios"),
-
             # Android (all_os)
             ("all_os", "android_x86_64"): ("qt6_680_x86_64", "android_x86_64"),
             ("all_os", "android_x86"): ("qt6_680_x86", "android_x86"),
@@ -339,8 +336,9 @@ class QtArchives:
         # Default to original arch for both path and package
         return arch, arch
 
-    def _handle_updates_xml(self, os_target_folder: str, update_xml_text: str,
-                            target_packages: Optional[ModuleToPackage]) -> None:
+    def _handle_updates_xml(
+        self, os_target_folder: str, update_xml_text: str, target_packages: Optional[ModuleToPackage]
+    ) -> None:
         """Parse regular Qt module Updates.xml file"""
         if not target_packages:
             target_packages = ModuleToPackage({})
@@ -397,18 +395,13 @@ class QtArchives:
         for packageupdate in update_xml.package_updates:
             if packageupdate.name == package_pattern:
                 found_package = True
-                should_filter_archives: bool = bool(self.subarchives) and self.should_filter_archives(
-                    packageupdate.name)
+                should_filter_archives: bool = bool(self.subarchives) and self.should_filter_archives(packageupdate.name)
 
                 for archive in packageupdate.downloadable_archives:
                     archive_name = archive.split("-", maxsplit=1)[0]
                     if should_filter_archives and self.subarchives is not None and archive_name not in self.subarchives:
                         continue
-                    archive_path = posixpath.join(
-                        os_target_folder,
-                        packageupdate.name,
-                        packageupdate.full_version + archive
-                    )
+                    archive_path = posixpath.join(os_target_folder, packageupdate.name, packageupdate.full_version + archive)
                     self.archives.append(
                         QtPackage(
                             name=archive_name,
@@ -434,8 +427,11 @@ class QtArchives:
                 if self.version >= Version("6.8.0"):
                     # Construct extensions path, e.g. linux_x64/extensions/qtwebengine/680/x86_64
                     version_short = f"{self.version.major}{self.version.minor}{self.version.patch}"
-                    os_arch = self.os_name + ("_x86" if self.os_name == "windows" else (
-                        "" if self.os_name in ("linux_arm64", "all_os", "windows_arm64") else "_x64"))
+                    os_arch = self.os_name + (
+                        "_x86"
+                        if self.os_name == "windows"
+                        else ("" if self.os_name in ("linux_arm64", "all_os", "windows_arm64") else "_x64")
+                    )
 
                     # Convert arch based on OS and input arch
                     folder_arch, package_arch = self._convert_arch_for_extension(self.os_name, self.arch)
@@ -462,8 +458,11 @@ class QtArchives:
             return False
 
         # Check for WASM paths first
-        if self.target == "desktop" and self.version >= Version("6.7.0") and self.arch in (
-        "wasm_singlethread", "wasm_multithread"):
+        if (
+            self.target == "desktop"
+            and self.version >= Version("6.7.0")
+            and self.arch in ("wasm_singlethread", "wasm_multithread")
+        ):
             base_url = "online/qtsdkrepository/all_os/wasm"
             if self.version >= Version("6.8.0"):
                 name = f"qt6_{self._version_str()}/qt6_{self._version_str()}_{self.arch}"
@@ -488,10 +487,14 @@ class QtArchives:
 
             os_target_folder = posixpath.join(
                 "online/qtsdkrepository",
-                os_name + ("_x86" if os_name == "windows" else (
-                    "" if os_name in ("linux_arm64", "all_os", "windows_arm64") else "_x64")),
+                os_name
+                + (
+                    "_x86"
+                    if os_name == "windows"
+                    else ("" if os_name in ("linux_arm64", "all_os", "windows_arm64") else "_x64")
+                ),
                 self.target,
-                name
+                name,
             )
 
         # Process main Updates.xml and modules
@@ -649,18 +652,13 @@ class QtArchives:
         for packageupdate in update_xml.package_updates:
             if packageupdate.name == package_pattern:
                 found_package = True
-                should_filter_archives: bool = bool(self.subarchives) and self.should_filter_archives(
-                    packageupdate.name)
+                should_filter_archives: bool = bool(self.subarchives) and self.should_filter_archives(packageupdate.name)
 
                 for archive in packageupdate.downloadable_archives:
                     archive_name = archive.split("-", maxsplit=1)[0]
                     if should_filter_archives and self.subarchives is not None and archive_name not in self.subarchives:
                         continue
-                    archive_path = posixpath.join(
-                        os_target_folder,
-                        packageupdate.name,
-                        packageupdate.full_version + archive
-                    )
+                    archive_path = posixpath.join(os_target_folder, packageupdate.name, packageupdate.full_version + archive)
                     self.archives.append(
                         QtPackage(
                             name=archive_name,
@@ -752,17 +750,17 @@ class SrcDocExamplesArchives(QtArchives):
     """Hold doc/src/example archive package list."""
 
     def __init__(
-            self,
-            flavor: str,
-            os_name,
-            target,
-            version,
-            base,
-            subarchives=None,
-            modules=None,
-            all_extra=False,
-            is_include_base_package: bool = True,
-            timeout=(5, 5),
+        self,
+        flavor: str,
+        os_name,
+        target,
+        version,
+        base,
+        subarchives=None,
+        modules=None,
+        all_extra=False,
+        is_include_base_package: bool = True,
+        timeout=(5, 5),
     ):
         self.flavor: str = flavor
         self.target = target
@@ -807,8 +805,9 @@ class SrcDocExamplesArchives(QtArchives):
         target_packages = self._target_packages()
         self._get_archives_base(name, target_packages)
 
-    def _parse_archives_xml(self, os_target_folder: str, update_xml_text: str,
-                            target_packages: Optional[ModuleToPackage] = None):
+    def _parse_archives_xml(
+        self, os_target_folder: str, update_xml_text: str, target_packages: Optional[ModuleToPackage] = None
+    ):
         """Parse src/doc/example specific Updates.xml"""
         if not target_packages:
             target_packages = ModuleToPackage({})
@@ -873,6 +872,7 @@ class SrcDocExamplesArchives(QtArchives):
         if has_non_base_pkg:
             messages.append(mods)
         return messages
+
 
 class ToolArchives(QtArchives):
     """Hold tool archive package list

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -361,7 +361,7 @@ class QtArchives:
         return target_packages
 
     def _get_archives(self):
-        if (self.target == "desktop" and self.arch in ("wasm_singlethread", "wasm_multithread")):
+        if self.target == "desktop" and self.version >= Version("6.7.0") and self.arch in ("wasm_singlethread", "wasm_multithread"):
             base_url = "online/qtsdkrepository/all_os/wasm"
             if self.version >= Version("6.8.0"):
                 name = f"qt6_{self._version_str()}/qt6_{self._version_str()}_{self.arch}"

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -30,7 +30,8 @@ import threading
 from logging import Handler, getLogger
 from logging.handlers import QueueListener
 from pathlib import Path
-from typing import Any, Callable, Dict, Generator, List, Optional, TextIO, Tuple, Union
+from typing import Any, Callable, Dict, Generator, TextIO, Union
+from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 from xml.etree.ElementTree import Element
 
@@ -82,9 +83,9 @@ def getUrl(url: str, timeout: Tuple[float, float], expected_hash: Optional[bytes
                 logger.info("Redirected: {}".format(urlparse(newurl).hostname))
                 r = session.get(newurl, stream=True, timeout=timeout)
         except (
-            ConnectionResetError,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
+                ConnectionResetError,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
         ) as e:
             raise ArchiveConnectionError(f"Failure to connect to {url}: {type(e).__name__}") from e
         else:
@@ -278,8 +279,8 @@ def ssplit(data: str) -> Generator[str, None, None]:
 
 
 def xml_to_modules(
-    xml_text: str,
-    predicate: Callable[[Element], bool],
+        xml_text: str,
+        predicate: Callable[[Element], bool],
 ) -> Dict[str, Dict[str, str]]:
     """Converts an XML document to a dict of `PackageUpdate` dicts, indexed by `Name` attribute.
     Only report elements that satisfy `predicate(element)`.

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -30,8 +30,7 @@ import threading
 from logging import Handler, getLogger
 from logging.handlers import QueueListener
 from pathlib import Path
-from typing import Any, Callable, Dict, Generator, TextIO, Union
-from typing import List, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, List, Optional, TextIO, Tuple, Union
 from urllib.parse import urlparse
 from xml.etree.ElementTree import Element
 
@@ -83,9 +82,9 @@ def getUrl(url: str, timeout: Tuple[float, float], expected_hash: Optional[bytes
                 logger.info("Redirected: {}".format(urlparse(newurl).hostname))
                 r = session.get(newurl, stream=True, timeout=timeout)
         except (
-                ConnectionResetError,
-                requests.exceptions.ConnectionError,
-                requests.exceptions.Timeout,
+            ConnectionResetError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
         ) as e:
             raise ArchiveConnectionError(f"Failure to connect to {url}: {type(e).__name__}") from e
         else:
@@ -279,8 +278,8 @@ def ssplit(data: str) -> Generator[str, None, None]:
 
 
 def xml_to_modules(
-        xml_text: str,
-        predicate: Callable[[Element], bool],
+    xml_text: str,
+    predicate: Callable[[Element], bool],
 ) -> Dict[str, Dict[str, str]]:
     """Converts an XML document to a dict of `PackageUpdate` dicts, indexed by `Name` attribute.
     Only report elements that satisfy `predicate(element)`.

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -482,14 +482,24 @@ class Cli:
     def run_install_example(self, args):
         """Run example subcommand"""
         start_time = time.perf_counter()
-        self._run_src_doc_examples("examples", args, cmd_name="example")
-        self.logger.info("Time elapsed: {time:.8f} second".format(time=time.perf_counter() - start_time))
+        try:
+            self._run_src_doc_examples("examples", args)
+            self.logger.info("Time elapsed: {time:.8f} second".format(time=time.perf_counter() - start_time))
+            return 1  # Return error code if no exception thrown but nothing found
+        except AqtException as e:
+            self.logger.error(format(e), exc_info=Settings.print_stacktrace_on_error)
+            return 1
 
     def run_install_doc(self, args):
         """Run doc subcommand"""
         start_time = time.perf_counter()
-        self._run_src_doc_examples("doc", args)
-        self.logger.info("Time elapsed: {time:.8f} second".format(time=time.perf_counter() - start_time))
+        try:
+            self._run_src_doc_examples("doc", args)
+            self.logger.info("Time elapsed: {time:.8f} second".format(time=time.perf_counter() - start_time))
+            return 1  # Return error code if no exception thrown but nothing found
+        except AqtException as e:
+            self.logger.error(format(e), exc_info=Settings.print_stacktrace_on_error)
+            return 1
 
     def run_install_tool(self, args: InstallToolArgParser):
         """Run tool subcommand"""

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -190,7 +190,7 @@ class ArchiveId:
         return self.category == "tools"
 
     def to_url(self) -> str:
-        if self.target == "desktop" and self.host in ("wasm_singlethread", "wasm_multithread") and self.version >= Version("6.7.0"):
+        if self.target == "desktop" and self.host in ("wasm_singlethread", "wasm_multithread"):
             return "online/qtsdkrepository/all_os/wasm/"
         return "online/qtsdkrepository/{os}{arch}/{target}/".format(
             os=self.host,

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -232,7 +232,7 @@ class ArchiveId:
         return self.category == "tools"
 
     def to_url(self) -> str:
-        if self.target == "desktop" and self.arch in ("wasm_singlethread", "wasm_multithread"):
+        if self.target == "desktop" and self.host in ("wasm_singlethread", "wasm_multithread") and self.version >= Version("6.7.0"):
             return "online/qtsdkrepository/all_os/wasm/"
         return "online/qtsdkrepository/{os}{arch}/{target}/".format(
             os=self.host,

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -34,12 +34,11 @@ from xml.etree.ElementTree import Element
 
 import bs4
 from semantic_version import SimpleSpec as SemanticSimpleSpec
-from semantic_version import Version as SemanticVersion
 from texttable import Texttable
 
 from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError, ArchiveListError, CliInputError, EmptyMetadata
 from aqt.helper import Settings, get_hash, getUrl, xml_to_modules
-
+from aqt.repository import QtRepoProperty, Version
 
 class SimpleSpec(SemanticSimpleSpec):
     pass
@@ -57,76 +56,6 @@ class SimpleSpec(SemanticSimpleSpec):
         )
 
 
-class Version(SemanticVersion):
-    """Override semantic_version.Version class
-    to accept Qt versions and tools versions
-    If the version ends in `-preview`, the version is treated as a preview release.
-    """
-
-    def __init__(
-        self,
-        version_string=None,
-        major=None,
-        minor=None,
-        patch=None,
-        prerelease=None,
-        build=None,
-        partial=False,
-    ):
-        if version_string is None:
-            super(Version, self).__init__(
-                version_string=None,
-                major=major,
-                minor=minor,
-                patch=patch,
-                prerelease=prerelease,
-                build=build,
-                partial=partial,
-            )
-            return
-        # test qt versions
-        match = re.match(r"^(\d+)\.(\d+)(\.(\d+)|-preview)$", version_string)
-        if not match:
-            # bad input
-            raise ValueError("Invalid version string: '{}'".format(version_string))
-        major, minor, end, patch = match.groups()
-        is_preview = end == "-preview"
-        super(Version, self).__init__(
-            major=int(major),
-            minor=int(minor),
-            patch=int(patch) if patch else 0,
-            prerelease=("preview",) if is_preview else None,
-        )
-
-    def __str__(self):
-        if self.prerelease:
-            return "{}.{}-preview".format(self.major, self.minor)
-        return super(Version, self).__str__()
-
-    @classmethod
-    def permissive(cls, version_string: str):
-        """Converts a version string with dots (5.X.Y, etc) into a semantic version.
-        If the version omits either the patch or minor versions, they will be filled in with zeros,
-        and the remaining version string becomes part of the prerelease component.
-        If the version cannot be converted to a Version, a ValueError is raised.
-
-        This is intended to be used on Version tags in an Updates.xml file.
-
-        '1.33.1-202102101246' => Version('1.33.1-202102101246')
-        '1.33-202102101246' => Version('1.33.0-202102101246')    # tools_conan
-        '2020-05-19-1' => Version('2020.0.0-05-19-1')            # tools_vcredist
-        """
-
-        match = re.match(r"^(\d+)(\.(\d+)(\.(\d+))?)?(-(.+))?$", version_string)
-        if not match:
-            raise ValueError("Invalid version string: '{}'".format(version_string))
-        major, dot_minor, minor, dot_patch, patch, hyphen_build, build = match.groups()
-        return cls(
-            major=int(major),
-            minor=int(minor) if minor else 0,
-            patch=int(patch) if patch else 0,
-            build=(build,) if build else None,
-        )
 
 
 class Versions:
@@ -234,18 +163,11 @@ def get_semantic_version(qt_ver: str, is_preview: bool) -> Optional[Version]:
 
 
 class ArchiveId:
-    CATEGORIES = ("tools", "qt")
-    HOSTS = ("windows", "windows_arm64", "mac", "linux", "linux_arm64", "all_os")
-    TARGETS_FOR_HOST = {
-        "windows": ["android", "desktop", "winrt"],
-        "windows_arm64": ["desktop"],
-        "mac": ["android", "desktop", "ios"],
-        "linux": ["android", "desktop"],
-        "linux_arm64": ["desktop"],
-        "all_os": ["qt", "wasm"],
-    }
-    EXTENSIONS_REQUIRED_ANDROID_QT6 = {"x86_64", "x86", "armv7", "arm64_v8a"}
-    ALL_EXTENSIONS = {"", "wasm", "src_doc_examples", *EXTENSIONS_REQUIRED_ANDROID_QT6}
+    CATEGORIES = QtRepoProperty.CATEGORIES
+    HOSTS = QtRepoProperty.HOSTS
+    TARGETS_FOR_HOST = QtRepoProperty.TARGETS_FOR_HOST
+    EXTENSIONS_REQUIRED_ANDROID_QT6 = QtRepoProperty.EXTENSIONS_REQUIRED_ANDROID_QT6
+    ALL_EXTENSIONS = QtRepoProperty.ALL_EXTENSIONS
 
     def __init__(self, category: str, host: str, target: str):
         if category not in ArchiveId.CATEGORIES:
@@ -411,165 +333,6 @@ class ModuleData(TableMetadata):
     @property
     def name_heading(self) -> str:
         return "Module Name"
-
-
-class QtRepoProperty:
-    """
-    Describes properties of the Qt repository at https://download.qt.io/online/qtsdkrepository.
-    Intended to help decouple the logic of aqt from specific properties of the Qt repository.
-    """
-
-    @staticmethod
-    def dir_for_version(ver: Version) -> str:
-        return "5.9" if ver == Version("5.9.0") else f"{ver.major}.{ver.minor}.{ver.patch}"
-
-    @staticmethod
-    def get_arch_dir_name(host: str, arch: str, version: Version) -> str:
-        if arch.startswith("win64_mingw"):
-            return arch[6:] + "_64"
-        elif arch.startswith("win64_llvm"):
-            return "llvm-" + arch[11:] + "_64"
-        elif arch.startswith("win32_mingw"):
-            return arch[6:] + "_32"
-        elif arch.startswith("win"):
-            m = re.match(r"win\d{2}_(?P<msvc>msvc\d{4})_(?P<winrt>winrt_x\d{2})", arch)
-            if m:
-                return f"{m.group('winrt')}_{m.group('msvc')}"
-            elif arch.endswith("_cross_compiled"):
-                return arch[6:-15]
-            else:
-                return arch[6:]
-        elif host == "mac" and arch == "clang_64":
-            return QtRepoProperty.default_mac_desktop_arch_dir(version)
-        elif host == "linux" and arch in ("gcc_64", "linux_gcc_64"):
-            return "gcc_64"
-        elif host == "linux_arm64" and arch == "linux_gcc_arm64":
-            return "gcc_arm64"
-        else:
-            return arch
-
-    @staticmethod
-    def default_linux_desktop_arch_dir() -> Tuple[str, str]:
-        return ("gcc_64", "gcc_arm64")
-
-    @staticmethod
-    def default_win_msvc_desktop_arch_dir(_version: Version) -> str:
-        if _version >= Version("6.8.0"):
-            return "msvc2022_64"
-        else:
-            return "msvc2019_64"
-
-    @staticmethod
-    def default_mac_desktop_arch_dir(version: Version) -> str:
-        return "macos" if version in SimpleSpec(">=6.1.2") else "clang_64"
-
-    @staticmethod
-    def extension_for_arch(architecture: str, is_version_ge_6: bool) -> str:
-        if architecture == "wasm_32":
-            return "wasm"
-        elif architecture == "wasm_singlethread":
-            return "wasm_singlethread"
-        elif architecture == "wasm_multithread":
-            return "wasm_multithread"
-        elif architecture.startswith("android_") and is_version_ge_6:
-            ext = architecture[len("android_") :]
-            if ext in ArchiveId.EXTENSIONS_REQUIRED_ANDROID_QT6:
-                return ext
-        return ""
-
-    @staticmethod
-    def possible_extensions_for_arch(arch: str) -> List[str]:
-        """Assumes no knowledge of the Qt version"""
-
-        # ext_ge_6: the extension if the version is greater than or equal to 6.0.0
-        # ext_lt_6: the extension if the version is less than 6.0.0
-        ext_lt_6, ext_ge_6 = [QtRepoProperty.extension_for_arch(arch, is_ge_6) for is_ge_6 in (False, True)]
-        if ext_lt_6 == ext_ge_6:
-            return [ext_lt_6]
-        return [ext_lt_6, ext_ge_6]
-
-    # Architecture, as reported in Updates.xml
-    MINGW_ARCH_PATTERN = re.compile(r"^win(?P<bits>\d+)_mingw(?P<version>\d+)?$")
-    # Directory that corresponds to an architecture
-    MINGW_DIR_PATTERN = re.compile(r"^mingw(?P<version>\d+)?_(?P<bits>\d+)$")
-
-    @staticmethod
-    def select_default_mingw(mingw_arches: List[str], is_dir: bool) -> Optional[str]:
-        """
-        Selects a default architecture from a non-empty list of mingw architectures, matching the pattern
-        MetadataFactory.MINGW_ARCH_PATTERN. Meant to be called on a list of installed mingw architectures,
-        or a list of architectures available for installation.
-        """
-
-        ArchBitsVer = Tuple[str, int, Optional[int]]
-        pattern = QtRepoProperty.MINGW_DIR_PATTERN if is_dir else QtRepoProperty.MINGW_ARCH_PATTERN
-
-        def mingw_arch_with_bits_and_version(arch: str) -> Optional[ArchBitsVer]:
-            match = pattern.match(arch)
-            if not match:
-                return None
-            bits = int(match.group("bits"))
-            ver = None if not match.group("version") else int(match.group("version"))
-            return arch, bits, ver
-
-        def select_superior_arch(lhs: ArchBitsVer, rhs: ArchBitsVer) -> ArchBitsVer:
-            _, l_bits, l_ver = lhs
-            _, r_bits, r_ver = rhs
-            if l_bits != r_bits:
-                return lhs if l_bits > r_bits else rhs
-            elif r_ver is None:
-                return lhs
-            elif l_ver is None:
-                return rhs
-            return lhs if l_ver > r_ver else rhs
-
-        candidates: List[ArchBitsVer] = list(filter(None, map(mingw_arch_with_bits_and_version, mingw_arches)))
-        if len(candidates) == 0:
-            return None
-        default_arch, _, _ = reduce(select_superior_arch, candidates)
-        return default_arch
-
-    @staticmethod
-    def find_installed_desktop_qt_dir(host: str, base_path: Path, version: Version, is_msvc: bool = False) -> Optional[Path]:
-        """
-        Locates the default installed desktop qt directory, somewhere in base_path.
-        """
-        installed_qt_version_dir = base_path / QtRepoProperty.dir_for_version(version)
-        if host == "mac":
-            arch_path = installed_qt_version_dir / QtRepoProperty.default_mac_desktop_arch_dir(version)
-            return arch_path if (arch_path / "bin/qmake").is_file() else None
-        elif host == "linux":
-            for arch_dir in QtRepoProperty.default_linux_desktop_arch_dir():
-                arch_path = installed_qt_version_dir / arch_dir
-                if (arch_path / "bin/qmake").is_file():
-                    return arch_path
-            return None
-        elif host == "windows" and is_msvc:
-            arch_path = installed_qt_version_dir / QtRepoProperty.default_win_msvc_desktop_arch_dir(version)
-            return arch_path if (arch_path / "bin/qmake.exe").is_file() else None
-
-        def contains_qmake_exe(arch_path: Path) -> bool:
-            return (arch_path / "bin/qmake.exe").is_file()
-
-        paths = [d for d in installed_qt_version_dir.glob("mingw*")]
-        directories = list(filter(contains_qmake_exe, paths))
-        arch_dirs = [d.name for d in directories]
-        selected_dir = QtRepoProperty.select_default_mingw(arch_dirs, is_dir=True)
-        return installed_qt_version_dir / selected_dir if selected_dir else None
-
-    @staticmethod
-    def is_in_wasm_range(host: str, version: Version) -> bool:
-        if version >= Version("6.7.0"):
-            return True
-        return (
-            version in SimpleSpec(">=6.2.0,<6.5.0")
-            or (host == "linux" and version in SimpleSpec(">=5.13,<6"))
-            or version in SimpleSpec(">=5.13.1,<6")
-        )
-
-    @staticmethod
-    def is_in_wasm_threaded_range(version: Version) -> bool:
-        return version in SimpleSpec(">=6.5.0")
 
 
 class MetadataFactory:
@@ -866,6 +629,7 @@ class MetadataFactory:
 
     def fetch_modules(self, version: Version, arch: str) -> List[str]:
         """Returns list of modules"""
+        # Get standard modules first
         extension = QtRepoProperty.extension_for_arch(arch, version >= Version("6.0.0"))
         qt_ver_str = self._get_qt_version_str(version)
         # Example: re.compile(r"^(preview\.)?qt\.(qt5\.)?590\.(.+)$")
@@ -881,14 +645,42 @@ class MetadataFactory:
                 return module_with_arch, None
             module, arch = module_with_arch.rsplit(".", 1)
             if module.startswith("addons."):
-                module = module[len("addons.") :]
+                module = module[len("addons."):]
             return module, arch
 
+        # Get regular modules
         modules: Set[str] = set()
         for name in modules_meta.keys():
             module, _arch = to_module_arch(name)
             if _arch == arch:
                 modules.add(cast(str, module))
+
+        # Check for extensions if Qt >= 6.8.0
+        if version >= Version("6.8.0"):
+            os_arch = self.archive_id.host + ("_x86" if self.archive_id.host == "windows" else (
+                "" if self.archive_id.host in ("linux_arm64", "all_os", "windows_arm64") else "_x64"))
+
+            # Convert arch for extensions path
+            folder_arch, package_arch = QtRepoProperty.convert_arch_for_extension(self.archive_id.host, arch)
+
+            # Try each known extension
+            for extension_module in QtRepoProperty.known_extensions():
+                extension_path = posixpath.join(
+                    "online/qtsdkrepository",
+                    os_arch,
+                    "extensions",
+                    extension_module,
+                    qt_ver_str,
+                    folder_arch,
+                    "Updates.xml"
+                )
+
+                try:
+                    self.fetch_http(extension_path)
+                    modules.add(extension_module)
+                except ArchiveDownloadError:
+                    continue
+
         return sorted(modules)
 
     @staticmethod

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -25,9 +25,7 @@ import re
 import secrets as random
 import shutil
 from abc import ABC, abstractmethod
-from functools import reduce
 from logging import getLogger
-from pathlib import Path
 from typing import Callable, Dict, Generator, Iterable, Iterator, List, NamedTuple, Optional, Set, Tuple, Union, cast
 from urllib.parse import ParseResult, urlparse
 from xml.etree.ElementTree import Element
@@ -39,6 +37,7 @@ from texttable import Texttable
 from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError, ArchiveListError, CliInputError, EmptyMetadata
 from aqt.helper import Settings, get_hash, getUrl, xml_to_modules
 from aqt.repository import QtRepoProperty, Version
+
 
 class SimpleSpec(SemanticSimpleSpec):
     pass
@@ -54,8 +53,6 @@ class SimpleSpec(SemanticSimpleSpec):
             '* "5.6": matches every version beginning with 5.6\n'
             '* "5.*.3": matches versions with major=5 and patch=3'
         )
-
-
 
 
 class Versions:
@@ -123,8 +120,8 @@ def get_semantic_version(qt_ver: str, is_preview: bool) -> Optional[Version]:
 
     try:
         # Handle versions with underscores (new format)
-        if '_' in qt_ver:
-            parts = qt_ver.split('_')
+        if "_" in qt_ver:
+            parts = qt_ver.split("_")
             if len(parts) < 2 or len(parts) > 3:
                 return None
 
@@ -645,7 +642,7 @@ class MetadataFactory:
                 return module_with_arch, None
             module, arch = module_with_arch.rsplit(".", 1)
             if module.startswith("addons."):
-                module = module[len("addons."):]
+                module = module[len("addons.") :]
             return module, arch
 
         # Get regular modules
@@ -657,8 +654,11 @@ class MetadataFactory:
 
         # Check for extensions if Qt >= 6.8.0
         if version >= Version("6.8.0"):
-            os_arch = self.archive_id.host + ("_x86" if self.archive_id.host == "windows" else (
-                "" if self.archive_id.host in ("linux_arm64", "all_os", "windows_arm64") else "_x64"))
+            os_arch = self.archive_id.host + (
+                "_x86"
+                if self.archive_id.host == "windows"
+                else ("" if self.archive_id.host in ("linux_arm64", "all_os", "windows_arm64") else "_x64")
+            )
 
             # Convert arch for extensions path
             folder_arch, package_arch = QtRepoProperty.convert_arch_for_extension(self.archive_id.host, arch)
@@ -666,13 +666,7 @@ class MetadataFactory:
             # Try each known extension
             for extension_module in QtRepoProperty.known_extensions():
                 extension_path = posixpath.join(
-                    "online/qtsdkrepository",
-                    os_arch,
-                    "extensions",
-                    extension_module,
-                    qt_ver_str,
-                    folder_arch,
-                    "Updates.xml"
+                    "online/qtsdkrepository", os_arch, "extensions", extension_module, qt_ver_str, folder_arch, "Updates.xml"
                 )
 
                 try:

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -206,7 +206,7 @@ class ArchiveId:
         "mac": ["android", "desktop", "ios"],
         "linux": ["android", "desktop"],
         "linux_arm64": ["desktop"],
-        "all_os": ["qt"],
+        "all_os": ["qt", "wasm"],
     }
     EXTENSIONS_REQUIRED_ANDROID_QT6 = {"x86_64", "x86", "armv7", "arm64_v8a"}
     ALL_EXTENSIONS = {"", "wasm", "src_doc_examples", *EXTENSIONS_REQUIRED_ANDROID_QT6}
@@ -232,6 +232,8 @@ class ArchiveId:
         return self.category == "tools"
 
     def to_url(self) -> str:
+        if self.target == "desktop" and self.arch in ("wasm_singlethread", "wasm_multithread"):
+            return "online/qtsdkrepository/all_os/wasm/"
         return "online/qtsdkrepository/{os}{arch}/{target}/".format(
             os=self.host,
             arch=(
@@ -521,6 +523,8 @@ class QtRepoProperty:
 
     @staticmethod
     def is_in_wasm_range(host: str, version: Version) -> bool:
+        if version >= Version("6.7.0"):
+            return True
         return (
             version in SimpleSpec(">=6.2.0,<6.5.0")
             or (host == "linux" and version in SimpleSpec(">=5.13,<6"))

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -642,7 +642,7 @@ class MetadataFactory:
                 return module_with_arch, None
             module, arch = module_with_arch.rsplit(".", 1)
             if module.startswith("addons."):
-                module = module[len("addons.") :]
+                module = module[len("addons."):]
             return module, arch
 
         # Get regular modules

--- a/aqt/repository.py
+++ b/aqt/repository.py
@@ -1,9 +1,11 @@
 import re
 from functools import reduce
 from pathlib import Path
-from typing import List, Tuple, Optional
-from semantic_version import Version as SemanticVersion
+from typing import List, Optional, Tuple
+
 from semantic_version import SimpleSpec
+from semantic_version import Version as SemanticVersion
+
 
 class Version(SemanticVersion):
     """Override semantic_version.Version class
@@ -103,20 +105,16 @@ class QtRepoProperty:
             # Linux x64
             ("linux", "gcc_64"): ("x86_64", "linux_gcc_64"),
             ("linux", "linux_gcc_64"): ("x86_64", "linux_gcc_64"),
-
             # Linux ARM64
             ("linux_arm64", "gcc_arm64"): ("arm64", "linux_gcc_arm64"),
             ("linux_arm64", "linux_gcc_arm64"): ("arm64", "linux_gcc_arm64"),
-
             # Windows
             ("windows", "win64_msvc2022_64"): ("msvc2022_64", "win64_msvc2022_64"),
             ("windows", "win64_mingw"): ("mingw", "win64_mingw"),
             ("windows", "win64_llvm_mingw"): ("llvm_mingw", "win64_llvm_mingw"),
-
             # macOS
             ("mac", "clang_64"): ("clang_64", "clang_64"),
             ("mac", "ios"): ("ios", "ios"),
-
             # Android (all_os)
             ("all_os", "android_x86_64"): ("qt6_680_x86_64", "android_x86_64"),
             ("all_os", "android_x86"): ("qt6_680_x86", "android_x86"),
@@ -196,7 +194,7 @@ class QtRepoProperty:
         elif architecture == "wasm_multithread":
             return "wasm_multithread"
         elif architecture.startswith("android_") and is_version_ge_6:
-            ext = architecture[len("android_"):]
+            ext = architecture[len("android_") :]
             if ext in QtRepoProperty.EXTENSIONS_REQUIRED_ANDROID_QT6:
                 return ext
         return ""
@@ -225,6 +223,7 @@ class QtRepoProperty:
         """
         ArchBitsVer = Tuple[str, int, Optional[int]]
         pattern = QtRepoProperty.MINGW_DIR_PATTERN if is_dir else QtRepoProperty.MINGW_ARCH_PATTERN
+
         def mingw_arch_with_bits_and_version(arch: str) -> Optional[ArchBitsVer]:
             match = pattern.match(arch)
             if not match:
@@ -232,6 +231,7 @@ class QtRepoProperty:
             bits = int(match.group("bits"))
             ver = None if not match.group("version") else int(match.group("version"))
             return arch, bits, ver
+
         def select_superior_arch(lhs: ArchBitsVer, rhs: ArchBitsVer) -> ArchBitsVer:
             _, l_bits, l_ver = lhs
             _, r_bits, r_ver = rhs
@@ -242,6 +242,7 @@ class QtRepoProperty:
             elif l_ver is None:
                 return rhs
             return lhs if l_ver > r_ver else rhs
+
         candidates: List[ArchBitsVer] = list(filter(None, map(mingw_arch_with_bits_and_version, mingw_arches)))
         if len(candidates) == 0:
             return None
@@ -266,8 +267,10 @@ class QtRepoProperty:
         elif host == "windows" and is_msvc:
             arch_path = installed_qt_version_dir / QtRepoProperty.default_win_msvc_desktop_arch_dir(version)
             return arch_path if (arch_path / "bin/qmake.exe").is_file() else None
+
         def contains_qmake_exe(arch_path: Path) -> bool:
             return (arch_path / "bin/qmake.exe").is_file()
+
         paths = [d for d in installed_qt_version_dir.glob("mingw*")]
         directories = list(filter(contains_qmake_exe, paths))
         arch_dirs = [d.name for d in directories]
@@ -279,9 +282,9 @@ class QtRepoProperty:
         if version >= Version("6.7.0"):
             return True
         return (
-                version in SimpleSpec(">=6.2.0,<6.5.0")
-                or (host == "linux" and version in SimpleSpec(">=5.13,<6"))
-                or version in SimpleSpec(">=5.13.1,<6")
+            version in SimpleSpec(">=6.2.0,<6.5.0")
+            or (host == "linux" and version in SimpleSpec(">=5.13,<6"))
+            or version in SimpleSpec(">=5.13.1,<6")
         )
 
     @staticmethod

--- a/aqt/repository.py
+++ b/aqt/repository.py
@@ -125,7 +125,7 @@ class QtRepoProperty:
         }
 
     @staticmethod
-    def convert_arch_for_extension(os_name: str, arch: str) -> Tuple[str, str]:
+    def convert_arch_for_extension(os_name: str, arch: str):
         """Convert architecture name for extensions path and package name
         Returns (folder_arch, package_arch) where:
         - folder_arch: used in the path: <os>_x64/extensions/<module>/<version>/<folder_arch>

--- a/aqt/repository.py
+++ b/aqt/repository.py
@@ -1,0 +1,289 @@
+import re
+from functools import reduce
+from pathlib import Path
+from typing import List, Tuple, Optional
+from semantic_version import Version as SemanticVersion
+from semantic_version import SimpleSpec
+
+class Version(SemanticVersion):
+    """Override semantic_version.Version class
+    to accept Qt versions and tools versions
+    If the version ends in `-preview`, the version is treated as a preview release.
+    """
+
+    def __init__(
+        self,
+        version_string=None,
+        major=None,
+        minor=None,
+        patch=None,
+        prerelease=None,
+        build=None,
+        partial=False,
+    ):
+        if version_string is None:
+            super(Version, self).__init__(
+                version_string=None,
+                major=major,
+                minor=minor,
+                patch=patch,
+                prerelease=prerelease,
+                build=build,
+                partial=partial,
+            )
+            return
+        # test qt versions
+        match = re.match(r"^(\d+)\.(\d+)(\.(\d+)|-preview)$", version_string)
+        if not match:
+            # bad input
+            raise ValueError("Invalid version string: '{}'".format(version_string))
+        major, minor, end, patch = match.groups()
+        is_preview = end == "-preview"
+        super(Version, self).__init__(
+            major=int(major),
+            minor=int(minor),
+            patch=int(patch) if patch else 0,
+            prerelease=("preview",) if is_preview else None,
+        )
+
+    def __str__(self):
+        if self.prerelease:
+            return "{}.{}-preview".format(self.major, self.minor)
+        return super(Version, self).__str__()
+
+    @classmethod
+    def permissive(cls, version_string: str):
+        """Converts a version string with dots (5.X.Y, etc) into a semantic version.
+        If the version omits either the patch or minor versions, they will be filled in with zeros,
+        and the remaining version string becomes part of the prerelease component.
+        If the version cannot be converted to a Version, a ValueError is raised.
+
+        This is intended to be used on Version tags in an Updates.xml file.
+
+        '1.33.1-202102101246' => Version('1.33.1-202102101246')
+        '1.33-202102101246' => Version('1.33.0-202102101246')    # tools_conan
+        '2020-05-19-1' => Version('2020.0.0-05-19-1')            # tools_vcredist
+        """
+
+        match = re.match(r"^(\d+)(\.(\d+)(\.(\d+))?)?(-(.+))?$", version_string)
+        if not match:
+            raise ValueError("Invalid version string: '{}'".format(version_string))
+        major, dot_minor, minor, dot_patch, patch, hyphen_build, build = match.groups()
+        return cls(
+            major=int(major),
+            minor=int(minor) if minor else 0,
+            patch=int(patch) if patch else 0,
+            build=(build,) if build else None,
+        )
+
+
+class QtRepoProperty:
+    """
+    Describes properties of the Qt repository at https://download.qt.io/online/qtsdkrepository.
+    Intended to help decouple the logic of aqt from specific properties of the Qt repository.
+    """
+
+    CATEGORIES = ("tools", "qt")
+    HOSTS = ("windows", "windows_arm64", "mac", "linux", "linux_arm64", "all_os")
+    TARGETS_FOR_HOST = {
+        "windows": ["android", "desktop", "winrt"],
+        "windows_arm64": ["desktop"],
+        "mac": ["android", "desktop", "ios"],
+        "linux": ["android", "desktop"],
+        "linux_arm64": ["desktop"],
+        "all_os": ["qt", "wasm"],
+    }
+    EXTENSIONS_REQUIRED_ANDROID_QT6 = {"x86_64", "x86", "armv7", "arm64_v8a"}
+    ALL_EXTENSIONS = {"", "wasm", "src_doc_examples", *EXTENSIONS_REQUIRED_ANDROID_QT6}
+
+    @staticmethod
+    def arch_conversion_map():
+        # Extension arch conversion table from Qt SDK layout
+        return {
+            # Linux x64
+            ("linux", "gcc_64"): ("x86_64", "linux_gcc_64"),
+            ("linux", "linux_gcc_64"): ("x86_64", "linux_gcc_64"),
+
+            # Linux ARM64
+            ("linux_arm64", "gcc_arm64"): ("arm64", "linux_gcc_arm64"),
+            ("linux_arm64", "linux_gcc_arm64"): ("arm64", "linux_gcc_arm64"),
+
+            # Windows
+            ("windows", "win64_msvc2022_64"): ("msvc2022_64", "win64_msvc2022_64"),
+            ("windows", "win64_mingw"): ("mingw", "win64_mingw"),
+            ("windows", "win64_llvm_mingw"): ("llvm_mingw", "win64_llvm_mingw"),
+
+            # macOS
+            ("mac", "clang_64"): ("clang_64", "clang_64"),
+            ("mac", "ios"): ("ios", "ios"),
+
+            # Android (all_os)
+            ("all_os", "android_x86_64"): ("qt6_680_x86_64", "android_x86_64"),
+            ("all_os", "android_x86"): ("qt6_680_x86", "android_x86"),
+            ("all_os", "android_armv7"): ("qt6_680_armv7", "android_armv7"),
+            ("all_os", "android_arm64_v8a"): ("qt6_680_arm64_v8a", "android_arm64_v8a"),
+        }
+
+    @staticmethod
+    def convert_arch_for_extension(os_name: str, arch: str) -> Tuple[str, str]:
+        """Convert architecture name for extensions path and package name
+        Returns (folder_arch, package_arch) where:
+        - folder_arch: used in the path: <os>_x64/extensions/<module>/<version>/<folder_arch>
+        - package_arch: used in package name: extensions.<module>.<version>.<package_arch>
+        """
+        conversions = QtRepoProperty.arch_conversion_map()
+        if (os_name, arch) in conversions:
+            return conversions[(os_name, arch)]
+
+        # Default to original arch for both path and package
+        return arch, arch
+
+    @staticmethod
+    def known_extensions() -> List[str]:
+        """Known Qt 6.8.0+ extensions"""
+        return ["qtpdf", "qtwebengine"]
+
+    @staticmethod
+    def dir_for_version(ver: Version) -> str:
+        return "5.9" if ver == Version("5.9.0") else f"{ver.major}.{ver.minor}.{ver.patch}"
+
+    @staticmethod
+    def get_arch_dir_name(host: str, arch: str, version: Version) -> str:
+        if arch.startswith("win64_mingw"):
+            return arch[6:] + "_64"
+        elif arch.startswith("win64_llvm"):
+            return "llvm-" + arch[11:] + "_64"
+        elif arch.startswith("win32_mingw"):
+            return arch[6:] + "_32"
+        elif arch.startswith("win"):
+            m = re.match(r"win\d{2}_(?P<msvc>msvc\d{4})_(?P<winrt>winrt_x\d{2})", arch)
+            if m:
+                return f"{m.group('winrt')}_{m.group('msvc')}"
+            elif arch.endswith("_cross_compiled"):
+                return arch[6:-15]
+            else:
+                return arch[6:]
+        elif host == "mac" and arch == "clang_64":
+            return QtRepoProperty.default_mac_desktop_arch_dir(version)
+        elif host == "linux" and arch in ("gcc_64", "linux_gcc_64"):
+            return "gcc_64"
+        elif host == "linux_arm64" and arch == "linux_gcc_arm64":
+            return "gcc_arm64"
+        else:
+            return arch
+
+    @staticmethod
+    def default_linux_desktop_arch_dir() -> Tuple[str, str]:
+        return ("gcc_64", "gcc_arm64")
+
+    @staticmethod
+    def default_win_msvc_desktop_arch_dir(_version: Version) -> str:
+        if _version >= Version("6.8.0"):
+            return "msvc2022_64"
+        else:
+            return "msvc2019_64"
+
+    @staticmethod
+    def default_mac_desktop_arch_dir(version: Version) -> str:
+        return "macos" if version in SimpleSpec(">=6.1.2") else "clang_64"
+
+    @staticmethod
+    def extension_for_arch(architecture: str, is_version_ge_6: bool) -> str:
+        if architecture == "wasm_32":
+            return "wasm"
+        elif architecture == "wasm_singlethread":
+            return "wasm_singlethread"
+        elif architecture == "wasm_multithread":
+            return "wasm_multithread"
+        elif architecture.startswith("android_") and is_version_ge_6:
+            ext = architecture[len("android_"):]
+            if ext in QtRepoProperty.EXTENSIONS_REQUIRED_ANDROID_QT6:
+                return ext
+        return ""
+
+    @staticmethod
+    def possible_extensions_for_arch(arch: str) -> List[str]:
+        """Assumes no knowledge of the Qt version"""
+        # ext_ge_6: the extension if the version is greater than or equal to 6.0.0
+        # ext_lt_6: the extension if the version is less than 6.0.0
+        ext_lt_6, ext_ge_6 = [QtRepoProperty.extension_for_arch(arch, is_ge_6) for is_ge_6 in (False, True)]
+        if ext_lt_6 == ext_ge_6:
+            return [ext_lt_6]
+        return [ext_lt_6, ext_ge_6]
+
+    # Architecture, as reported in Updates.xml
+    MINGW_ARCH_PATTERN = re.compile(r"^win(?P<bits>\d+)_mingw(?P<version>\d+)?$")
+    # Directory that corresponds to an architecture
+    MINGW_DIR_PATTERN = re.compile(r"^mingw(?P<version>\d+)?_(?P<bits>\d+)$")
+
+    @staticmethod
+    def select_default_mingw(mingw_arches: List[str], is_dir: bool) -> Optional[str]:
+        """
+        Selects a default architecture from a non-empty list of mingw architectures, matching the pattern
+        MetadataFactory.MINGW_ARCH_PATTERN. Meant to be called on a list of installed mingw architectures,
+        or a list of architectures available for installation.
+        """
+        ArchBitsVer = Tuple[str, int, Optional[int]]
+        pattern = QtRepoProperty.MINGW_DIR_PATTERN if is_dir else QtRepoProperty.MINGW_ARCH_PATTERN
+        def mingw_arch_with_bits_and_version(arch: str) -> Optional[ArchBitsVer]:
+            match = pattern.match(arch)
+            if not match:
+                return None
+            bits = int(match.group("bits"))
+            ver = None if not match.group("version") else int(match.group("version"))
+            return arch, bits, ver
+        def select_superior_arch(lhs: ArchBitsVer, rhs: ArchBitsVer) -> ArchBitsVer:
+            _, l_bits, l_ver = lhs
+            _, r_bits, r_ver = rhs
+            if l_bits != r_bits:
+                return lhs if l_bits > r_bits else rhs
+            elif r_ver is None:
+                return lhs
+            elif l_ver is None:
+                return rhs
+            return lhs if l_ver > r_ver else rhs
+        candidates: List[ArchBitsVer] = list(filter(None, map(mingw_arch_with_bits_and_version, mingw_arches)))
+        if len(candidates) == 0:
+            return None
+        default_arch, _, _ = reduce(select_superior_arch, candidates)
+        return default_arch
+
+    @staticmethod
+    def find_installed_desktop_qt_dir(host: str, base_path: Path, version: Version, is_msvc: bool = False) -> Optional[Path]:
+        """
+        Locates the default installed desktop qt directory, somewhere in base_path.
+        """
+        installed_qt_version_dir = base_path / QtRepoProperty.dir_for_version(version)
+        if host == "mac":
+            arch_path = installed_qt_version_dir / QtRepoProperty.default_mac_desktop_arch_dir(version)
+            return arch_path if (arch_path / "bin/qmake").is_file() else None
+        elif host == "linux":
+            for arch_dir in QtRepoProperty.default_linux_desktop_arch_dir():
+                arch_path = installed_qt_version_dir / arch_dir
+                if (arch_path / "bin/qmake").is_file():
+                    return arch_path
+            return None
+        elif host == "windows" and is_msvc:
+            arch_path = installed_qt_version_dir / QtRepoProperty.default_win_msvc_desktop_arch_dir(version)
+            return arch_path if (arch_path / "bin/qmake.exe").is_file() else None
+        def contains_qmake_exe(arch_path: Path) -> bool:
+            return (arch_path / "bin/qmake.exe").is_file()
+        paths = [d for d in installed_qt_version_dir.glob("mingw*")]
+        directories = list(filter(contains_qmake_exe, paths))
+        arch_dirs = [d.name for d in directories]
+        selected_dir = QtRepoProperty.select_default_mingw(arch_dirs, is_dir=True)
+        return installed_qt_version_dir / selected_dir if selected_dir else None
+
+    @staticmethod
+    def is_in_wasm_range(host: str, version: Version) -> bool:
+        if version >= Version("6.7.0"):
+            return True
+        return (
+                version in SimpleSpec(">=6.2.0,<6.5.0")
+                or (host == "linux" and version in SimpleSpec(">=5.13,<6"))
+                or version in SimpleSpec(">=5.13.1,<6")
+        )
+
+    @staticmethod
+    def is_in_wasm_threaded_range(version: Version) -> bool:
+        return version in SimpleSpec(">=6.5.0")

--- a/aqt/repository.py
+++ b/aqt/repository.py
@@ -194,7 +194,7 @@ class QtRepoProperty:
         elif architecture == "wasm_multithread":
             return "wasm_multithread"
         elif architecture.startswith("android_") and is_version_ge_6:
-            ext = architecture[len("android_") :]
+            ext = architecture[len("android_"):]
             if ext in QtRepoProperty.EXTENSIONS_REQUIRED_ANDROID_QT6:
                 return ext
         return ""

--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -61,10 +61,10 @@ class Updater:
         if idx < 0:
             return
         assert len(newpath) < 256, "Qt Prefix path is too long(255)."
-        oldlen = data[idx + len(key) :].find(b"\0")
+        oldlen = data[idx + len(key):].find(b"\0")
         assert oldlen >= 0
         value = newpath + b"\0" * (oldlen - len(newpath))
-        data = data[: idx + len(key)] + value + data[idx + len(key) + len(value) :]
+        data = data[: idx + len(key)] + value + data[idx + len(key) + len(value):]
         file.write_bytes(data)
         os.chmod(str(file), st.st_mode)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,14 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "bs4",  # canonical name is beautifulsoup4
-    "defusedxml",
-    "humanize",
-    "patch>=1.16",
+    "defusedxml~=0.8.0rc2",
+    "humanize~=4.11.0",
+    "patch~=1.16",
     "py7zr>=1.0.0-rc1",
-    "requests>=2.31.0",
-    "semantic-version",
-    "texttable",
+    "requests~=2.32.3",
+    "semantic-version~=2.10.0",
+    "texttable~=1.7.0",
+    "pyinstaller~=6.11.1"
 ]
 dynamic = ["version", "readme"]
 
@@ -130,7 +131,7 @@ disallow_incomplete_defs = false
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_untyped_decorators = false
-# not a all 3rd party package has type hints
+# not an all 3rd party package has type hints
 ignore_missing_imports = true
 # Optional check: implicit check enabled in mypy 0.980 or before
 strict_optional = true


### PR DESCRIPTION
### Description

- Handle the specificity of Qt versions 6.7.0 and above while remaining backward compatible
```bash
$ aqt install-qt windows desktop 6.7.3 win64_llvm_mingw
$ aqt install-qt windows desktop 6.8.0 win64_llvm_mingw
$ aqt install-qt windows android 6.7.0 android_arm64_v8a
```
- Adds support for downloading and installing Qt WASM packages for Qt versions 6.7.0 and above
```bash
$ aqt install-qt linux desktop 6.7.3 wasm_singlethread --autodesktop --modules qtquick3d qtshadertools
```
- For those using [jurplel/install-qt-action](https://github.com/marketplace/actions/install-qt), you can use it to install WASM for Qt 6.7.0 and above once more. Here's an example configuration, and [a successful deploy on a project of mine](https://github.com/Kidev/QtQuick3D-Tools/actions/runs/12074945980/workflow)
```yml
- name: Install Qt for host architecture
  uses: jurplel/install-qt-action@v4.1.1
  with:
    version: '6.7.3'
    host: 'linux'
    target: 'desktop'
    set-env: 'false'
    arch: 'gcc_64'
    modules: 'all'
    cache: 'true'
    cache-key-prefix: 'install-qt-host'
    aqtsource: 'git+https://github.com/Kidev/aqtinstall.git@semver'

- name: Install Qt for target architecture
  uses: jurplel/install-qt-action@v4.1.1
  with:
    version: '6.7.3'
    host: 'linux'
    target: 'desktop'
    set-env: 'true'
    arch: 'wasm_singlethread'
    modules: 'all'
    cache: 'true'
    cache-key-prefix: 'install-qt-target'
    aqtsource: 'git+https://github.com/Kidev/aqtinstall.git@semver'
```
- All modules that became extensions on Qt 6.8.0 are available as modules again
```bash
$ aqt list-qt windows desktop --modules 6.8.0 win64_msvc2022_64   
```

> debug_info qt3d qt3d.debug_information qt5compat qt5compat.debug_information qtactiveqt qtactiveqt.debug_information qtcharts qtcharts.debug_information qtconnectivity qtconnectivity.debug_information qtdatavis3d qtdatavis3d.debug_information qtgraphs qtgraphs.debug_information qtgrpc qtgrpc.debug_information qthttpserver qthttpserver.debug_information qtimageformats qtimageformats.debug_information qtlanguageserver qtlocation qtlocation.debug_information qtlottie qtlottie.debug_information qtmultimedia qtmultimedia.debug_information qtnetworkauth qtnetworkauth.debug_information **`qtpdf`** qtpositioning qtpositioning.debug_information qtquick3d qtquick3d.debug_information qtquick3dphysics qtquick3dphysics.debug_information qtquickeffectmaker qtquickeffectmaker.debug_information qtquicktimeline qtquicktimeline.debug_information qtremoteobjects qtremoteobjects.debug_information qtscxml qtscxml.debug_information qtsensors qtsensors.debug_information qtserialbus qtserialbus.debug_information qtserialport qtserialport.debug_information qtshadertools qtshadertools.debug_information qtspeech qtspeech.debug_information qtvirtualkeyboard qtvirtualkeyboard.debug_information qtwebchannel qtwebchannel.debug_information **`qtwebengine`** qtwebsockets qtwebsockets.debug_information qtwebview qtwebview.debug_information

- Fixes crash and issues with the new Qt version notation
```python
>>> get_semantic_version('51212', False)
Version('5.12.12')
>>> get_semantic_version('600', False)
Version('6.0.0')
>>> get_semantic_version('6_7_3', False)
Version('6.7.3')
```

This is building on top of my PR #837 (more details on there)
Fix #825 fix #817 fix #803 fix #779 fix #774