### PR TITLE
Update docs for more recent versions of Qt, and for WASM

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -54,11 +54,11 @@ List available versions of Qt, targets, modules, and architectures.
 
 .. describe:: host
 
-    linux, linux_arm64, windows or mac
+    linux, linux_arm64, windows, mac or all_os for Qt 6.7+
 
 .. describe:: target
 
-    desktop, winrt, ios or android.
+    desktop, winrt, ios, android or wasm for Qt 6.7+
     When omitted, the command prints all the targets available for a host OS.
     Note that winrt is only available on Windows, and ios is only available on Mac OS.
 
@@ -84,7 +84,7 @@ List available versions of Qt, targets, modules, and architectures.
     This flag lists all the modules available for Qt 5.X.Y with a host/target/architecture
     combination, or the latest version of Qt if ``latest`` is specified.
     You can list available architectures by using ``aqt list-qt`` with the
-    ``--arch`` flag described below.
+    ``--arch`` flag described below. As of Qt 6.7 this also lists extensions.
 
 .. option:: --long-modules (<Qt version> | latest) <architecture>
 
@@ -96,37 +96,41 @@ List available versions of Qt, targets, modules, and architectures.
 .. code-block:: console
 
     $ python -m aqt list-qt windows desktop --long-modules latest win64_mingw
