### PR TITLE
chore(ci): Bump 2 GitHub `actions` for full Node.js 24 compatibility

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,7 +31,7 @@ jobs:
       - name: twine check
         run: python -m twine check dist/*
       - name: upload dist artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: dists
           path: dist/
@@ -44,7 +44,7 @@ jobs:
       id-token: write
     steps:
       - name: download dist artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: dists
           path: dist/

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -187,7 +187,7 @@ jobs:
             print('QT_INATALL_PREFIX {}\nExpected path {}'.format(result, expected_path))
         shell: python
         working-directory: ${{ github.workspace }}
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: matrix.artifact == 'binary'
         with:
           name: aqt-${{ matrix.os }}-standalone


### PR DESCRIPTION
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/upload-artifact/releases