### PR TITLE
Update changelog for preparation of the next v3.3.0 release

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,20 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 =============
 
+Fixed
+-----
+- Fix arch guessing error when version not fully qualified, fix list-qt android, add --UNSAFE-ignore-hash, add --use-official-installer to list-qt (#909)
+- Add --use-official-installer, fix official installer download after update 4.9 (#906)
+
+Added
+-----
+- update host windows_arm64 files as we do with windows (#914)
+
+Changed
+-------
+- Documentation: Add --use-official-installer, --dry-run, --UNSAFE-ignore-hash, examples (#907)
+
+
 `v3.2.1`_ (16, March, 2025)
 ===========================
 
@@ -46,7 +60,7 @@ Fixed
 
 Added
 -----
-- Add support for commercal version of Qt (#878)
+- Add support for commercial version of Qt (#878)
 
 Changed
 -------

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -12,11 +12,15 @@ Original qli-installer is written by Linus Jahn
 Significant contributions for improvements of version 2.0 and 2.1 by David Dalcino
 David also leads many developments and reviews effort after 2.0.
 
+Significant contributions have been made by @tsteven4 for implementing support for tracking changing folder hierarchies,
+and by Alexandre @Kidev Poumaroux for developing the official installer option integration.
+
+
 All contributors, listed alphabetically, are:
 
 * Adrian Eddy (fix the case of Android 6.7.0)
 * Alberto Mardegan(ignore_hash option)
-* Alexandre @Kidev Poumaroux (official installer option, WASM fixes for Qt6.7.x)
+* Alexandre @Kidev Poumaroux (official installer option, WASM fixes for Qt6.7.x, manuals)
 * Andrew Wason (support arm64)
 * Andrei Yankovich (tools ifw installation)
 * Aurélien Gâteau (patching to qmake)
@@ -29,7 +33,7 @@ All contributors, listed alphabetically, are:
 * Felix Barz (Android, Explicit extra module installation)
 * Gamso (improve parsing of update.xml)
 * iakov (improve wasm test cases)
-* J.D. Purcell (patch Qt scripts)
+* J.D. Purcell (patch Qt scripts, fix for list-qt)
 * Julien Marrec (mypy, type hints)
 * Kyle Altendorf (7z binary path search)
 * @lebarsfa (ignore_hash/hash_algorithm options)
@@ -46,7 +50,8 @@ All contributors, listed alphabetically, are:
 * @Steveice10 (MacOS binary build)
 * Sztergbaum Roman (Version database)
 * Thomas Grainger (CLI entry point)
-* @tsteven4 (fix patching, support for Qt 6.8.x)
+* @tsteven4 (fix patching, support for Qt 6.8.x, and windows_arm64)
+* @xavier2k6 (Update ci/test conditions)
 * Vadim Peretokin (Version database)
 * Vladyslav Hnatiuk (Version database)
 * @ypnos (Documents)

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -33,7 +33,7 @@ All contributors, listed alphabetically, are:
 * Felix Barz (Android, Explicit extra module installation)
 * Gamso (improve parsing of update.xml)
 * iakov (improve wasm test cases)
-* J.D. Purcell (patch Qt scripts, fix for list-qt)
+* J.D. Purcell (patch Qt scripts, fix list-qt)
 * Julien Marrec (mypy, type hints)
 * Kyle Altendorf (7z binary path search)
 * @lebarsfa (ignore_hash/hash_algorithm options)


### PR DESCRIPTION
- Update changelog
- Plan to bump minor version from 3.2.1 to 3.3.0.\
- Also update authors.rst 
    - Added @tsteven4 and Alexandre @Kidev Poumaroux's major contributions to the description section.
    - Adjusted individual contribution details for multiple authors and updated the alphabetical list accordingly.