### PR TITLE
Fallback to mac-x64 when mac-arm64 installer is missing

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -147,13 +147,16 @@ def get_qt_installers() -> dict[str, str]:
 
 def get_qt_installer_name() -> str:
     installer_dict = get_qt_installers()
-    
-    # If mac-arm64 is missing but mac-x64 exists, use that
     os_arch = get_os_arch()
+    
     if os_arch == "mac-arm64" and os_arch not in installer_dict:
         fallback = "mac-x64"
         if fallback in installer_dict:
+            print("Warning: Falling back to mac-x64 installer for mac-arm64 platform.")
             return installer_dict[fallback]
+
+    if os_arch not in installer_dict:
+        raise RuntimeError(f"No installer found for platform: {os_arch}")
             
     return installer_dict[get_os_arch()]
 

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -147,6 +147,13 @@ def get_qt_installers() -> dict[str, str]:
 
 def get_qt_installer_name() -> str:
     installer_dict = get_qt_installers()
+    
+    # If mac-arm64 is missing but mac-x64 exists, use that
+    if os_arch == "mac-arm64" and os_arch not in installer_dict:
+        fallback = "mac-x64"
+        if fallback in installer_dict:
+            return installer_dict[fallback]
+            
     return installer_dict[get_os_arch()]
 
 

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -149,6 +149,7 @@ def get_qt_installer_name() -> str:
     installer_dict = get_qt_installers()
     
     # If mac-arm64 is missing but mac-x64 exists, use that
+    os_arch = get_os_arch()
     if os_arch == "mac-arm64" and os_arch not in installer_dict:
         fallback = "mac-x64"
         if fallback in installer_dict:


### PR DESCRIPTION
macOS ARM (Apple Silicon) systems currently cause a KeyError in `get_qt_installer_name()` because no `mac-arm64` installer exists in the Qt online releases. This patch adds a fallback to `mac-x64`, which runs fine under Rosetta and is the only available macOS installer for the moment.

The patch also includes a runtime check to raise a clearer error message if no installer is found for the detected platform.

Please let me know if I need to change anything in my patch. Thanks!