### PR TITLE
fix mypy detected type errors related to hashlib.

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -224,13 +224,12 @@ def getUrl(url: str, timeout: Tuple[float, float], expected_hash: Optional[bytes
                 raise ArchiveDownloadError(msg)
         result: str = r.text
         filename = url.split("/")[-1]
-        _kwargs = {"usedforsecurity": False} if sys.version_info >= (3, 9) else {}
         if Settings.hash_algorithm == "sha256":
-            actual_hash = hashlib.sha256(bytes(result, "utf-8"), **_kwargs).digest()
+            actual_hash = hashlib.sha256(bytes(result, "utf-8"), usedforsecurity=False).digest()
         elif Settings.hash_algorithm == "sha1":
-            actual_hash = hashlib.sha1(bytes(result, "utf-8"), **_kwargs).digest()
+            actual_hash = hashlib.sha1(bytes(result, "utf-8"), usedforsecurity=False).digest()
         elif Settings.hash_algorithm == "md5":
-            actual_hash = hashlib.md5(bytes(result, "utf-8"), **_kwargs).digest()
+            actual_hash = hashlib.md5(bytes(result, "utf-8"), usedforsecurity=False).digest()
         else:
             raise ArchiveChecksumError(f"Unknown hash algorithm: {Settings.hash_algorithm}.\nPlease check settings.ini")
         if expected_hash is not None and expected_hash != actual_hash:
@@ -264,10 +263,7 @@ def downloadBinaryFile(url: str, out: Path, hash_algo: str, exp: Optional[bytes]
         except requests.exceptions.Timeout as e:
             raise ArchiveConnectionError(f"Connection timeout: {e.args}") from e
         else:
-            if sys.version_info >= (3, 9):
-                hash = hashlib.new(hash_algo, usedforsecurity=False)
-            else:
-                hash = hashlib.new(hash_algo)
+            hash = hashlib.new(hash_algo, usedforsecurity=False)
             try:
                 with open(out, "wb") as fd:
                     for chunk in r.iter_content(chunk_size=8196):


### PR DESCRIPTION
This fixes mypy the following mypy issues
```
aqt/helper.py:229:68: error: Argument 2 to "openssl_sha256" has incompatible type "**dict[str, bool]"; expected "Buffer | None"  [arg-type]
                actual_hash = hashlib.sha256(bytes(result, "utf-8"), **_kwargs).digest()
                                                                       ^~~~~~~
aqt/helper.py:231:66: error: Argument 2 to "openssl_sha1" has incompatible type "**dict[str, bool]"; expected "Buffer | None"  [arg-type]
                actual_hash = hashlib.sha1(bytes(result, "utf-8"), **_kwargs).digest()
                                                                     ^~~~~~~
aqt/helper.py:233:65: error: Argument 2 to "openssl_md5" has incompatible type "**dict[str, bool]"; expected "Buffer | None"  [arg-type]
                actual_hash = hashlib.md5(bytes(result, "utf-8"), **_kwargs).digest()
                                                                    ^~~~~~~
```

Our minimum python requirement is currently 3.10 so the usedforsecurity argument that was introduced in 3.9 will be available.
