### PR TITLE
Fix official installer on macOS

### DIFF
--- a/aqt/commercial.py
+++ b/aqt/commercial.py
@@ -35,6 +35,7 @@ from aqt.helper import (
     get_os_name,
     get_qt_account_path,
     get_qt_installer_name,
+    prepare_installer,
     safely_run,
     safely_run_save_output,
 )
@@ -340,7 +341,8 @@ class CommercialInstaller:
 
         self.logger.info(f"Downloading Qt installer to {installer_path}")
         timeout = (Settings.connection_timeout, Settings.response_timeout)
-        download_installer(self.base_url, self._installer_filename, self.os_name, installer_path, timeout)
+        download_installer(self.base_url, self._installer_filename, installer_path, timeout)
+        installer_path = prepare_installer(installer_path, self.os_name)
 
         try:
             if self.override:

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -78,7 +78,7 @@ def get_qt_account_path() -> Path:
 def get_qt_installer_name() -> str:
     installer_dict = {
         "windows": "qt-unified-windows-x64-online.exe",
-        "mac": "qt-unified-macOS-x64-online.dmg",
+        "mac": "qt-unified-mac-x64-online.dmg",
         "linux": "qt-unified-linux-x64-online.run",
     }
     return installer_dict[get_os_name()]

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -65,6 +65,7 @@ from aqt.helper import (
     get_hash,
     get_os_name,
     get_qt_installer_name,
+    prepare_installer,
     retry_on_bad_connection,
     retry_on_errors,
     safely_run_save_output,
@@ -905,7 +906,8 @@ class Cli:
             # Download installer
             self.logger.info(f"Downloading Qt installer to {installer_path}")
             timeout = (Settings.connection_timeout, Settings.response_timeout)
-            download_installer(Settings.baseurl, installer_filename, get_os_name(), installer_path, timeout)
+            download_installer(Settings.baseurl, installer_filename, installer_path, timeout)
+            installer_path = prepare_installer(installer_path, get_os_name())
 
             # Build command
             cmd = [str(installer_path), "--accept-licenses", "--accept-obligations", "--confirm-command"]

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -221,13 +221,7 @@ def test_commercial_installer_download_sha256(tmp_path, monkeypatch, commercial_
     target_path = tmp_path / "qt-installer"
 
     timeout = (Settings.connection_timeout, Settings.response_timeout)
-    download_installer(
-        commercial_installer.base_url,
-        commercial_installer._installer_filename,
-        commercial_installer.os_name,
-        target_path,
-        timeout,
-    )
+    download_installer(commercial_installer.base_url, commercial_installer._installer_filename,target_path, timeout)
     assert target_path.exists()
 
 


### PR DESCRIPTION
Fixes #889. In addition to the incorrect download URL, the file we get is a macOS `.dmg` (disk image) which cannot be executed directly, so this handles mounting/extracting the contents. After these changes, I was able to successfully complete a [macOS build](https://github.com/jdpurcell/QtHelloWorld/actions/runs/13610178522/job/38046297825) via GitHub Actions with the official installer.