### PR TITLE
Fix arch guessing error when version not fully qualified, fix list-qt android, add --UNSAFE-ignore-hash, add --use-official-installer to list-qt

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -517,7 +517,10 @@ class QtArchives:
             self._parse_update_xml(update_xml.target_folder, update_xml.xml_text, target_packages)
         # if we have located every requested package, then target_packages will be empty
         if not self.all_extra and len(target_packages) > 0:
-            message = f"The packages {target_packages} were not found while parsing XML of package information!"
+            message = f"The packages {target_packages} were not found while parsing XML of package information! {
+                self.target} {
+                self.arch} {
+                self.version}"
             raise NoPackageFound(message, suggested_action=self.help_msg(list(target_packages.get_modules())))
 
     def _append_tool_update(self, os_target_folder, update_xml, target, tool_version_str):

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -517,10 +517,7 @@ class QtArchives:
             self._parse_update_xml(update_xml.target_folder, update_xml.xml_text, target_packages)
         # if we have located every requested package, then target_packages will be empty
         if not self.all_extra and len(target_packages) > 0:
-            message = f"The packages {target_packages} were not found while parsing XML of package information! {
-                self.target} {
-                self.arch} {
-                self.version}"
+            message = f"The packages {target_packages} were not found while parsing XML of package information!"
             raise NoPackageFound(message, suggested_action=self.help_msg(list(target_packages.get_modules())))
 
     def _append_tool_update(self, os_target_folder, update_xml, target, tool_version_str):

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -467,12 +467,14 @@ class SettingsClass:
         "config": None,
         "configfile": None,
         "loggingconf": None,
+        "_ignore_hash_override": None,
         "_lock": Lock(),
     }
 
     def __init__(self) -> None:
         self.config: Optional[ConfigParser]
         self._lock: Lock
+        self._ignore_hash_override: Optional[bool] = None
         self._initialize()
 
     def __new__(cls, *p, **k):
@@ -505,6 +507,10 @@ class SettingsClass:
         self._initialize()
         assert self.config is not None
         return self.config
+
+    def set_ignore_hash_for_session(self, value: bool) -> None:
+        """Override the INSECURE_NOT_FOR_PRODUCTION_ignore_hash setting for the current session without modifying config."""
+        self._ignore_hash_override = value
 
     def load_settings(self, file: Optional[Union[str, TextIO]] = None) -> None:
         if self.config is None:
@@ -604,6 +610,8 @@ class SettingsClass:
 
     @property
     def ignore_hash(self):
+        if self._ignore_hash_override is not None:
+            return self._ignore_hash_override
         return self.config.getboolean("requests", "INSECURE_NOT_FOR_PRODUCTION_ignore_hash", fallback=False)
 
     @property

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1016,7 +1016,7 @@ class Cli:
             help="Search terms (all non-option arguments are treated as search terms)",
         )
 
-    def run_list_qt_commercial(self, args: ListArgumentParser, print_version: bool = True) -> None:
+    def run_list_qt_commercial(self, args: ListArgumentParser, print_version: Optional[bool] = True) -> None:
         """Execute Qt commercial package listing."""
         if print_version:
             self.show_aqt_version()

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -369,6 +369,9 @@ class Cli:
             qt_version = args.qt_version
             Cli._validate_version_str(qt_version)
 
+        if qt_version != qt_version_or_spec:
+            arch = self._set_arch(args.arch, os_name, target, qt_version)
+
         if hasattr(args, "use_official_installer") and args.use_official_installer is not None:
 
             if len(args.use_official_installer) not in [0, 2]:
