### PR TITLE
update host windows_arm64 files as we do with windows.

### DIFF
--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -185,11 +185,11 @@ class Updater:
             )
 
     def patch_qt_scripts(self, base_dir, version_dir: str, os_name: str, desktop_arch_dir: str, version: Version):
-        sep = "\\" if os_name == "windows" else "/"
+        sep = "\\" if os_name.startswith("windows") else "/"
         patched = sep.join([base_dir, version_dir, desktop_arch_dir, "bin"])
 
         def patch_script(script_name):
-            script_path = self.prefix / "bin" / (script_name + ".bat" if os_name == "windows" else script_name)
+            script_path = self.prefix / "bin" / (script_name + ".bat" if os_name.startswith("windows") else script_name)
             self.logger.info(f"Patching {script_path}")
             for unpatched in unpatched_paths():
                 self._patch_textfile(script_path, f"{unpatched}bin", patched, is_executable=True)
@@ -209,7 +209,7 @@ class Updater:
         elif target.os_name == "linux":
             lib_dir = self.prefix.joinpath("lib")
             components = ["libQt5Core.so"]
-        elif target.os_name == "windows":
+        elif target.os_name.startswith("windows"):
             lib_dir = self.prefix.joinpath("bin")
             components = ["Qt5Cored.dll", "Qt5Core.dll"]
         else:
@@ -255,7 +255,7 @@ class Updater:
         new_hostprefix = f"HostPrefix=../../{desktop_arch_dir}"
         new_targetprefix = "Prefix={}".format(str(Path(base_dir).joinpath(qt_version, arch_dir, "target")))
         new_hostdata = "HostData=../{}".format(arch_dir)
-        new_host_lib_execs = "./bin" if os_name == "windows" else "./libexec"
+        new_host_lib_execs = "./bin" if os_name.startswith("windows") else "./libexec"
         old_host_lib_execs = re.compile(r"^HostLibraryExecutables=[^\n]*$", flags=re.MULTILINE)
 
         self._patch_textfile(target_qt_conf, old_host_lib_execs, f"HostLibraryExecutables={new_host_lib_execs}")
@@ -321,7 +321,7 @@ class Updater:
                     updater.patch_pkgconfig("/Users/qt/work/install", target.os_name)
                     updater.patch_libtool("/Users/qt/work/install/lib", target.os_name)
                     updater.patch_prl("/Users/qt/work/install/lib")
-                elif target.os_name == "windows":
+                elif target.os_name.startswith("windows"):
                     updater.patch_pkgconfig("c:/Users/qt/work/install", target.os_name)
                     updater.patch_prl("c:/Users/qt/work/install/lib")
                     updater.make_qtenv2(base_dir, version_dir, arch_dir)


### PR DESCRIPTION
Qt 6.8 has added Windows on Arm as a supported configuration.  The restriction "Windows on ARM is only supported as a deployment target. Applications have to be cross-compiled from an x86-64 Windows machine and deployed to target." has been removed.

This PR simply treats windows and windows_arm64 hosts identically when patching files and creating scripts.  Some of these cases don't actually apply to WoA, but I treated them all identically for consistency.  For example patch_qt_core won't ever do anything on WoA because the windows_arm64 hosts wasn't ever supported with Qt 5.

Note other issues prevent aqt from running on WoA machines, e.g. https://codeberg.org/miurahr/pyppmd/issues/128.  However, this at least allows the WoA install to be done on another machine type and subsequently transferred to the WoA machine for use (with an identical path).