### PR TITLE
decode std streams when using an external extractor.

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1694,7 +1694,7 @@ def installer(
     else:
         command_args = [command, "x", "-aoa", "-bd", "-y", "-o{}".format(base_dir), str(archive)]
         try:
-            proc = subprocess.run(command_args, stdout=subprocess.PIPE, check=True)
+            proc = subprocess.run(command_args, capture_output=True, check=True, text=True)
             logger.debug(proc.stdout)
         except subprocess.CalledProcessError as cpe:
             msg = "\n".join(filter(None, [f"Extraction error: {cpe.returncode}", cpe.stdout, cpe.stderr]))


### PR DESCRIPTION
This resolves #976, i.e. it fixes the reported TypeError.  Because of the TypeError in #976 it isn't clear what underlying issue the OP had.  In the test below /opt/qt-libs does not exist and the user running aqt does not have sufficient privileges to create it.  Without the change the TypeError was reproduced.  With the PR note that 7z reports 'Cannot create output directory ' which is correct, and 'File exists : /opt/qt-libs/6.10.1/gcc_64/' which is not.  

With the PR:
```
~/aqttest-venv-3142/bin/aqt install-qt -O /opt/qt-libs linux desktop 6.10.1 linux_gcc_64 -m qtconnectivity qtwebsockets --external 7z
INFO    : aqtinstall(aqt) v3.3.1.dev55 on Python 3.14.2 [CPython GCC 13.3.0]
INFO    : Found extension qtwebengine
INFO    : Found extension qtpdf
INFO    : Downloading qtconnectivity...
INFO    : Downloading qtbase...
INFO    : Downloading qtsvg...
INFO    : Downloading qtwebsockets...
INFO    : Redirected: qt.mirror.constant.com
INFO    : Redirected: qt.mirror.constant.com
INFO    : Redirected: qt.mirror.constant.com
INFO    : Redirected: qt.mirror.constant.com
INFO    : Downloading qtdeclarative...
INFO    : Downloading qttools...
INFO    : Downloading qttranslations...
INFO    : Downloading qtwayland...
INFO    : Redirected: qt.mirror.constant.com
INFO    : Redirected: qt.mirror.constant.com
INFO    : Redirected: qt.mirror.constant.com
INFO    : Redirected: qt.mirror.constant.com
INFO    : Downloading icu...
INFO    : Redirected: qt.mirror.constant.com
WARNING : Caught ArchiveExtractionError, terminating installer workers
ERROR   : Extraction error: 2

7-Zip 23.01 (x64) : Copyright (c) 1999-2023 Igor Pavlov : 2023-06-20
 64-bit locale=C.UTF-8 Threads:20 OPEN_MAX:10240

Scanning the drive for archives:
1 file, 106471 bytes (104 KiB)

Extracting archive: /tmp/tmps70_p4qn/qtwebsockets-Linux-RHEL_9_4-GCC-Linux-RHEL_9_4-X86_64.7z
--
Path = /tmp/tmps70_p4qn/qtwebsockets-Linux-RHEL_9_4-GCC-Linux-RHEL_9_4-X86_64.7z
Type = 7z
Physical Size = 106471
Headers Size = 1502
Method = LZMA:23
Solid = +
Blocks = 1




ERROR:
Cannot create output directory : errno=17 : File exists : /opt/qt-libs/6.10.1/gcc_64/


System ERROR:
errno=17 : File exists
```