### PR TITLE
appease mypy Version no-untyped-call

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -79,7 +79,7 @@ class Version(SemanticVersion):
         prerelease=None,
         build=None,
         partial=False,
-    ):
+    ) -> None:
         if version_string is None:
             super(Version, self).__init__(
                 version_string=None,


### PR DESCRIPTION
Without the type hint we get:
error: Call to untyped function "Version" in typed context  [no-untyped-call]

Note that our Version is derived from semantic_version, which doesn't have type hints.