### PR TITLE
Patch all executables under bin and libexec 

### DIFF
--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -190,12 +190,10 @@ class Updater:
 
         def patch_script(script_dir_name, script_glob):
             script_dir = self.prefix / script_dir_name
-
             script_names = sorted(script_dir.glob(script_glob))  # order matters in unit tests
             if len(script_names) == 0:
                 self.logger.debug(f"Skipped patching scripts {script_dir / script_glob}")
                 return
-
             for script_name in script_names:
                 script_path = script_dir / script_name
                 self.logger.info(f"Patching {script_path}")


### PR DESCRIPTION
## Why

An issue in the "jurplel/install-qt-action" project: wasm_singlethreaded/bin all files are non-executable (https://github.com/jurplel/install-qt-action/issues/227).

## Test the packages themselves

### Qt 6.3.2

https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt6_632_wasm/qt.qt6.632.wasm_32/6.3.2-0-202209072004qtbase-Linux-openSUSE_15_3-GCC-Linux-WebAssembly-X86_64.7z

<details open>
<summary>Package details of Qt 6.3.2</summary>

```console
$ ls -l ./6.3.2/wasm_32/{bin,libexec}
./6.3.2/wasm_32/bin:
total 32
-rwxr-xr-x 1 root root  266 Sep  6  2022 qmake
-rwxr-xr-x 1 root root  651 Sep  6  2022 qt-cmake
-rwxr-xr-x 1 root root  660 Sep  6  2022 qt-cmake-private
-rw-r--r-- 1 root root 1035 Sep  6  2022 qt-cmake-private-install.cmake
-rwxr-xr-x 1 root root  219 Sep  6  2022 qt-cmake-standalone-test
-rwxr-xr-x 1 root root  847 Sep  6  2022 qt-configure-module
-rwxr-xr-x 1 root root  268 Sep  6  2022 qtpaths
-rw-r--r-- 1 root root  172 Sep  6  2022 target_qt.conf

./6.3.2/wasm_32/libexec:
total 88
-rwxr-xr-x 1 root root  4632 Sep  2  2022 android_emulator_launcher.sh
-rw-r--r-- 1 root root   448 Sep  2  2022 ensure_pro_file.cmake
-rwxr-xr-x 1 root root   163 Sep  6  2022 qt-internal-configure-tests
-rwxr-xr-x 1 root root 17284 Sep  2  2022 qt-testrunner.py
-rwxr-xr-x 1 root root 51077 Sep  2  2022 syncqt.pl

```

</details>

Fine.

### Qt 6.5.0

https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt6_650_wasm_singlethread/qt.qt6.650.wasm_singlethread/6.5.0-0-202303290841qtbase-Windows-Windows_10_22H2-Clang-Windows-WebAssembly-X86_64.7z

<details open>
<summary>Package details of Qt 6.5.0</summary>

```console
$ ls -l ./6.5.0/wasm_singlethread/{bin,libexec}
./6.5.0/wasm_singlethread/bin:
total 64
-rw-r--r-- 1 root root  268 Mar 25  2023 qmake
-rw-r--r-- 1 root root  268 Mar 25  2023 qmake6                                                                                                           -rw-r--r-- 1 root root   84 Mar 25  2023 qmake6.bat
-rw-r--r-- 1 root root   84 Mar 25  2023 qmake.bat
-rw-r--r-- 1 root root  646 Mar 25  2023 qt-cmake
-rw-r--r-- 1 root root  459 Mar 25  2023 qt-cmake.bat
-rw-r--r-- 1 root root  468 Mar 25  2023 qt-cmake-private.bat
-rw-r--r-- 1 root root  217 Mar 25  2023 qt-cmake-standalone-test.bat
-rw-r--r-- 1 root root  922 Mar 25  2023 qt-configure-module
-rw-r--r-- 1 root root 1106 Mar 25  2023 qt-configure-module.bat
-rw-r--r-- 1 root root  394 Mar 25  2023 qt-internal-configure-tests.bat
-rw-r--r-- 1 root root  270 Mar 25  2023 qtpaths
-rw-r--r-- 1 root root  270 Mar 25  2023 qtpaths6
-rw-r--r-- 1 root root   86 Mar 25  2023 qtpaths6.bat
-rw-r--r-- 1 root root   86 Mar 25  2023 qtpaths.bat                                                                                                      -rw-r--r-- 1 root root  235 Mar 25  2023 target_qt.conf

./6.5.0/wasm_singlethread/libexec:
total 112                                                                                                                                                 -rw-r--r-- 1 root root  3606 Mar 14  2023 android_emulator_launcher.sh
-rw-r--r-- 1 root root   416 Mar 14  2023 batchedtestrunner.html                                                                                          -rw-r--r-- 1 root root  6260 Mar 14  2023 batchedtestrunner.js
-rw-r--r-- 1 root root  4337 Mar 14  2023 emrunadapter.js
-rw-r--r-- 1 root root   549 Mar 14  2023 ensure_pro_file.cmake
-rw-r--r-- 1 root root   655 Mar 25  2023 qt-cmake-private
-rw-r--r-- 1 root root  1059 Mar 25  2023 qt-cmake-private-install.cmake                                                                                  -rw-r--r-- 1 root root   226 Mar 25  2023 qt-cmake-standalone-test
-rw-r--r-- 1 root root  1696 Mar 14  2023 qtestoutputreporter.css
-rw-r--r-- 1 root root 11810 Mar 14  2023 qtestoutputreporter.js
-rw-r--r-- 1 root root   163 Mar 25  2023 qt-internal-configure-tests
-rw-r--r-- 1 root root 17228 Mar 14  2023 qt-testrunner.py
-rw-r--r-- 1 root root 12048 Mar 25  2023 qt-wasmtestrunner.py
-rw-r--r-- 1 root root  7330 Mar 14  2023 qwasmjsruntime.js
-rw-r--r-- 1 root root  2646 Mar 14  2023 qwasmtestmain.js
-rw-r--r-- 1 root root  1458 Mar 14  2023 sanitizer-testrunner.py                                                                                         -rw-r--r-- 1 root root   932 Mar 14  2023 util.js

```

</details>

Missing "x"es.

### Qt 6.8.3

https://download.qt.io/online/qtsdkrepository/all_os/wasm/qt6_683/qt6_683_wasm_singlethread/qt.qt6.683.wasm_singlethread/6.8.3-0-202503201334qtbase-Windows-Windows_10_22H2-Clang-Windows-WebAssembly-X86_64.7z

<details open>
<summary>Package details of Qt 6.8.3</summary>

```console
# ls -l ./{bin,libexec}
./bin:                                                
total 76
-rw-r--r-- 1 root root  268 Mar 17 14:32 qmake
-rw-r--r-- 1 root root  268 Mar 17 14:32 qmake6
-rw-r--r-- 1 root root   84 Mar 17 14:32 qmake6.bat
-rw-r--r-- 1 root root   84 Mar 17 14:32 qmake.bat
-rw-r--r-- 1 root root  648 Mar 17 14:32 qt-cmake                                                                                                         -rw-r--r-- 1 root root  469 Mar 17 14:32 qt-cmake.bat
-rw-r--r-- 1 root root  766 Mar 17 14:32 qt-cmake-create
-rw-r--r-- 1 root root  648 Mar 17 14:32 qt-cmake-create.bat
-rw-r--r-- 1 root root  508 Mar 17 14:32 qt-cmake-private.bat                                                                                             -rw-r--r-- 1 root root  217 Mar 17 14:32 qt-cmake-standalone-test.bat
-rw-r--r-- 1 root root  922 Mar 17 14:32 qt-configure-module
-rw-r--r-- 1 root root 1106 Mar 17 14:32 qt-configure-module.bat
-rw-r--r-- 1 root root 1020 Mar 17 14:32 qt-internal-configure-examples.bat
-rw-r--r-- 1 root root 1020 Mar 17 14:32 qt-internal-configure-tests.bat
-rw-r--r-- 1 root root  270 Mar 17 14:32 qtpaths
-rw-r--r-- 1 root root  270 Mar 17 14:32 qtpaths6
-rw-r--r-- 1 root root   86 Mar 17 14:32 qtpaths6.bat                                                                                                     -rw-r--r-- 1 root root   86 Mar 17 14:32 qtpaths.bat
-rw-r--r-- 1 root root  456 Mar 17 14:33 target_qt.conf

./libexec:
total 112                                                                                                                                                 -rw-r--r-- 1 root root   442 Mar 17 14:30 batchedtestrunner.html
-rw-r--r-- 1 root root  6369 Mar 17 14:30 batchedtestrunner.js
-rw-r--r-- 1 root root  4904 Mar 17 14:30 emrunadapter.js
-rw-r--r-- 1 root root   549 Mar 17 14:30 ensure_pro_file.cmake
-rw-r--r-- 1 root root   687 Mar 17 14:32 qt-cmake-private
-rw-r--r-- 1 root root  1111 Mar 17 14:32 qt-cmake-private-install.cmake
-rw-r--r-- 1 root root   226 Mar 17 14:32 qt-cmake-standalone-test
-rw-r--r-- 1 root root  1722 Mar 17 14:30 qtestoutputreporter.css
-rw-r--r-- 1 root root 11836 Mar 17 14:30 qtestoutputreporter.js
-rw-r--r-- 1 root root   217 Mar 17 14:32 qt-internal-configure-examples
-rw-r--r-- 1 root root   217 Mar 17 14:32 qt-internal-configure-tests
-rw-r--r-- 1 root root 17228 Mar 17 14:30 qt-testrunner.py
-rw-r--r-- 1 root root 12048 Mar 17 14:32 qt-wasmtestrunner.py
-rw-r--r-- 1 root root  7563 Mar 17 14:30 qwasmjsruntime.js
-rw-r--r-- 1 root root  3199 Mar 17 14:30 qwasmtestmain.js
-rw-r--r-- 1 root root  1595 Mar 17 14:30 sanitizer-testrunner.py
-rw-r--r-- 1 root root   958 Mar 17 14:30 util.js

```

</details>

Missing "x"es, too.

As you can see, WASM 7z packages don't contain Unix permission information since Qt 6.5.0.

## Fix and test

Qt 6.3.2, 6.5.0 and 6.8.3.

<details open>
<summary>File info of installed Qt's</summary>

```console
$ aqt install-qt linux desktop 6.3.2 wasm_32 && \
> aqt install-qt linux desktop 6.5.0 wasm_singlethread && \
> aqt install-qt all_os wasm 6.8.3 wasm_singlethread
$ ls -l ./6.?.?/wasm_*/{bin,libexec}/*
-rwxr-xr-x 1 root root   278 May 21 11:05 ./6.3.2/wasm_32/bin/qmake
-rwxr-xr-x 1 root root   651 Sep  6  2022 ./6.3.2/wasm_32/bin/qt-cmake
-rwxr-xr-x 1 root root   660 Sep  6  2022 ./6.3.2/wasm_32/bin/qt-cmake-private
-rw-r--r-- 1 root root  1035 Sep  6  2022 ./6.3.2/wasm_32/bin/qt-cmake-private-install.cmake
-rwxr-xr-x 1 root root   219 Sep  6  2022 ./6.3.2/wasm_32/bin/qt-cmake-standalone-test
-rwxr-xr-x 1 root root   847 Sep  6  2022 ./6.3.2/wasm_32/bin/qt-configure-module
-rwxr-xr-x 1 root root   280 May 21 11:05 ./6.3.2/wasm_32/bin/qtpaths
-rw-r--r-- 1 root root   182 May 21 11:05 ./6.3.2/wasm_32/bin/target_qt.conf
-rwxr-xr-x 1 root root  4632 May 21 11:05 ./6.3.2/wasm_32/libexec/android_emulator_launcher.sh
-rw-r--r-- 1 root root   448 Sep  2  2022 ./6.3.2/wasm_32/libexec/ensure_pro_file.cmake
-rwxr-xr-x 1 root root   163 Sep  6  2022 ./6.3.2/wasm_32/libexec/qt-internal-configure-tests
-rwxr-xr-x 1 root root 17284 May 21 11:05 ./6.3.2/wasm_32/libexec/qt-testrunner.py
-rwxr-xr-x 1 root root 51077 Sep  2  2022 ./6.3.2/wasm_32/libexec/syncqt.pl
-rwxrwxr-x 1 root root   279 May 21 11:06 ./6.5.0/wasm_singlethread/bin/qmake
-rwxrwxr-x 1 root root   279 May 21 11:06 ./6.5.0/wasm_singlethread/bin/qmake6
-rw-rw-r-- 1 root root    84 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qmake6.bat
-rw-rw-r-- 1 root root    84 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qmake.bat
-rwxrwxr-x 1 root root   646 May 21 11:06 ./6.5.0/wasm_singlethread/bin/qt-cmake
-rw-rw-r-- 1 root root   459 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qt-cmake.bat
-rw-rw-r-- 1 root root   468 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qt-cmake-private.bat
-rw-rw-r-- 1 root root   217 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qt-cmake-standalone-test.bat
-rwxrwxr-x 1 root root   922 May 21 11:06 ./6.5.0/wasm_singlethread/bin/qt-configure-module
-rw-rw-r-- 1 root root  1106 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qt-configure-module.bat
-rw-rw-r-- 1 root root   394 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qt-internal-configure-tests.bat
-rwxrwxr-x 1 root root   281 May 21 11:06 ./6.5.0/wasm_singlethread/bin/qtpaths
-rwxrwxr-x 1 root root   281 May 21 11:06 ./6.5.0/wasm_singlethread/bin/qtpaths6
-rw-rw-r-- 1 root root    86 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qtpaths6.bat
-rw-rw-r-- 1 root root    86 Mar 25  2023 ./6.5.0/wasm_singlethread/bin/qtpaths.bat
-rw-rw-r-- 1 root root   246 May 21 11:06 ./6.5.0/wasm_singlethread/bin/target_qt.conf
-rwxrwxr-x 1 root root  3500 May 21 11:06 ./6.5.0/wasm_singlethread/libexec/android_emulator_launcher.sh
-rw-rw-r-- 1 root root   416 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/batchedtestrunner.html
-rw-rw-r-- 1 root root  6260 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/batchedtestrunner.js
-rw-rw-r-- 1 root root  4337 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/emrunadapter.js
-rw-rw-r-- 1 root root   549 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/ensure_pro_file.cmake
-rwxrwxr-x 1 root root   655 May 21 11:06 ./6.5.0/wasm_singlethread/libexec/qt-cmake-private
-rw-rw-r-- 1 root root  1059 Mar 25  2023 ./6.5.0/wasm_singlethread/libexec/qt-cmake-private-install.cmake
-rwxrwxr-x 1 root root   226 May 21 11:06 ./6.5.0/wasm_singlethread/libexec/qt-cmake-standalone-test
-rw-rw-r-- 1 root root  1696 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/qtestoutputreporter.css
-rw-rw-r-- 1 root root 11810 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/qtestoutputreporter.js
-rwxrwxr-x 1 root root   163 May 21 11:06 ./6.5.0/wasm_singlethread/libexec/qt-internal-configure-tests
-rwxrwxr-x 1 root root 16833 May 21 11:06 ./6.5.0/wasm_singlethread/libexec/qt-testrunner.py
-rwxrwxr-x 1 root root 11717 May 21 11:06 ./6.5.0/wasm_singlethread/libexec/qt-wasmtestrunner.py
-rw-rw-r-- 1 root root  7330 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/qwasmjsruntime.js
-rw-rw-r-- 1 root root  2646 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/qwasmtestmain.js
-rwxrwxr-x 1 root root  1409 May 21 11:06 ./6.5.0/wasm_singlethread/libexec/sanitizer-testrunner.py
-rw-rw-r-- 1 root root   932 Mar 14  2023 ./6.5.0/wasm_singlethread/libexec/util.js
-rwxr-xr-x 1 root root   279 May 21 11:06 ./6.8.3/wasm_singlethread/bin/qmake
-rwxr-xr-x 1 root root   279 May 21 11:06 ./6.8.3/wasm_singlethread/bin/qmake6
-rw-r--r-- 1 root root    84 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qmake6.bat
-rw-r--r-- 1 root root    84 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qmake.bat
-rwxr-xr-x 1 root root   648 May 21 11:06 ./6.8.3/wasm_singlethread/bin/qt-cmake
-rw-r--r-- 1 root root   469 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qt-cmake.bat
-rwxr-xr-x 1 root root   766 May 21 11:06 ./6.8.3/wasm_singlethread/bin/qt-cmake-create
-rw-r--r-- 1 root root   648 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qt-cmake-create.bat
-rw-r--r-- 1 root root   508 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qt-cmake-private.bat
-rw-r--r-- 1 root root   217 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qt-cmake-standalone-test.bat
-rwxr-xr-x 1 root root   922 May 21 11:06 ./6.8.3/wasm_singlethread/bin/qt-configure-module
-rw-r--r-- 1 root root  1106 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qt-configure-module.bat
-rw-r--r-- 1 root root  1020 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qt-internal-configure-examples.bat
-rw-r--r-- 1 root root  1020 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qt-internal-configure-tests.bat
-rwxr-xr-x 1 root root   281 May 21 11:06 ./6.8.3/wasm_singlethread/bin/qtpaths
-rwxr-xr-x 1 root root   281 May 21 11:06 ./6.8.3/wasm_singlethread/bin/qtpaths6
-rw-r--r-- 1 root root    86 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qtpaths6.bat
-rw-r--r-- 1 root root    86 Mar 17 14:32 ./6.8.3/wasm_singlethread/bin/qtpaths.bat
-rw-r--r-- 1 root root   456 May 21 11:06 ./6.8.3/wasm_singlethread/bin/target_qt.conf
-rw-r--r-- 1 root root   442 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/batchedtestrunner.html
-rw-r--r-- 1 root root  6369 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/batchedtestrunner.js
-rw-r--r-- 1 root root  4904 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/emrunadapter.js
-rw-r--r-- 1 root root   549 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/ensure_pro_file.cmake
-rwxr-xr-x 1 root root   687 May 21 11:06 ./6.8.3/wasm_singlethread/libexec/qt-cmake-private
-rw-r--r-- 1 root root  1111 Mar 17 14:32 ./6.8.3/wasm_singlethread/libexec/qt-cmake-private-install.cmake
-rwxr-xr-x 1 root root   226 May 21 11:06 ./6.8.3/wasm_singlethread/libexec/qt-cmake-standalone-test
-rw-r--r-- 1 root root  1722 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/qtestoutputreporter.css
-rw-r--r-- 1 root root 11836 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/qtestoutputreporter.js
-rwxr-xr-x 1 root root   217 May 21 11:06 ./6.8.3/wasm_singlethread/libexec/qt-internal-configure-examples
-rwxr-xr-x 1 root root   217 May 21 11:06 ./6.8.3/wasm_singlethread/libexec/qt-internal-configure-tests
-rwxr-xr-x 1 root root 16833 May 21 11:06 ./6.8.3/wasm_singlethread/libexec/qt-testrunner.py
-rwxr-xr-x 1 root root 11717 May 21 11:06 ./6.8.3/wasm_singlethread/libexec/qt-wasmtestrunner.py
-rw-r--r-- 1 root root  7563 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/qwasmjsruntime.js
-rw-r--r-- 1 root root  3199 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/qwasmtestmain.js
-rwxr-xr-x 1 root root  1544 May 21 11:06 ./6.8.3/wasm_singlethread/libexec/sanitizer-testrunner.py
-rw-r--r-- 1 root root   958 Mar 17 14:30 ./6.8.3/wasm_singlethread/libexec/util.js

```

</details>

Now all shell scripts are executable.
