### PR TITLE
fix test_connection.

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,6 +10,7 @@ import aqt
 @pytest.mark.remote_data
 def test_cli_unknown_version(capsys):
     wrong_version = "5.16.0"
+    wrong_version_str = "qt5_5160"
     cli = aqt.installer.Cli()
     assert cli.run(["install-qt", "mac", "desktop", wrong_version]) == 1
     out, err = capsys.readouterr()
@@ -20,26 +21,25 @@ def test_cli_unknown_version(capsys):
     """
     Expected result when no redirect occurs:
 
-    aqtinstall(aqt) v.* on Python 3.*
-    Specified Qt version is unknown: 5.16.0.
-    Failed to locate XML data for Qt version '5.16.0'.
+    INFO    : aqtinstall(aqt) v.* on Python 3.*
+    WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml'. This may happen on unofficial mirrors.
+    ERROR   : Failed to locate XML data for Qt version '5.16.0'.
     ==============================Suggested follow-up:==============================
     * Please use 'aqt list-qt mac desktop' to show versions available.
 
     Expected result when redirect occurs:
 
-    aqtinstall(aqt) v.* on Python 3.*
-    Specified Qt version is unknown: 5.16.0.
-    Connection to the download site failed and fallback to mirror site.
-    Failed to locate XML data for Qt version '5.16.0'.
-    ==============================Suggested follow-up:==============================
-    * Please use 'aqt list-qt mac desktop' to show versions available.
+    INFO    : aqtinstall(aqt) v.* on Python 3.*
+    WARNING : Connection to 'https://download.qt.io' failed. Retrying with fallback '.*'.
+    WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml'. This may happen on unofficial mirrors.
+    ERROR   : Failed to locate XML data for Qt version '5.16.0'.
     """
 
     matcher = re.compile(
         r"[^\n]*aqtinstall\(aqt\) v.* on Python 3.*\n"
-        r".*Specified Qt version is unknown: " + re.escape(wrong_version) + r"\.\n"
-        r".*Failed to locate XML data for Qt version '" + re.escape(wrong_version) + r"'\.\n"
+        r"(?:WARNING : Connection to 'https://download.qt.io' failed. Retrying with fallback '.*'.\n)?"
+        rf"WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/{wrong_version_str}/Updates.xml'. This may happen on unofficial mirrors.\n"
+        rf".*Failed to locate XML data for Qt version '{re.escape(wrong_version)}'\.\n"
         r"==============================Suggested follow-up:==============================\n"
         r"\* Please use 'aqt list-qt mac desktop' to show versions available\.\n",
     )


### PR DESCRIPTION
This test is skipped in CI, but it failed when I ran pytest locally.  In any event this catches the test up for changes in logging including but not limited to #654, and works locally.

In CI today we see:
```
2026-01-09T04:34:56.9889655Z tests/test_connection.py::test_cli_unknown_version SKIPPED (need
2026-01-09T04:34:56.9897128Z --remote-data option to run
```