@@ -818,10 +821,11 @@ class Cli:
         install_qt_parser.add_argument(
             "arch",
             nargs="?",
-            help="\ntarget linux/desktop: gcc_64, wasm_32"
+            help="\ntarget linux/desktop: linux_gcc_64, gcc_64, wasm_32"
             "\ntarget mac/desktop:   clang_64, wasm_32"
             "\ntarget mac/ios:       ios"
-            "\nwindows/desktop:      win64_msvc2019_64, win32_msvc2019"
+            "\nwindows/desktop:      win64_msvc2022_64"
+            "\n                      win64_msvc2019_64, win32_msvc2019"
             "\n                      win64_msvc2017_64, win32_msvc2017"
             "\n                      win64_msvc2015_64, win32_msvc2015"
             "\n                      win64_mingw81, win32_mingw81"

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -105,6 +105,9 @@ class ListArgumentParser(BaseArgumentParser):
     qt_version_spec: str
     spec: str
     target: str
+    email: Optional[str]
+    pw: Optional[str]
+    search_terms: Optional[str]
 
 
 class ListToolArgumentParser(ListArgumentParser):
@@ -662,6 +665,62 @@ class Cli:
     def run_list_qt(self, args: ListArgumentParser):
         """Print versions of Qt, extensions, modules, architectures"""
 
+        if hasattr(args, "use_official_installer") and args.use_official_installer is not None:
+
+            if len(args.use_official_installer) not in [0, 2]:
+                raise CliInputError(
+                    "When providing arguments to --use-official-installer, exactly 2 arguments are required: "
+                    "--use-official-installer email password"
+                )
+
+            self.logger.info("Using official Qt installer for search")
+
+            commercial_search_args = ListArgumentParser()
+
+            email = None
+            password = None
+            if len(args.use_official_installer) == 2:
+                email, password = args.use_official_installer
+                self.logger.info("Using credentials provided with --use-official-installer")
+
+            commercial_search_args.email = email or getattr(args, "email", None)
+            commercial_search_args.pw = password or getattr(args, "pw", None)
+
+            target_str = ""
+            version_str = ""
+            if hasattr(args, "target") and args.target is not None:
+                target_str = args.target
+            if hasattr(args, "arch") and args.arch is not None:
+                try:
+                    version = Version(args.arch)
+                    version_str = f"{version.major}{version.minor}{version.patch}"
+                except Exception as e:
+                    self.logger.warning(f"{e}. Ignoring 'arch' value")
+
+            commercial_search_args.search_terms = [rf"^.*{re.escape(version_str)}\.{re.escape(target_str)}.*$"]
+
+            ignored_options = []
+            if getattr(args, "extensions", False):
+                ignored_options.append("--extensions")
+            if getattr(args, "extension", False):
+                ignored_options.append("--extension")
+            if getattr(args, "modules", None):
+                ignored_options.append("--modules")
+            if getattr(args, "long_modules", False):
+                ignored_options.append("--long_modules")
+            if getattr(args, "spec", False):
+                ignored_options.append("--spec")
+            if getattr(args, "archives", False):
+                ignored_options.append("--archives")
+            if getattr(args, "latest-version", False):
+                ignored_options.append("--latest-version")
+
+            if ignored_options:
+                self.logger.warning("Options ignored because you requested the official installer:")
+                self.logger.warning(", ".join(ignored_options))
+
+            return self.run_list_qt_commercial(commercial_search_args, print_version=False)
+
         if args.extensions:
             self._warn_on_deprecated_parameter("extensions", args.extensions)
             self.logger.warning(
@@ -957,9 +1016,10 @@ class Cli:
             help="Search terms (all non-option arguments are treated as search terms)",
         )
 
-    def run_list_qt_commercial(self, args) -> None:
+    def run_list_qt_commercial(self, args: ListArgumentParser, print_version: bool = True) -> None:
         """Execute Qt commercial package listing."""
-        self.show_aqt_version()
+        if print_version:
+            self.show_aqt_version()
 
         # Create temporary directory for installer
         temp_dir = Settings.qt_installer_temp_path
@@ -1129,6 +1189,16 @@ class Cli:
             metavar="SPECIFICATION",
             help="Filter output so that only versions that match the specification are printed. "
             'IE: `aqt list-qt windows desktop --spec "5.12"` prints all versions beginning with 5.12',
+        )
+        list_parser.add_argument(
+            "--use-official-installer",
+            nargs="*",
+            default=None,
+            metavar=("EMAIL", "PASSWORD"),
+            help="Use the official Qt installer for research instead of the aqt researcher. "
+            "Can be used without arguments or with email and password: --use-official-installer email password. "
+            "This redirects to list-qt-official. "
+            "Arguments not compatible with the official installer will be ignored.",
         )
         output_modifier_exclusive_group = list_parser.add_mutually_exclusive_group()
         output_modifier_exclusive_group.add_argument(

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1269,6 +1269,11 @@ class Cli:
             action="store_true",
             help="Print what would be downloaded and installed without actually doing it",
         )
+        subparser.add_argument(
+            "--UNSAFE-ignore-hash",
+            action="store_true",
+            help="UNSAFE: Skip hash verification of downloaded files. Use at your own risk.",
+        )
 
     def _set_module_options(self, subparser):
         subparser.add_argument("-m", "--modules", nargs="*", help="Specify extra modules to install")
@@ -1324,6 +1329,22 @@ class Cli:
                 self.logger.debug("Load configuration from {}".format(config))
             else:
                 Settings.load_settings()