-
-       Module Name                         Display Name                       Release Date   Download Size   Installed Size
-    =======================================================================================================================
-    debug_info          Desktop MinGW 11.2.0 64-bit debug information files   2022-07-07     1.0G            6.4G
-    qt3d                Qt 3D for MinGW 11.2.0 64-bit                         2022-07-07     2.8M            21.3M
-    qt5compat           Qt 5 Compatibility Module for MinGW 11.2.0 64-bit     2022-07-07     679.3K          2.5M
-    qtactiveqt          Qt 3D for MinGW 11.2.0 64-bit                         2022-07-07     5.9M            32.6M
-    qtcharts            Qt Charts for MinGW 11.2.0 64-bit                     2022-07-07     713.0K          7.5M
-    qtconnectivity      Qt Connectivity for MinGW 11.2.0 64-bit               2022-07-07     227.5K          1.5M
-    qtdatavis3d         Qt Data Visualization for MinGW 11.2.0 64-bit         2022-07-07     565.7K          4.3M
-    qthttpserver        Qt HTTP Server for MinGW 11.2.0 64-bit                2022-07-07     73.2K           372.6K
-    qtimageformats      Qt Image Formats for MinGW 11.2.0 64-bit              2022-07-07     184.6K          705.5K
-    qtlanguageserver    Qt language Server for MinGW 11.2.0 64-bit            2022-07-07     300.1K          1.8M
-    qtlottie            Qt Lottie Animation for MinGW 11.2.0 64-bit           2022-07-07     131.7K          704.0K
-    qtmultimedia        Qt Multimedia for MinGW 11.2.0 64-bit                 2022-07-07     9.7M            79.2M
-    qtnetworkauth       Qt Network Authorization for MinGW 11.2.0 64-bit      2022-07-07     85.5K           507.6K
-    qtpositioning       Qt Positioning for MinGW 11.2.0 64-bit                2022-07-07     347.2K          2.2M
-    qtquick3d           Qt Quick 3D for MinGW 11.2.0 64-bit                   2022-07-07     13.0M           75.4M
-    qtquick3dphysics    Quick: 3D Physics for MinGW 11.2.0 64-bit             2022-07-07     35.5M           203.9M
-    qtquicktimeline     Qt Quick Timeline for MinGW 11.2.0 64-bit             2022-07-07     54.6K           301.4K
-    qtremoteobjects     Qt Remote Objects for MinGW 11.2.0 64-bit             2022-07-07     424.4K          2.0M
-    qtscxml             Qt State Machine for MinGW 11.2.0 64-bit              2022-07-07     448.5K          2.9M
-    qtsensors           Qt Sensors for MinGW 11.2.0 64-bit                    2022-07-07     175.7K          2.0M
-    qtserialbus         Qt SerialBus for MinGW 11.2.0 64-bit                  2022-07-07     208.8K          1.2M
-    qtserialport        Qt SerialPort for MinGW 11.2.0 64-bit                 2022-07-07     58.3K           255.3K
-    qtshadertools       Qt Shader Tools for MinGW 11.2.0 64-bit               2022-07-07     1.2M            4.1M
-    qtspeech            Qt Speech for MinGW 11.2.0 64-bit                     2022-07-07     81.8K           427.9K
-    qtvirtualkeyboard   Qt Virtual Keyboard for MinGW 11.2.0 64-bit           2022-07-07     2.1M            6.0M
-    qtwebchannel        Qt WebChannel for MinGW 11.2.0 64-bit                 2022-07-07     114.0K          500.3K
-    qtwebsockets        Qt WebSockets for MinGW 11.2.0 64-bit                 2022-07-07     96.3K           509.6K
-    qtwebview           Qt WebView for MinGW 11.2.0 64-bit                    2022-07-07     64.2K           470.7K
+       Module Name                          Display Name                       Release Date   Download Size   Installed Size
+    ========================================================================================================================
+    debug_info           Desktop MinGW 13.1.0 64-bit debug information files   2024-12-12     912.6M          5.7G          
+    qt3d                 Qt 3D for MinGW 13.1.0 64-bit                         2024-12-12     3.4M            26.5M         
+    qt5compat            Qt 5 Compatibility Module for MinGW 13.1.0 64-bit     2024-12-12     768.6K          3.2M          
+    qtactiveqt           Active Qt for MinGW 13.1.0 64-bit                     2024-12-12     6.4M            35.1M         
+    qtcharts             Qt Charts for MinGW 13.1.0 64-bit                     2024-12-12     836.5K          8.7M          
+    qtconnectivity       Qt Connectivity for MinGW 13.1.0 64-bit               2024-12-12     259.2K          1.8M          
+    qtdatavis3d          Qt Data Visualization for MinGW 13.1.0 64-bit         2024-12-12     636.4K          5.0M          
+    qtgraphs             Qt Graphs for MinGW 13.1.0 64-bit                     2024-12-12     843.2K          6.9M          
+    qtgrpc               Qt Protobuf and Qt GRPC for MinGW 13.1.0 64-bit       2024-12-12     4.1M            34.7M         
+    qthttpserver         Qt HTTP Server for MinGW 13.1.0 64-bit                2024-12-12     106.0K          563.2K        
+    qtimageformats       Qt Image Formats for MinGW 13.1.0 64-bit              2024-12-12     427.2K          1.5M          
+    qtlanguageserver     Qt language Server for MinGW 13.1.0 64-bit            2024-12-12     7.7M            56.1M         
+    qtlocation           Qt Location for MinGW 13.1.0 64-bit                   2024-12-12     718.1K          5.9M          
+    qtlottie             Qt Lottie Animation for MinGW 13.1.0 64-bit           2024-12-12     161.2K          951.5K        
+    qtmultimedia         Qt Multimedia for MinGW 13.1.0 64-bit                 2024-12-12     18.0M           107.6M        
+    qtnetworkauth        Qt Network Authorization for MinGW 13.1.0 64-bit      2024-12-12     128.4K          811.7K        
+    qtpdf                MinGW 13.1.0 x64                                      2024-12-12     4.0M            11.1M         
+    qtpositioning        Qt Positioning for MinGW 13.1.0 64-bit                2024-12-12     414.3K          2.8M          
+    qtquick3d            Qt Quick 3D for MinGW 13.1.0 64-bit                   2024-12-12     18.0M           102.1M        
+    qtquick3dphysics     Qt Quick 3D Physics for MinGW 13.1.0 64-bit           2024-12-12     35.0M           198.8M        
+    qtquickeffectmaker   Qt Quick Effect Maker for MinGW 13.1.0 64-bit         2024-12-12     3.8M            5.0M          
+    qtquicktimeline      Qt Quick Timeline for MinGW 13.1.0 64-bit             2024-12-12     91.7K           646.7K        
+    qtremoteobjects      Qt Remote Objects for MinGW 13.1.0 64-bit             2024-12-12     486.9K          2.3M          
+    qtscxml              Qt State Machine for MinGW 13.1.0 64-bit              2024-12-12     539.5K          3.6M          
+    qtsensors            Qt Sensors for MinGW 13.1.0 64-bit                    2024-12-12     206.8K          2.3M          
+    qtserialbus          Qt SerialBus for MinGW 13.1.0 64-bit                  2024-12-12     300.7K          1.8M          
+    qtserialport         Qt SerialPort for MinGW 13.1.0 64-bit                 2024-12-12     76.3K           377.8K        
+    qtshadertools        Qt Shader Tools for MinGW 13.1.0 64-bit               2024-12-12     1.5M            5.4M          
+    qtspeech             Qt Speech for MinGW 13.1.0 64-bit                     2024-12-12     124.7K          686.3K        
+    qtvirtualkeyboard    Qt Virtual Keyboard for MinGW 13.1.0 64-bit           2024-12-12     2.2M            7.1M          
+    qtwebchannel         Qt WebChannel for MinGW 13.1.0 64-bit                 2024-12-12     139.8K          722.6K        
+    qtwebsockets         Qt WebSockets for MinGW 13.1.0 64-bit                 2024-12-12     117.9K          679.9K        
+    qtwebview            Qt WebView for MinGW 13.1.0 64-bit                    2024-12-12     84.8K           687.8K 
 
 
 .. option:: --arch (<Qt version> | latest)
