### PR TITLE
fix mypy configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ commands = [["check-manifest", "{toxinidir}"], ["flake8", "aqt", "tests"]]
 
 [tool.tox.env.mypy]
 extras = ["check"]
-deps = ["types-request", "types-beautifulsoup4", "types-psutil"]
+deps = ["lxml", "types-requests", "types-beautifulsoup4", "types-psutil"]
 commands = [["mypy", "--html-report", "build/mypy", "aqt"]]
 
 [tool.tox.env.docs]


### PR DESCRIPTION
correct spelling of types-requests for mypy.

add missing dependency for mypy to fix:
mypy: commands[0]> mypy --html-report build/mypy aqt You must install the lxml package before you can run mypy with `--html-report`.