### PR TITLE
feat: install-qt-official checks hash for downloaded binary

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ recursive-include tests *.json
 recursive-include tests *.py
 recursive-include tests *.xml
 recursive-include tools *.py
+prune ci
 prune .github
 exclude .gitignore
 exclude .readthedocs.yml

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -669,7 +669,9 @@ def extract_auth(args: List[str]) -> Tuple[str | None, str | None, List[str] | N
     return username, password, args
 
 
-def download_installer(base_url: str, installer_filename:str, os_name:str, target_path: Path, timeout: Tuple[float, float]) -> None:
+def download_installer(
+    base_url: str, installer_filename: str, os_name: str, target_path: Path, timeout: Tuple[float, float]
+) -> None:
     base_path = f"official_releases/online_installers/{installer_filename}"
     url = f"{base_url}/{base_path}"
     try:

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -667,3 +667,15 @@ def extract_auth(args: List[str]) -> Tuple[str | None, str | None, List[str] | N
             continue
         i += 1
     return username, password, args
+
+
+def download_installer(base_url: str, installer_filename:str, os_name:str, target_path: Path, timeout: Tuple[float, float]) -> None:
+    base_path = f"official_releases/online_installers/{installer_filename}"
+    url = f"{base_url}/{base_path}"
+    try:
+        hash = get_hash(base_path, Settings.hash_algorithm, timeout)
+        downloadBinaryFile(url, target_path, Settings.hash_algorithm, hash, timeout=timeout)
+        if os_name != "windows":
+            os.chmod(target_path, 0o500)
+    except Exception as e:
+        raise RuntimeError(f"Failed to download installer: {e}")

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -63,6 +63,7 @@ from aqt.helper import (
     downloadBinaryFile,
     extract_auth,
     get_hash,
+    get_os_name,
     get_qt_installer_name,
     retry_on_bad_connection,
     retry_on_errors,
@@ -903,7 +904,8 @@ class Cli:
         try:
             # Download installer
             self.logger.info(f"Downloading Qt installer to {installer_path}")
-            download_installer(Settings.baseurl, installer_path)
+            timeout = (Settings.connection_timeout, Settings.response_timeout)
+            download_installer(Settings.baseurl, installer_filename, get_os_name(), temp_path, timeout)
 
             # Build command
             cmd = [str(installer_path), "--accept-licenses", "--accept-obligations", "--confirm-command"]

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -905,7 +905,7 @@ class Cli:
             # Download installer
             self.logger.info(f"Downloading Qt installer to {installer_path}")
             timeout = (Settings.connection_timeout, Settings.response_timeout)
-            download_installer(Settings.baseurl, installer_filename, get_os_name(), temp_path, timeout)
+            download_installer(Settings.baseurl, installer_filename, get_os_name(), installer_path, timeout)
 
             # Build command
             cmd = [str(installer_path), "--accept-licenses", "--accept-obligations", "--confirm-command"]

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (C) 2018 Linus Jahn <lnj@kaidan.im>
-# Copyright (C) 2019-2024 Hiroshi Miura <miurahr@linux.com>
+# Copyright (C) 2019-2025 Hiroshi Miura <miurahr@linux.com>
 # Copyright (C) 2020, Aurélien Gâteau
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -59,10 +59,10 @@ from aqt.exceptions import (
 from aqt.helper import (
     MyQueueListener,
     Settings,
+    download_installer,
     downloadBinaryFile,
     extract_auth,
     get_hash,
-    get_os_name,
     get_qt_installer_name,
     retry_on_bad_connection,
     retry_on_errors,
@@ -903,20 +903,7 @@ class Cli:
         try:
             # Download installer
             self.logger.info(f"Downloading Qt installer to {installer_path}")
-            base_url = Settings.baseurl
-            url = f"{base_url}/official_releases/online_installers/{installer_filename}"
-
-            import requests
-
-            response = requests.get(url, stream=True, timeout=Settings.qt_installer_timeout)
-            response.raise_for_status()
-
-            with open(installer_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-
-            if get_os_name() != "windows":
-                os.chmod(installer_path, 0o500)
+            download_installer(Settings.baseurl, installer_path)
 
             # Build command
             cmd = [str(installer_path), "--accept-licenses", "--accept-obligations", "--confirm-command"]

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -221,8 +221,13 @@ def test_commercial_installer_download_sha256(tmp_path, monkeypatch, commercial_
     target_path = tmp_path / "qt-installer"
 
     timeout = (Settings.connection_timeout, Settings.response_timeout)
-    download_installer(commercial_installer.base_url, commercial_installer._installer_filename, commercial_installer.os_name,
-                       target_path, timeout)
+    download_installer(
+        commercial_installer.base_url,
+        commercial_installer._installer_filename,
+        commercial_installer.os_name,
+        target_path,
+        timeout,
+    )
     assert target_path.exists()
 
 

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -10,7 +10,7 @@ import requests
 
 from aqt.commercial import CommercialInstaller, QtPackageInfo, QtPackageManager
 from aqt.exceptions import DiskAccessNotPermitted
-from aqt.helper import Settings, get_qt_account_path
+from aqt.helper import Settings, download_installer, get_qt_account_path
 from aqt.installer import Cli
 from aqt.metadata import Version
 from tests.test_helper import mocked_requests_get
@@ -219,7 +219,10 @@ def test_commercial_installer_download_sha256(tmp_path, monkeypatch, commercial_
     monkeypatch.setattr(requests.Session, "get", mocked_requests_get)
 
     target_path = tmp_path / "qt-installer"
-    commercial_installer.download_installer(target_path, timeout=Settings.qt_installer_timeout)
+
+    timeout = (Settings.connection_timeout, Settings.response_timeout)
+    download_installer(commercial_installer.base_url, commercial_installer._installer_filename,
+                       commercial_installer.os_name, target_path, timeout)
     assert target_path.exists()
 
 
@@ -284,7 +287,7 @@ def test_install_qt_commercial(
         return CompletedProcess(args=args[0], returncode=0)
 
     def mock_get_default_local_cache_path(*args, **kwargs):
-        return tmp_path.joinpath('cache')
+        return tmp_path.joinpath("cache")
 
     monkeypatch.setattr("aqt.commercial.safely_run", mock_safely_run)
     monkeypatch.setattr("aqt.helper.get_default_local_cache_path", mock_get_default_local_cache_path)

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -221,8 +221,8 @@ def test_commercial_installer_download_sha256(tmp_path, monkeypatch, commercial_
     target_path = tmp_path / "qt-installer"
 
     timeout = (Settings.connection_timeout, Settings.response_timeout)
-    download_installer(commercial_installer.base_url, commercial_installer._installer_filename,
-                       commercial_installer.os_name, target_path, timeout)
+    download_installer(commercial_installer.base_url, commercial_installer._installer_filename, commercial_installer.os_name,
+                       target_path, timeout)
     assert target_path.exists()
 
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -139,7 +139,8 @@ def test_helper_downloadBinary_sha256(tmp_path, monkeypatch):
 
     expected = binascii.unhexlify("07b3ef4606b712923a14816b1cfe9649687e617d030fc50f948920d784c0b1cd")
     out = tmp_path.joinpath("text.xml")
-    helper.downloadBinaryFile("http://example.com/test.xml", out, "sha256", expected, 60)
+    timeout = (Settings.connection_timeout, Settings.response_timeout)
+    helper.downloadBinaryFile("http://example.com/test.xml", out, "sha256", expected, timeout)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The current `install-qt-officiial` feature uses requests library directory. 
This PR replace `requests.get` with `aqt.helper.downloadBinaryFile` 

Also, this updates functional test to adopt a method signature change, and to use of tmp_path fixture.