### PR TITLE
chore(ci): Fix/update Windows ARM64 cross-compilation job

### DIFF
--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -182,12 +182,12 @@ windows_build_jobs.extend(
     [
         BuildJob(
             "install-qt",
-            "6.5.3",
+            "6.8.1",
             "windows",
             "desktop",
-            "win64_msvc2019_arm64",
-            "msvc2019_arm64",
-            is_autodesktop=True,  # Should install win64_msvc2019_arm64 in parallel
+            "win64_msvc2022_arm64_cross_compiled",
+            "msvc2022_arm64",
+            is_autodesktop=True,
         ),
         BuildJob(
             "install-qt",

--- a/ci/steps.yml
+++ b/ci/steps.yml
@@ -234,7 +234,9 @@ steps:
     if ('$(ARCH)' -like '*mingw*') {
       Write-Host '##vso[task.setvariable variable=TOOLCHAIN]MINGW'
     }
-    if ('$(ARCH)' -like 'win64_msvc*') {
+    if ('$(ARCH)' -like 'win64_msvc*_arm64*') {
+      Write-Host '##vso[task.setvariable variable=ARCHITECTURE]amd64_arm64'
+    } elseif ('$(ARCH)' -like 'win64_msvc*') {
       Write-Host '##vso[task.setvariable variable=ARCHITECTURE]amd64'
     } else {
       Write-Host '##vso[task.setvariable variable=ARCHITECTURE]x86'


### PR DESCRIPTION
When the Windows ARM64 job was [initially added](https://github.com/miurahr/aqtinstall/commit/15f72c5c9df77d3c1794c4f96f3bc52769aa7a3f), it attempted to initialize vcvars with `arm64` architecture, but it didn't work and was [reverted](https://github.com/miurahr/aqtinstall/commit/8ad9c686e385af66a6d9d348a8a7f4e3d9b00710) soon after. It was almost correct though, it just needed to be `amd64_arm64` to indicate an [ARM64 on x64 cross](https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#vcvarsall-syntax) compilation.

This PR brings back the vcvars architecture support for ARM64 to fix a compilation error when [updating jom](https://github.com/miurahr/aqtinstall/pull/892). The condition (`'$(ARCH)' -like 'win64_msvc*_arm64*'`) now includes a `*` at the end, because Qt 6.8 changed the naming from `win64_msvc2019_arm64` to `win64_msvc2022_arm64_cross_compiled`.

This PR also updates the Windows ARM64 job to use Qt 6.8.1.