### PR TITLE
Fix patching for Qt 6.10.1 cross compile.

### DIFF
--- a/aqt/updater.py
+++ b/aqt/updater.py
@@ -190,6 +190,9 @@ class Updater:
 
         def patch_script(script_name):
             script_path = self.prefix / "bin" / (script_name + ".bat" if os_name.startswith("windows") else script_name)
+            if not os.path.isfile(script_path):
+                # Qt 6.10.1 msvc2022_arm64 prepends "host-"
+                script_path = self.prefix / "bin" / ("host-" + script_name + ".bat" if os_name.startswith("windows") else script_name)
             self.logger.info(f"Patching {script_path}")
             for unpatched in unpatched_paths():
                 self._patch_textfile(script_path, f"{unpatched}bin", patched, is_executable=True)


### PR DESCRIPTION
Qt 6.10.1 cross compile prepends "host-" to the qmake, qmake6, qtpaths, qtpaths6 .bat files.  This has come up before in 6.10.0 betas, but not in the released 6.10.0. (#939).
To accommodate this variability in naming we check if the usual bat file exists and patch that if it does, otherwise we attempt to patch a bat file with "host-" prepended.

Without this patch
```
aqt install-qt windows desktop 6.10.1  win64_msvc2022_arm64_cross_compiled -O C:\Qt -m qt3d qt5compat qtactiveqt qtconnectivity qtimageformats qtlanguageserver qtlocation qtmultimedia qtpositioning  qtremoteobjects qtscxml qtsensors qtserialbus qtserialport qtspeech qtwebchannel qtwebsockets qtwebview
```
fails with
```
2025-11-19 07:32:01,938 - aqt.updater - INFO - updater 24740 Patching C:\Qt\6.10.1\msvc2022_arm64\bin\qmake.bat
2025-11-19 07:32:01,938 - aqt.main - ERROR - installer 24740 Updater caused an IO error: [WinError 2] The system cannot find the file specified: 'C:\\Qt\\6.10.1\\msvc2022_arm64\\bin\\qmake.bat'
```
