### PR TITLE
chore: Bump numerous `action` revisions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,12 +19,12 @@ jobs:
       AQT_TEST_EMAIL: ${{ secrets.AQT_TEST_EMAIL }}
       AQT_TEST_PASSWORD: ${{ secrets.AQT_TEST_PASSWORD }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 20
         fetch-tags: true
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Install tools
@@ -41,7 +41,7 @@ jobs:
       run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
       with:
         distribution: 'temurin'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Fetch release tag
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python 3.13🐍
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install build and twine
@@ -31,7 +31,7 @@ jobs:
       - name: twine check
         run: python -m twine check dist/*
       - name: upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dists
           path: dist/
@@ -44,7 +44,7 @@ jobs:
       id-token: write
     steps:
       - name: download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: dists
           path: dist/

--- a/.github/workflows/run-linter.yml
+++ b/.github/workflows/run-linter.yml
@@ -16,14 +16,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           architecture: x64
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
       - name: Install dependencies
         run: |
           pip install -U pip tox wheel setuptools coveralls coverage[toml]
@@ -38,9 +38,9 @@ jobs:
     name: Document checks
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           architecture: x64

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -37,12 +37,12 @@ jobs:
             qtver: 6.8.1
             artifact: standard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 20
           fetch-tags: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py }}
       - name: Build and install
@@ -187,7 +187,7 @@ jobs:
             print('QT_INATALL_PREFIX {}\nExpected path {}'.format(result, expected_path))
         shell: python
         working-directory: ${{ github.workspace }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: matrix.artifact == 'binary'
         with:
           name: aqt-${{ matrix.os }}-standalone

--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -27,12 +27,12 @@ jobs:
       run:
         shell: ${{ startsWith(matrix.system.os, 'windows-') && 'pwsh' || 'bash' }} {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 20
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py }}
           architecture: ${{ matrix.system.arch }}
@@ -47,7 +47,7 @@ jobs:
           ${{ startsWith(matrix.system.os, 'windows-') && 'Remove-Item venv -Recurse -Force' || 'rm -rf venv' }}
 
       - name: Upload to Release
-        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 #v2.11.2
+        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/${{ matrix.system.output_file }}
@@ -56,7 +56,7 @@ jobs:
           overwrite: true
         if: matrix.system.primary_artifact!='' && startsWith(github.ref, 'refs/tags/v')
       - name: Upload to Release for all architectures
-        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 #v2.11.2
+        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/${{ matrix.system.output_file }}
@@ -65,7 +65,7 @@ jobs:
           overwrite: true
         if: matrix.system.secondary_artifact!='' && startsWith(github.ref, 'refs/tags/v')
       - name: Update continuous build
-        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 #v2.11.2
+        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           overwrite: true
@@ -75,7 +75,7 @@ jobs:
           asset_name: ${{ matrix.system.primary_artifact }}
         if: matrix.system.primary_artifact!='' && startsWith(github.ref, 'refs/tags/v')
       - name: Update continuous build for all architectures
-        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 #v2.11.2
+        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           overwrite: true


### PR DESCRIPTION
* Bump `actions/checkout` to `v6`.
* Bump `actions/setup-python` to `v6`.
* Bump `actions/setup-java` to `v5`.
* Bump `codeql-action/init` to `v4`.
* Bump `codeql-action/analyze` to `v4`.
* Bump `actions/upload-artifact` to `v5`.
* Bump `actions/download-artifact` to `v6`.
* Bump `reviewdog/action-setup` to `v1.5.0`.
* Bump `svenstaro/upload-release-action` to `v2.11.3`.