### PR TITLE
fix doc generation with Sphinx 9.1.0

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -22,7 +22,7 @@ blacklisting of proxy urls.
 Zero trust network
 ------------------
 
-The `Zero trust network` is popular administration concept in a enterprise local network.
+The *Zero trust network* is popular administration concept in a enterprise local network.
 Enterprise administrator force employers to install network traffic redirector agent in PC and tablet.
 All the traffic are forwarded to cloud service that decrypt SSL communication and checks all the
 employers communications. Security vendor emphasis it as "SECURE" by zero trust for employers privacy.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -94,7 +94,7 @@ archive_download_location:
 min_module_size:
     This is the minimum decompressed size, in bytes, of the modules that aqt is permitted to list.
     The authors of aqt have discovered that the Qt repository contains a few mysteriously
-    "empty" modules, including the examples modules for `qtlottie` and `qtquicktimeline`.
+    "empty" modules, including the examples modules for *qtlottie* and *qtquicktimeline*.
     These modules consist of a single archive that contains empty directories,
     and they are exactly 40 bytes when uncompressed.
     The authors feel that it is not useful for ``aqt list-*`` to list these empty modules.


### PR DESCRIPTION
 With 8.2.3 the usages of the default role led to \<cite> elements in html. With 9.1.0 document generation fails with
```sphinx.errors.SphinxError: cannot determine default role!```
We now use inline markup for emphasis instead of relying on the default role. This results in \<em> elements instead of \<cite> elements, which seems more in accordance with our usage.