+
+        # Set ignore_hash to True if --UNSAFE-ignore-hash flag was passed
+        if args is not None and hasattr(args, "UNSAFE_ignore_hash") and args.UNSAFE_ignore_hash:
+            self.logger.warning(
+                "************************************************************************************************"
+            )
+            self.logger.warning(
+                "Hash verification is disabled. This is UNSAFE and may allow malicious files to be downloaded."
+            )
+            self.logger.warning(
+                "If your install mirror hosts malicious files, you won't be able to know. Use at your own risk."
+            )
+            self.logger.warning(
+                "************************************************************************************************"
+            )
+            Settings.set_ignore_hash_for_session(True)
 
     @staticmethod
     def _validate_version_str(

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -237,6 +237,8 @@ def get_semantic_version(qt_ver: str, is_preview: bool) -> Optional[Version]:
         return Version(major=int(qt_ver[0]), minor=int(qt_ver[1]), patch=int(qt_ver[2]))
     elif len(qt_ver) == 2:
         return Version(major=int(qt_ver[0]), minor=int(qt_ver[1]), patch=0)
+    elif len(qt_ver) == 1:
+        return Version(major=int(qt_ver[0]), minor=0, patch=0)
 
     raise ValueError("Invalid version string '{}'".format(qt_ver))
 
@@ -250,7 +252,7 @@ class ArchiveId:
         "mac": ["android", "desktop", "ios"],
         "linux": ["android", "desktop"],
         "linux_arm64": ["desktop"],
-        "all_os": ["wasm", "qt"],
+        "all_os": ["wasm", "qt", "android"],
     }
     EXTENSIONS_REQUIRED_ANDROID_QT6 = {"x86_64", "x86", "armv7", "arm64_v8a"}
     ALL_EXTENSIONS = {
@@ -787,6 +789,7 @@ class MetadataFactory:
         )
         versions = sorted([ver for ver, ext in versions_extensions if ver is not None and filter_by(ver, ext)])
         grouped = cast(Iterable[Tuple[int, Iterable[Version]]], itertools.groupby(versions, lambda version: version.minor))
+
         return Versions(grouped)
 
     def fetch_latest_version(self, ext: str) -> Optional[Version]:

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -782,7 +782,7 @@ class MetadataFactory:
         def match_any_ext(ver: Version) -> bool:
             return (
                 self.archive_id.host == "all_os"
-                and self.archive_id.target in {"wasm", "android"}
+                and self.archive_id.target in ArchiveId.TARGETS_FOR_HOST["all_os"]
                 and ver in SimpleSpec("6.7.*")
             )
 


### PR DESCRIPTION
# New features

## Add `--use-official-installer` to `list-qt`
Very simple implementation. Will ignore `host` (as the official installer only lists the packages for your current OS, but the `host` value must still be provided and valid), will use `target` as research term, along with eventual `arch`, using the following regex: `^.*{re.escape(version_str)}\.{re.escape(target_str)}.*$`. Similar to `install-qt`, it will list all the arguments ignored.  
For example, if you use `aqt list-qt linux android --arch 6.8.3 --use-official-installer` on Linux, it will trigger a search using the official installer like this: 
```console
kidev:~$ aqt list-qt all_os android --arch 6.8.3 --use-official-installer 
INFO    : Using official Qt installer for search
INFO    : Downloading Qt installer to /home/kidev/.local/share/aqt/tmp/qt-online-installer-linux-x64-online.run
INFO    : Redirected: mirrors.20i.com
INFO    : [0] Arguments: /home/kidev/.local/share/aqt/tmp/qt-online-installer-linux-x64-online.run, --accept-licenses, --accept-obligations, --confirm-command, search, ^.*683\.android.*$
...
<availablepackages>
    <package name="qt.qt6.683.android" displayname="Android" version="6.8.3-0-202503201334"/>
    <package name="extensions.qtinsighttracker.683.android" displayname="Android" version="6.8.3-0-202503201624"/>
    <package name="extensions.qtpdf.683.android" displayname="Android" version="6.8.3-0-202503201636"/>
</availablepackages>
```

## Enable usage when Qt mirrors are down
Added common option `--UNSAFE-ignore-hash` that have the same effect as setting `INSECURE_NOT_FOR_PRODUCTION_ignore_hash: True` in the `settings.ini` file, but from the CLI. It does not edit the config file and affects only the current session. It prints warnings. 
```console
kidev:~$ python -m aqt install-qt linux desktop 6.8 --UNSAFE-ignore-hash
WARNING : ************************************************************************************************
WARNING : Hash verification is disabled. This is UNSAFE and may allow malicious files to be downloaded.
WARNING : If your install mirror hosts malicious files, you won't be able to know. Use at your own risk.
WARNING : ************************************************************************************************
INFO    : aqtinstall(aqt) v0.1.dev1903 on Python 3.12.8 [CPython GCC 14.2.1 20240910]
INFO    : Resolved spec '6.8' to 6.8.3
...
```

# Bug fixes

## Fix #908 

In `run_install_qt`, the version in the args is used to determine the architecture. However, if the version is not fully qualified (6.8 in instead of 6.8.3 for example), then the architecture guessing is done with the version not yet resolved. This is because the version guessing also needs the arch. To fix this, I try to guess the arch, then the version, and if the resolved version is different from the argument one, then I run the arch guessing again.  

## Fix #910
Bug in `aqt/metadata.py`/`get_versions_extensions`/`folder_to_version_extension` that was not taking into account Qt 6.7.x special format on the repo.  
Thanks to @jdpurcell for help on the fix of Qt 6.7.* not showing up with `all_os` host in `aqt/metadata.py`/`fetch_versions`


# Misc
Added the architectures `linux_gcc_64` and `win64_msvc2022_64` in the help string.