### PR TITLE
Correct NLUUG mirror URL to ftp.nluug.nl

### DIFF
--- a/aqt/settings.ini
+++ b/aqt/settings.ini
@@ -52,8 +52,7 @@ fallbacks :
     https://www.nic.funet.fi/pub/mirrors/download.qt-project.org/
     https://master.qt.io/
     https://mirrors.ukfast.co.uk/sites/qt.io/
-    https://ftp2.nluug.nl/languages/qt/
-    https://ftp1.nluug.nl/languages/qt/
+    https://ftp.nluug.nl/languages/qt/
     https://qt.mirror.constant.com/
 
 [kde_patches]


### PR DESCRIPTION
Fixes: #1004 

`ftp1.nluug.nl` and `ftp2.nluug.nl` appear to be no longer available; replaced them with `ftp.nluug.nl`.