@@ -506,7 +510,7 @@ There are various combinations to accept according to Qt version.
 
 .. describe:: target
 
-    desktop, ios, winrt, or android. The type of device for which you are developing Qt programs.
+    desktop, ios, winrt, android, or wasm. The type of device for which you are developing Qt programs.
     If your target is ios, please be aware that versions of Qt older than 6.2.4 are expected to be
     non-functional with current versions of XCode (applies to any XCode greater than or equal to 13).
 
@@ -544,6 +548,8 @@ There are various combinations to accept according to Qt version.
    * win64_msvc2022_arm64 for windows_arm64 desktop
 
    * android_armv7, android_arm64_v8a, android_x86, android_x86_64 for android
+
+   * wasm_singlethread or wasm_multithread for wasm
 
     Use the :ref:`List-Qt Command` to list available architectures.
 
@@ -849,11 +855,13 @@ Example: Install Web Assembly
     aqt install-qt linux desktop 5.15.0 wasm_32
 
 
-Example: Install Qt6 for Web Assembly
+Example: Install different versions of Qt6 for Web Assembly (WASM)
 
 .. code-block:: console
 
     aqt install-qt linux desktop 6.2.4 wasm_32 --autodesktop
+    aqt install-qt linux desktop 6.5.0 wasm_singlethread --autodesktop
+    aqt install-qt all_os wasm 6.8.0 wasm_multithread --autodesktop
 
 
 Example: List available versions of Qt on Linux

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -848,7 +848,7 @@ Example: Print modules available for installation with ``install-example/doc``:
     aqt list-example windows 5.15.2 --modules
     aqt list-doc windows 5.15.2 --modules
 
-Example: Install Web Assembly
+Example: Install Web Assembly for Qt5
 
 .. code-block:: console
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -29,8 +29,8 @@ Some older operating systems may require you to specify Python version 3, like t
 
 To use ``aqt`` to install Qt, you will need to tell ``aqt`` four things:
 
-1. The host operating system (windows, mac, linux, or linux_arm64)
-2. The target SDK (desktop, android, ios, or winrt)
+1. The host operating system (windows, mac, linux, linux_arm64, or all_os for Qt 6.7+)
+2. The target SDK (desktop, android, ios, winrt, or wasm for Qt 6.7+)
 3. The version of Qt you would like to install
 4. The target architecture
 
@@ -41,6 +41,8 @@ In current versions of Qt, mac binaries are universal.
 As of Qt 6.7.0, Linux desktop now supports the arm64 architecture.
 This is implemented as a new host type - ``linux`` is amd64, ``linux_arm64`` is arm64.
 
+As of Qt 6.7.0, the WASM architecture can be installed using ``all_os`` as host and ``wasm`` as target.
+
 To find out what versions of Qt are available, you can use the :ref:`aqt list-qt command <list-qt command>`.
 This command will print all versions of Qt available for Windows Desktop:
 
@@ -50,13 +52,20 @@ This command will print all versions of Qt available for Windows Desktop:
     5.9.0 5.9.1 5.9.2 5.9.3 5.9.4 5.9.5 5.9.6 5.9.7 5.9.8 5.9.9
     5.10.0 5.10.1
     5.11.0 5.11.1 5.11.2 5.11.3
-    5.12.0 5.12.1 5.12.2 5.12.3 5.12.4 5.12.5 5.12.6 5.12.7 5.12.8 5.12.9 5.12.10 5.12.11
+    5.12.0 5.12.1 5.12.2 5.12.3 5.12.4 5.12.5 5.12.6 5.12.7 5.12.8 5.12.9 5.12.10 5.12.11 5.12.12
     5.13.0 5.13.1 5.13.2
     5.14.0 5.14.1 5.14.2
     5.15.0 5.15.1 5.15.2
     6.0.0 6.0.1 6.0.2 6.0.3 6.0.4
