### PR TITLE
chore: support trusted publisher to publish with OIDC

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,8 +10,8 @@ on:
       - v*
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
+  build:
+    name: Build package
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 🛎️
@@ -30,6 +30,23 @@ jobs:
         run: python -m build ./
       - name: twine check
         run: python -m twine check dist/*
+      - name: upload dists
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  publish:
+    name: publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
       - name: Publish distribution 📦 to Test PyPI when releases branch
         if: ${{ startsWith(github.event.ref, 'refs/heads/releases') }}
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -39,5 +56,3 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         if: ${{ startsWith(github.event.ref, 'refs/tags') }}
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
PyPI encourage us to use "Trusted Publishing". This is a part of migration.