### PR TITLE
Correct remaining NLUUG mirror URLs to ftp.nluug.nl

### DIFF
--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional
 
 MIRRORS = [
     "https://ftp.jaist.ac.jp/pub/qtproject",
-    "https://ftp1.nluug.nl/languages/qt",
+    "https://ftp.nluug.nl/languages/qt",
     "https://mirrors.dotsrc.org/qtproject",
 ]
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -44,7 +44,7 @@ A file is like as follows:
     fallbacks:
         https://mirrors.ocf.berkeley.edu/qt
         https://ftp.jaist.ac.jp/pub/qtproject
-        http://ftp1.nluug.nl/languages/qt
+        https://ftp.nluug.nl/languages/qt
         https://mirrors.dotsrc.org/qtproject
 
     [kde_patches]

--- a/tests/data/settings_no_concurrency.ini
+++ b/tests/data/settings_no_concurrency.ini
@@ -19,7 +19,7 @@ blacklist:
     http://mirrors.geekpie.club
 fallbacks:
     https://ftp.jaist.ac.jp/pub/qtproject
-    http://ftp1.nluug.nl/languages/qt
+    https://ftp.nluug.nl/languages/qt
     https://mirrors.dotsrc.org/qtproject
 
 [kde_patches]


### PR DESCRIPTION
Fixes: #1004, follows: #1005

Ref: https://download.qt.io/static/mirrorlist/ (https://web.archive.org/web/20260227053254/https://download.qt.io/static/mirrorlist/)