-    6.1.0 6.1.1 6.1.2
-    6.2.0
+    6.1.0 6.1.1 6.1.2 6.1.3
+    6.2.0 6.2.1 6.2.2 6.2.3 6.2.4
+    6.3.0 6.3.1 6.3.2
+    6.4.0 6.4.1 6.4.2 6.4.3
+    6.5.0 6.5.1 6.5.2 6.5.3
+    6.6.0 6.6.1 6.6.2 6.6.3
+    6.7.0 6.7.1 6.7.2 6.7.3
+    6.8.0 6.8.1
+    6.9.0
 
 Notice that the version numbers are sorted, grouped by minor version number,
 and separated by a single space-character. The output of all of the 
@@ -70,16 +79,16 @@ so it may or may not be up to date.
 
 .. _Available Qt versions: https://github.com/miurahr/aqtinstall/wiki/Available-Qt-versions
 
-Now that we know what versions of Qt are available, let's choose version 6.2.0.
+Now that we know what versions of Qt are available, let's choose version 6.8.0.
 
 The next thing we need to do is find out what architectures are available for
-Qt 6.2.0 for Windows Desktop. To do this, we can use :ref:`aqt list-qt <list-qt command>` with the
+Qt 6.8.0 for Windows Desktop. To do this, we can use :ref:`aqt list-qt <list-qt command>` with the
 ``--arch`` flag:
 
 .. code-block:: console
 
-    $ aqt list-qt windows desktop --arch 6.2.0
-    win64_mingw81 win64_msvc2019_64 win64_msvc2019_arm64 wasm_32
+    $ aqt list-qt windows desktop --arch 6.8.0
+    win64_llvm_mingw win64_mingw win64_msvc2022_64 win64_msvc2022_arm64_cross_compiled
 
 Notice that this is a very small subset of the architectures listed in the 
 `Available Qt versions`_ wiki page. If we need to use some architecture that
@@ -87,21 +96,21 @@ is not on this list, we can use the `Available Qt versions`_ wiki page to get
 a rough idea of what versions support the architecture we want, and then use
 :ref:`aqt list-qt <list-qt command>` to confirm that the architecture is available.
 
-Let's say that we want to install Qt 6.2.0 with architecture ``win64_mingw81``.
+Let's say that we want to install Qt 6.8.0 with architecture ``win64_mingw``.
 The installation command we need is:
 
 .. code-block:: console
 
-    $ aqt install-qt windows desktop 6.2.0 win64_mingw81
+    $ aqt install-qt windows desktop 6.8.0 win64_mingw
 
-Let's say that we want to install the next version of Qt 6.2 as soon as it is available.
+Let's say that we want to install the next version of Qt 6.8 as soon as it is available.
 We can do this by using a
 `SimpleSpec <https://python-semanticversion.readthedocs.io/en/latest/reference.html#semantic_version.SimpleSpec>`_
 instead of an explicit version:
 
 .. code-block:: console
 
-    $ aqt install-qt windows desktop 6.2 win64_mingw81
+    $ aqt install-qt windows desktop 6.8 win64_mingw
 
 As of Qt 6.7.0, arm64 architecture is now supported for linux desktop.
 It is implemented using both a different host (``linux_arm64``) and architecture (``linux_gcc_arm64``).
@@ -109,6 +118,13 @@ It is implemented using both a different host (``linux_arm64``) and architecture
 .. code-block:: console
 
     $ aqt install-qt linux_arm64 desktop 6.7.0 linux_gcc_arm64
+
+As of Qt 6.7.0, the WASM architecture can be installed using ``all_os`` as host and ``wasm`` as target.
+The available architectures are ``wasm_singlethread`` and ``wasm_multithread``
+
+.. code-block:: console
+
+    $ aqt install-qt all_os wasm 6.7.0 wasm_singlethread
 
 External 7-zip extractor
 ------------------------
@@ -120,14 +136,14 @@ you could use 7-zip_ on a Windows desktop, using this command:
 
 .. code-block:: doscon
 
-    C:\> aqt install-qt windows desktop 6.2.0 gcc_64 --external 7za.exe
+    C:\> aqt install-qt windows desktop 6.8.0 win64_msvc2022_64 --external 7za.exe
 
 On Linux, you can specify p7zip_, a Linux port of 7-zip_, which is often
 installed by default, using this command:
 
 .. code-block:: console
 
