### PR TITLE
Fix spec version input for `all_os` `wasm` not detecting `wasm_*` architectures for Qt >= 6.8.0

### DIFF
--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -783,7 +783,7 @@ class MetadataFactory:
             return (
                 self.archive_id.host == "all_os"
                 and self.archive_id.target in ArchiveId.TARGETS_FOR_HOST["all_os"]
-                and ver in SimpleSpec("6.7.*")
+                and ver >= Version("6.7.0")
             )
 
         def filter_by(ver: Version, ext: str) -> bool:


### PR DESCRIPTION
### Fix #926 
In `fetch_versions` in `aqt/metadata.py`, `match_any_ext` did not capture correctly WASM packages with version >= 6.8.0. That meant only Qt 6.7.* WASM versions worked when the specification resolver tried to check versions validity for `all_os`, `wasm` and Qt >= 6.7.0 (so `aqt install-qt all_os wasm '6.9.*' wasm_singlethread` did not work, neither did `aqt install-qt all_os wasm '6.8.*' wasm_singlethread`, but `aqt install-qt all_os wasm '6.7.*' wasm_singlethread` worked). 
This fixes it.