### PR TITLE
Add binaries for windows-arm64 and macos15-arm64

### DIFF
--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -1,6 +1,6 @@
 # This will only run automatically when releases have been created,
 # and will only upload binaries to previously-created releases.
-# When run manually, it will overwrite the previous reelease binary
+# When run manually, it will overwrite the previous release binary
 
 name: Upload release artifacts
 
@@ -16,14 +16,16 @@ jobs:
     strategy:
       matrix:
         system: [
-          {os: windows-latest, arch: x86, output_file: 'aqt_x86.exe', primary_artifact: '', secondary_artifact: 'aqt_x86.exe'},
-          {os: windows-latest, arch: x64, output_file: 'aqt_x64.exe', primary_artifact: 'aqt.exe', secondary_artifact: 'aqt_x64.exe'},
-          {os: macOS-13, arch: x64, output_file: 'aqt_x64', primary_artifact: 'aqt-macos', secondary_artifact: 'aqt-macos_x64'}
+          {os: windows-2025, arch: x86, output_file: 'aqt_x86.exe', primary_artifact: '', secondary_artifact: 'aqt_x86.exe'},
+          {os: windows-2025, arch: x64, output_file: 'aqt_x64.exe', primary_artifact: 'aqt.exe', secondary_artifact: 'aqt_x64.exe'},
+          {os: windows-11-arm, arch: arm64, output_file: 'aqt_arm64.exe', primary_artifact: '', secondary_artifact: 'aqt_arm64.exe'},
+          {os: macos-13, arch: x64, output_file: 'aqt_x64', primary_artifact: 'aqt-macos', secondary_artifact: 'aqt-macos_x64'},
+          {os: macos-15, arch: arm64, output_file: 'aqt_arm64', primary_artifact: '', secondary_artifact: 'aqt-macos_arm64'}
         ]
         py: [3.13]
     defaults:
       run:
-        shell: ${{ matrix.system.os == 'windows-latest' && 'pwsh' || 'bash' }} {0}
+        shell: ${{ startsWith(matrix.system.os, 'windows-') && 'pwsh' || 'bash' }} {0}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,12 +39,12 @@ jobs:
       - name: Build standalone binary
         run: |
           python -m venv venv
-          ${{ matrix.system.os == 'windows-latest' && 'venv/Scripts/activate.ps1' || 'chmod +x venv/bin/activate && venv/bin/activate' }}
+          ${{ startsWith(matrix.system.os, 'windows-') && 'venv/Scripts/activate.ps1' || 'chmod +x venv/bin/activate && venv/bin/activate' }}
           python -m pip install -U pip wheel setuptools setuptools_scm pyinstaller
           python -m pip install .
           python tools/build_standalone.py ${{ matrix.system.arch }}
-          ${{ matrix.system.os == 'windows-latest' && 'deactivate' || 'chmod +x venv/bin/deactivate && venv/bin/deactivate' }}
-          ${{ matrix.system.os == 'windows-latest' && 'Remove-Item venv -Recurse -Force' || 'rm -rf venv' }}
+          ${{ startsWith(matrix.system.os, 'windows-') && 'deactivate' || 'chmod +x venv/bin/deactivate && venv/bin/deactivate' }}
+          ${{ startsWith(matrix.system.os, 'windows-') && 'Remove-Item venv -Recurse -Force' || 'rm -rf venv' }}
 
       - name: Upload to Release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Complete #930 

- Add binaries for Windows arm64 and macOS15 arm64
- Make the Github Action script use `windows-2025` instead of `windows-latest` for stability

**[Binaries available for download here](https://github.com/Kidev/aqtinstall/releases/tag/v3.4.0) to test**  

_(build run available [here](https://github.com/Kidev/aqtinstall/actions/runs/16254178111) for details)_