### PR TITLE
handle cases where extensions don't exist.

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -438,21 +438,33 @@ class QtArchives:
                     "online/qtsdkrepository", os_name, "extensions", ext, self._version_str(), arch
                 )
                 extensions_xml_url = posixpath.join(extensions_target_folder, "Updates.xml")
-                extensions_xml_text = self._download_update_xml(extensions_xml_url)
-                update_xmls.append(UpdateXmls(extensions_target_folder, extensions_xml_text))
+                # The extension may or may not exist for this version and arch.
+                try:
+                    extensions_xml_text = self._download_update_xml(extensions_xml_url, True)
+                except ArchiveDownloadError:
+                    # In case _download_update_xml ignores the hash and tries to get the url.
+                    pass
+                if extensions_xml_text:
+                    self.logger.info("Found extension {}".format(ext))
+                    update_xmls.append(UpdateXmls(extensions_target_folder, extensions_xml_text))
 
         self._parse_update_xmls(update_xmls, target_packages)
 
-    def _download_update_xml(self, update_xml_path):
+    def _download_update_xml(self, update_xml_path, silent=False):
         """Hook for unit test."""
         if not Settings.ignore_hash:
             try:
                 xml_hash = get_hash(update_xml_path, Settings.hash_algorithm, self.timeout)
             except ChecksumDownloadFailure:
-                self.logger.warning(
-                    "Failed to download checksum for the file 'Updates.xml'. This may happen on unofficial mirrors."
-                )
-                xml_hash = None
+                if silent:
+                    return None
+                else:
+                    self.logger.warning(
+                        "Failed to download checksum for the file '{}'. This may happen on unofficial mirrors.".format(
+                            update_xml_path
+                        )
+                    )
+                    xml_hash = None
         else:
             xml_hash = None
         return getUrl(posixpath.join(self.base, update_xml_path), self.timeout, xml_hash)

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -41,9 +41,9 @@ from aqt.exceptions import (
     ArchiveConnectionError,
     ArchiveDownloadError,
     ArchiveListError,
+    ChecksumDownloadFailure,
     CliInputError,
     EmptyMetadata,
-    ChecksumDownloadFailure,
 )
 from aqt.helper import Settings, get_hash, getUrl, xml_to_modules
 

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -37,7 +37,14 @@ from semantic_version import SimpleSpec as SemanticSimpleSpec
 from semantic_version import Version as SemanticVersion
 from texttable import Texttable
 
-from aqt.exceptions import ArchiveConnectionError, ArchiveDownloadError, ArchiveListError, CliInputError, EmptyMetadata, ChecksumDownloadFailure
+from aqt.exceptions import (
+    ArchiveConnectionError,
+    ArchiveDownloadError,
+    ArchiveListError,
+    CliInputError,
+    EmptyMetadata,
+    ChecksumDownloadFailure,
+)
 from aqt.helper import Settings, get_hash, getUrl, xml_to_modules
 
 
@@ -561,6 +568,7 @@ class QtRepoProperty:
         if version >= Version("6.8.0"):
             return ["qtpdf", "qtwebengine"]
         return []
+
 
 class MetadataFactory:
     """Retrieve metadata of Qt variations, versions, and descriptions from Qt site."""

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -891,9 +891,19 @@ class MetadataFactory:
             module, _arch = to_module_arch(name)
             if _arch == arch:
                 modules.add(cast(str, module))
-        if version >= Version("6.8.0"):
-            for ext in self.fetch_extensions():
-                modules.add(ext)
+
+        ext_pattern = re.compile(r"^extensions\." + r"(?P<module>[^.]+)\." + qt_ver_str + r"\." + arch + r"$")
+        for ext in QtRepoProperty.known_extensions(version):
+            try:
+                ext_meta = self._fetch_extension_metadata(self.archive_id.to_extension_folder(ext, qt_ver_str, arch))
+                for key, value in ext_meta.items():
+                    ext_match = ext_pattern.match(key)
+                    if ext_match is not None:
+                        module = ext_match.group("module")
+                        if module is not None:
+                            modules.add(ext)
+            except (ChecksumDownloadFailure, ArchiveDownloadError):
+                pass
         return sorted(modules)
 
     @staticmethod


### PR DESCRIPTION
for example with windows desktop 6.8.1 win64_msvc2022_arm64_cross_compiled both qtwebengine and qtpdf don't exist.

this resolves #851 