-    $ aqt install-qt linux desktop 6.2.0 gcc_64 --external 7z
+    $ aqt install-qt linux desktop 6.8.0 linux_gcc_64 --external 7z
 
 .. _py7zr: https://pypi.org/project/py7zr/
 .. _p7zip: https://p7zip.sourceforge.net/
@@ -138,8 +154,8 @@ Changing the output directory
 
 By default, ``aqt`` will install all of the Qt packages into the current
 working directory, in the subdirectory ``./<Qt version>/<arch>/``.
-For example, if we install Qt 6.2.0 for Windows desktop with arch ``win64_mingw81``,
-it would end up in ``./6.2.0/win64_mingw81``.
+For example, if we install Qt 6.8.0 for Windows desktop with arch ``win64_mingw``,
+it would end up in ``./6.8.0/win64_mingw``.
 
 If you would prefer to install it to another location, you
 will need to use the ``-O`` or ``--outputdir`` flag.
@@ -152,7 +168,7 @@ you may use this command:
 .. code-block:: doscon
 
     C:\> mkdir Qt
-    C:\> aqt install-qt --outputdir c:\Qt windows desktop 6.2.0 win64_mingw81
+    C:\> aqt install-qt --outputdir c:\Qt windows desktop 6.8.0 win64_mingw
 
 
 Installing Modules
@@ -294,7 +310,9 @@ You can do this automatically with the ``--autodesktop`` flag:
 Installing Qt for WASM
 ----------------------
 
-To find out how to install Qt for WASM, we will need to use the ``wasm_32`` architecture.
+To find out how to install Qt for WASM, we will need to use the ``wasm_32`` architecture for Qt versions <= 6.4.*
+For Qt versions 6.5.* and 6.6.*, we will need to use the ``wasm_singlethread`` or ``wasm_multithread`` architectures.
+For Qt version >= 6.7.*, we will need to use the host ``all_os``, the target ``wasm``, and the ``wasm_singlethread`` or ``wasm_multithread`` architectures.
 We can find out whether or not that architecture is available for our version of Qt with the
 ``--arch`` flag.
 
@@ -307,8 +325,9 @@ We can find out whether or not that architecture is available for our version of
 
 Not every version of Qt supports WASM. This command shows us that we cannot use WASM with Qt 6.1.3.
 
-Please note that the WASM architecture for Qt 6.5.0+ changed from ``wasm_32`` to ``wasm_singlethread`` and
-``wasm_multithread``. Always use ``aqt list-qt`` to check what architectures are available for the desired version of Qt.
+Please note that the WASM architecture for Qt 6.5.* and Qt 6.6.* changed from ``wasm_32`` to ``wasm_singlethread`` and
+``wasm_multithread``. For Qt 6.7.* and above, you will also need to use the host ``all_os`` and target ``wasm``.
+Always use ``aqt list-qt`` to check what architectures are available for the desired version of Qt.
 
 We can check the modules available as before:
 
@@ -331,6 +350,8 @@ You can do this automatically with the ``--autodesktop`` flag:
 .. code-block:: console
 
     $ aqt install-qt linux desktop 6.2.0 wasm_32 -m qtcharts qtnetworkauth --autodesktop
+    $ aqt install-qt linux desktop 6.6.0 wasm_singlethread -m qtcharts qtnetworkauth --autodesktop
+    $ aqt install-qt all_os wasm 6.8.0 wasm_multithread -m qtcharts qtnetworkauth --autodesktop
 
 
 Installing Docs

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -322,6 +322,11 @@ We can find out whether or not that architecture is available for our version of
     win64_mingw81 win64_msvc2019_64
     $ python -m aqt list-qt windows desktop --arch 6.2.0
     win64_mingw81 win64_msvc2019_64 win64_msvc2019_arm64 wasm_32
+    $ python -m aqt list-qt windows desktop --arch 6.5.0
+    win64_mingw win64_msvc2019_64 win64_msvc2019_arm64 wasm_singlethread wasm_multithread
+    $ python -m aqt list-qt all_os wasm --arch 6.8.0
+    wasm_singlethread wasm_multithread
+
 
 Not every version of Qt supports WASM. This command shows us that we cannot use WASM with Qt 6.1.3.
 


### PR DESCRIPTION
- Update the documentation to showcase more recent versions as examples
- Add examples for versions 6.5.*, 6.6.*
- Add examples and explanations for how to install WASM for Qt 6.7+ (with `all_os` and `wasm`) in preparation for the merge of PR #846 