### PR TITLE
fix list-qt-official wrt types, search term.

### DIFF
--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -107,7 +107,7 @@ class ListArgumentParser(BaseArgumentParser):
     target: str
     email: Optional[str]
     pw: Optional[str]
-    search_terms: Optional[str]
+    search_term: Optional[str]
 
 
 class ListToolArgumentParser(ListArgumentParser):
@@ -686,18 +686,18 @@ class Cli:
             commercial_search_args.email = email or getattr(args, "email", None)
             commercial_search_args.pw = password or getattr(args, "pw", None)
 
-            target_str = ""
-            version_str = ""
+            search_target_str = ""
+            search_version_str = ""
             if hasattr(args, "target") and args.target is not None:
-                target_str = args.target
+                search_target_str = args.target
             if hasattr(args, "arch") and args.arch is not None:
                 try:
                     version = Version(args.arch)
-                    version_str = f"{version.major}{version.minor}{version.patch}"
+                    search_version_str = f"{version.major}{version.minor}{version.patch}"
                 except Exception as e:
                     self.logger.warning(f"{e}. Ignoring 'arch' value")
 
-            commercial_search_args.search_terms = [rf"^.*{re.escape(version_str)}\.{re.escape(target_str)}.*$"]
+            commercial_search_args.search_term = rf"^.*{re.escape(search_version_str)}\.{re.escape(search_target_str)}.*$"
 
             ignored_options = []
             if getattr(args, "extensions", False):
@@ -1011,9 +1011,9 @@ class Cli:
 
         # Capture all remaining arguments as search terms
         list_qt_commercial_parser.add_argument(
-            "search_terms",
-            nargs="*",  # Zero or more arguments
-            help="Search terms (all non-option arguments are treated as search terms)",
+            "search_term",
+            nargs="?",  # Zero or one arguments
+            help="Search term",
         )
 
     def run_list_qt_commercial(self, args: ListArgumentParser, print_version: Optional[bool] = True) -> None:
@@ -1049,8 +1049,8 @@ class Cli:
             cmd.append("search")
 
             # Add all search terms if present
-            if args.search_terms:
-                cmd.extend(args.search_terms)
+            if args.search_term:
+                cmd.append(args.search_term)
 
             # Run search
             output = safely_run_save_output(cmd, Settings.qt_installer_timeout)

--- a/docs/official.rst
+++ b/docs/official.rst
@@ -54,13 +54,13 @@ Search available Qt packages using the official Qt installer.
 
 .. code-block:: bash
 
-   aqt list-qt-official [search_terms] [options]
+   aqt list-qt-official [search_term] [options]
 
 Options
 ~~~~~~~
 - ``--email <email>`` - Qt account email/username
 - ``--pw <password>`` - Qt account password
-- ``search_terms`` - Terms to search for in package names (grabs all that is not other options)
+- ``search_term`` - Term to search for in package names
 
 Override Mode
 ----------------------


### PR DESCRIPTION
Previously we accepted zero, one or more search terms for list-qt-official.  However, the official installer ignores all terms after the first.  This PR changes argument parsing for list-qt-official so only zero or one search terms are accepted.

This PR also fixes the mypy errors in installer.py:

```
aqt/installer.py:700:51: error: Incompatible types in assignment (expression
has type "list[str]", variable has type "str | None")  [assignment]
                commercial_search_args.search_terms = [rf"^.*{re.escape(version_str)}\.{re.escape(target_str)}.*$"]
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
aqt/installer.py:752:9: error: Incompatible types in assignment (expression has
type "str | None", variable has type "str")  [assignment]
            for version_str in (modules_ver, args.arch, args.archives[0] i...
            ^
```

The second was fixed by eliminating variable reuse of version_str by renaming, allowing different type signatures to be inferred by mypy for the different usages.

This resolves #965.