### PR TITLE
Handle special mac arm64 official installer case

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -137,7 +137,7 @@ def get_qt_installers() -> dict[str, str]:
 
             # macOS arm64 special case, as no official arm64 installer exists
             # it should not override the arm64 installer if it appears later
-            if installers["mac-x64"] and not installers["mac-arm64"]:
+            if installers.get("mac-x64") and not installers.get("mac-arm64"):
                 installers["mac-arm64"] = installers["mac-x64"]
 
         return installers


### PR DESCRIPTION
Qt does not currently provide an official ARM64 online installer for macOS.

On Apple Silicon Macs, the command `aqt list-qt-official` fails because it strictly searches for an ARM64 installer. However, since macOS supports Rosetta, the x64 installer works without issues on ARM Macs.

This PR adds an override to map the x64 installer to the ARM64 architecture, allowing aqt to function correctly on ARM Macs. Once an official ARM64 installer becomes available, it will automatically take precedence.