### PR TITLE
Add support to use config from environment variables

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -443,8 +443,19 @@ def xml_to_modules(
 
 
 class MyConfigParser(ConfigParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.acceptable_env_keys = [
+            "MIRRORS_TRUSTED_MIRRORS",
+            "MIRRORS_BLACKLIST",
+            "MIRRORS_FALLBACKS",
+        ]
+
     def getlist(self, section: str, option: str, fallback: List[str] = []) -> List[str]:
-        value = self.get(section, option, fallback=None)
+        value = self.getenv(section, option)
+        if value is None:
+            value = self.get(section, option, fallback=None)
+
         if value is None:
             return fallback
         try:
@@ -459,6 +470,14 @@ class MyConfigParser(ConfigParser):
         except Exception:
             result = fallback
         return result
+
+    def getenv(self, section, option):
+        key = section.upper() + "_" + option.upper()
+        if key in self.acceptable_env_keys:
+            value = os.environ.get("AQT_" + key)
+            if value is None:
+                return None
+            return value.replace(",", "\n")
 
 
 class SettingsClass:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -165,6 +165,9 @@ trusted_mirrors:
     the checksums downloaded from the ``trusted_mirrors`` list.
     ``aqtinstall`` uses the SHA-256 algorithm to perform this check.
 
+    Alternatively, you can set ``AQT_MIRRORS_TRUSTED_MIRRORS`` as an environment
+    variable, which will override any value in ``settings.iniˇ.
+
 blacklist:
     It is a list of URL where is a problematic mirror site.
     Some mirror sites ignore a connection from IP addresses out of their preffered one.
@@ -173,7 +176,13 @@ blacklist:
     If you are not happy with the default sites,
     you can override them with custom settings.
 
+    Alternatively, you can set ``AQT_MIRRORS_BLACKLIST`` as an environment
+    variable, which will override any value in ``settings.iniˇ.
+
 fallbacks:
     It is a list of URL where is a good for access.
     When mirror site cause an error, aqt use fallbacks when possible.
     You can find a list of mirrors at: https://download.qt.io/static/mirrorlist/
+
+    Alternatively, you can set ``AQT_MIRRORS_FALLBACKS`` as an environment
+    variable, which will override any value in ``settings.iniˇ.


### PR DESCRIPTION
This is particularly helpful for short-lived containers in CI pipelines, where provisioning and mounting separate config files can be inconvenient. Using environment variables makes setups simpler, more portable, and easier to automate in container-based workflows.

Fixes #992