### PR TITLE
fix: use new IFW repository; remove "tool_version_str" from ToolArchives

### DIFF
--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -566,43 +566,6 @@ class QtArchives:
             message = f"The packages {target_packages} were not found while parsing XML of package information!"
             raise NoPackageFound(message, suggested_action=self.help_msg(list(target_packages.get_modules())))
 
-    def _append_tool_update(self, os_target_folder, update_xml, target, tool_version_str):
-        packageupdate = update_xml.get(target)
-        if packageupdate is None:
-            message = f"The package '{self.arch}' was not found while parsing XML of package information!"
-            raise NoPackageFound(message, suggested_action=self.help_msg())
-        name = packageupdate.name
-        named_version = packageupdate.full_version
-        if tool_version_str and named_version != tool_version_str:
-            message = f"The package '{self.arch}' has the version '{named_version}', not the requested '{self.version}'."
-            raise NoPackageFound(message, suggested_action=self.help_msg())
-        package_desc = packageupdate.description
-        downloadable_archives = packageupdate.downloadable_archives
-        archive_install_paths = packageupdate.archive_install_paths
-        if not downloadable_archives:
-            message = f"The package '{self.arch}' contains no downloadable archives!"
-            raise NoPackageFound(message)
-        for archive, archive_install_path in zip_longest(downloadable_archives, archive_install_paths, fillvalue=""):
-            archive_path = posixpath.join(
-                # online/qtsdkrepository/linux_x64/desktop/tools_ifw/
-                os_target_folder,
-                # qt.tools.ifw.41/
-                name,
-                #  4.1.1-202105261130ifw-linux-x64.7z
-                f"{named_version}{archive}",
-            )
-            self.archives.append(
-                QtPackage(
-                    name=name,
-                    base_url=self.base,
-                    archive_path=archive_path,
-                    archive=archive,
-                    archive_install_path=archive_install_path,
-                    package_desc=package_desc,
-                    pkg_update_name=name,  # Redundant
-                )
-            )
-
     def help_msg(self, missing_modules: Optional[List[str]] = None) -> List[str]:
         _missing_modules: List[str] = missing_modules or []
         base_cmd = f"aqt list-qt {self.os_name} {self.target}"
@@ -708,9 +671,9 @@ class SrcDocExamplesArchives(QtArchives):
 class ToolArchives(QtArchives):
     """Hold tool archive package list
     when installing mingw tool, argument would be
-    ToolArchive(windows, desktop, 4.9.1-3, mingw)
+    ToolArchive(windows, desktop, mingw, 4.9.1-3)
     when installing ifw tool, argument would be
-    ToolArchive(linux, desktop, 3.1.1, ifw)
+    ToolArchive(linux, desktop, ifw, 3.1.1)
     """
 
     def __init__(
@@ -719,14 +682,12 @@ class ToolArchives(QtArchives):
         target: str,
         tool_name: str,
         base: str,
-        version_str: Optional[str] = None,
         arch: str = "",
         timeout: Tuple[float, float] = (5, 5),
     ):
         self.tool_name = tool_name
         self.os_name = os_name
         self.logger = getLogger("aqt.archives")
-        self.tool_version_str: Optional[str] = version_str
         super(ToolArchives, self).__init__(
             os_name=os_name,
             target=target,
@@ -747,18 +708,26 @@ class ToolArchives(QtArchives):
     def _get_archives(self):
         os_segment = self._resolve_os_segment()
         os_target_folder = self._main_repo_folder(os_segment, self.tool_name)
+
         update_xml_url = posixpath.join(os_target_folder, "Updates.xml")
-        update_xml_text = self._download_update_xml(update_xml_url)
+        silent_attempt = self.tool_name == "tools_ifw"
+        update_xml_text = self._download_update_xml(update_xml_url, silent_attempt)
+        if not update_xml_text:
+            message = f"The package '{self.tool_name}' contains no downloadable archives for variant '{self.arch}'!"
+            raise NoPackageFound(message, suggested_action=self.help_msg())
+
         update_xmls = [UpdateXmls(os_target_folder, update_xml_text)]
         self._parse_update_xmls(update_xmls, None)
 
     def _main_repo_folder(self, os_segment: str, name: str) -> str:
         """Build the main repository folder path for Updates.xml."""
-        # For IFW, newer variants (e.g., tools_ifw410) live under 'ifw/<variant>',
-        # while legacy 'tools_ifw47' and unspecified version fall back to the
-        # generic desktop path '.../desktop/tools_ifw'. Ensure we don't join None.
-        if name == "tools_ifw" and self.tool_version_str and self.tool_version_str != "tools_ifw47":
-            os_target_folder = posixpath.join("online/qtsdkrepository", os_segment, "ifw", self.tool_version_str)
+        # For IFW, variants live under 'ifw/<variant>'. The variant 'tools_ifw47' still
+        # resides in the legacy place '.../desktop/tools_ifw' but we don't use it any
+        # more. Unspecified version won't go here and won't fall back to any version,
+        # but will include all versions.
+        if name == "tools_ifw":
+            ifw_version = self.arch.replace("qt.tools.ifw.", "tools_ifw_")
+            os_target_folder = posixpath.join("online/qtsdkrepository", os_segment, "ifw", ifw_version)
             self._debug_repo_choice = "ifw"
         else:
             os_target_folder = posixpath.join("online/qtsdkrepository", os_segment, self.target, name)
@@ -767,7 +736,7 @@ class ToolArchives(QtArchives):
 
     def _parse_update_xml(self, os_target_folder: str, update_xml_text: str, *ignored: Any) -> None:
         update_xml = Updates.fromstring(self.base, update_xml_text)
-        self._append_tool_update(os_target_folder, update_xml, self.arch, self.tool_version_str)
+        self._append_tool_update(os_target_folder, update_xml, self.arch)
 
     def help_msg(self, *args) -> List[str]:
         return [f"Please use 'aqt list-tool {self.os_name} {self.target} {self.tool_name}' to show tool variants available."]
@@ -778,3 +747,37 @@ class ToolArchives(QtArchives):
         :return tuple of three parameter, "Tools", target and arch
         """
         return TargetConfig("Tools", self.target, self.arch, self.os_name)
+
+    def _append_tool_update(self, os_target_folder, update_xml, target):
+        packageupdate = update_xml.get(target)
+        if packageupdate is None:
+            message = f"The package '{self.arch}' was not found while parsing XML of package information!"
+            raise NoPackageFound(message, suggested_action=self.help_msg())
+        name = packageupdate.name
+        named_version = packageupdate.full_version
+        package_desc = packageupdate.description
+        downloadable_archives = packageupdate.downloadable_archives
+        archive_install_paths = packageupdate.archive_install_paths
+        if not downloadable_archives:
+            message = f"The package '{self.arch}' contains no downloadable archives!"
+            raise NoPackageFound(message)
+        for archive, archive_install_path in zip_longest(downloadable_archives, archive_install_paths, fillvalue=""):
+            archive_path = posixpath.join(
+                # online/qtsdkrepository/linux_x64/ifw/tools_ifw_47/
+                os_target_folder,
+                # qt.tools.ifw.47/
+                name,
+                # 4.7.0-0-202402231255ifw-linux-x64.7z
+                f"{named_version}{archive}",
+            )
+            self.archives.append(
+                QtPackage(
+                    name=name,
+                    base_url=self.base,
+                    archive_path=archive_path,
+                    archive=archive,
+                    archive_install_path=archive_install_path,
+                    package_desc=package_desc,
+                    pkg_update_name=name,  # Redundant
+                )
+            )

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -710,11 +710,13 @@ class ToolArchives(QtArchives):
         os_target_folder = self._main_repo_folder(os_segment, self.tool_name)
 
         update_xml_url = posixpath.join(os_target_folder, "Updates.xml")
-        silent_attempt = self.tool_name == "tools_ifw"
-        update_xml_text = self._download_update_xml(update_xml_url, silent_attempt)
-        if not update_xml_text:
-            message = f"The package '{self.tool_name}' contains no downloadable archives for variant '{self.arch}'!"
-            raise NoPackageFound(message, suggested_action=self.help_msg())
+        try:
+            update_xml_text = self._download_update_xml(update_xml_url)
+        except ArchiveDownloadError as e:
+            if self.tool_name == "tools_ifw":
+                message = f"The package '{self.tool_name}' contains no downloadable archives for variant '{self.arch}'!"
+                raise NoPackageFound(message, suggested_action=self.help_msg()) from e
+            raise
 
         update_xmls = [UpdateXmls(os_target_folder, update_xml_text)]
         self._parse_update_xmls(update_xmls, None)

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -673,7 +673,7 @@ class ToolArchives(QtArchives):
     when installing mingw tool, argument would be
     ToolArchive(windows, desktop, mingw, 4.9.1-3)
     when installing ifw tool, argument would be
-    ToolArchive(linux, desktop, ifw, 3.1.1)
+    ToolArchive(linux, desktop, ifw, "qt.tools.ifw.48")
     """
 
     def __init__(

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -161,7 +161,6 @@ class InstallToolArgParser(CommonInstallArgParser):
     """Install-tool arguments and options"""
 
     tool_name: str
-    version: Optional[str]
     tool_variant: Optional[str]
 
 
@@ -618,9 +617,6 @@ class Cli:
         else:
             base_dir = output_dir
         sevenzip = self._set_sevenzip(args.external)
-        version = getattr(args, "version", None)
-        if version is not None:
-            Cli._validate_version_str(version, allow_minus=True)
         keep: bool = args.keep or Settings.always_keep_archives
         archive_dest: Optional[str] = args.archive_dest
         if args.base is not None:
@@ -650,7 +646,6 @@ class Cli:
                     tool_name=tool_name,
                     target=target,
                     base=base_url,
-                    version_str=version,
                     arch=arch,
                     timeout=timeout,
                 ),

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -319,6 +319,11 @@ class ArchiveId:
             osarch=self.to_os_arch(),
         )
 
+    def to_ifw_url(self) -> str:
+        return "online/qtsdkrepository/{osarch}/ifw/".format(
+            osarch=self.to_os_arch(),
+        )
+
     def to_url(self) -> str:
         return "online/qtsdkrepository/{osarch}/{target}/".format(
             osarch=self.to_os_arch(),
@@ -969,12 +974,26 @@ class MetadataFactory:
         return f"{version.major}{version.minor}{patch}"
 
     def _fetch_module_metadata(self, folder: str, predicate: Optional[Callable[[Element], bool]] = None):
-        rest_of_url = posixpath.join(self.archive_id.to_url(), folder, "Updates.xml")
-        xml = self.fetch_http(rest_of_url) if not Settings.ignore_hash else self.fetch_http(rest_of_url, False)
-        return xml_to_modules(
-            xml,
-            predicate=predicate if predicate else MetadataFactory._has_nonempty_downloads,
-        )
+        # For IFW, variants live under 'ifw/<variant>'.
+        if folder == "tools_ifw":
+            html_doc = self.fetch_http(self.archive_id.to_ifw_url(), False)
+            folders = list(self.iterate_folders(html_doc, self.base_url, filter_category="tools_ifw_"))
+            to_url = self.archive_id.to_ifw_url
+        else:
+            folders = [folder]
+            to_url = self.archive_id.to_url
+
+        result: Dict[str, Dict[str, str]] = {}
+        for folder in folders:
+            rest_of_url = posixpath.join(to_url(), folder, "Updates.xml")
+            xml = self.fetch_http(rest_of_url) if not Settings.ignore_hash else self.fetch_http(rest_of_url, False)
+            result.update(
+                xml_to_modules(
+                    xml,
+                    predicate=predicate if predicate else MetadataFactory._has_nonempty_downloads,
+                )
+            )
+        return result
 
     def _fetch_extension_metadata(self, url: str, predicate: Optional[Callable[[Element], bool]] = None):
         rest_of_url = posixpath.join(url, "Updates.xml")

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -818,8 +818,9 @@ Install tools like QtIFW, mingw, Cmake, Conan, and vcredist.
 
 .. option:: tool variant name
 
-    Optional field to specify tool variant. It may be required for vcredist and mingw installation.
-    tool variant names may be 'qt.tools.win64_mingw810', 'qt.tools.vcredist_msvc2013_x64'.
+    Optional field to specify tool variant. It may be required for vcredist, mingw, and QtIFW
+    installation. Tool variant names may be 'qt.tools.vcredist_msvc2013_x64', 'qt.tools.win64_mingw810',
+    and 'qt.tools.ifw.48'.
 
 You should use the :ref:`List-Tool command` to display what tools and tool variant names are available.
     
@@ -959,9 +960,9 @@ Example: List the variants of IFW available:
 
 .. code-block:: console
 
-    aqt list-tool linux desktop tools_ifw       # prints 'qt.tools.ifw.41'
+    aqt list-tool linux desktop tools_ifw    # prints 'qt.tools.ifw.47', 'qt.tools.ifw.48', etc
     # Alternate: `tools_` prefix is optional
-    aqt list-tool linux desktop ifw             # prints 'qt.tools.ifw.41'
+    aqt list-tool linux desktop ifw          # prints 'qt.tools.ifw.47', 'qt.tools.ifw.48', etc
 
 
 Example: List the variants of IFW, including version, release date, description, etc.:
@@ -975,7 +976,7 @@ Example: Install an Install FrameWork (IFW):
 
 .. code-block:: console
 
-    aqt install-tool linux desktop tools_ifw
+    aqt install-tool linux desktop tools_ifw qt.tools.ifw.48
 
 
 Example: Install vcredist on Windows:

--- a/tests/data/mac-desktop-tools_ifw-expect.json
+++ b/tests/data/mac-desktop-tools_ifw-expect.json
@@ -1,13 +1,21 @@
 {
   "modules": [
-    "qt.tools.ifw.41"
+    "qt.tools.ifw.48",
+    "qt.tools.ifw.47"
   ],
   "long_listing": [
     [
-      "qt.tools.ifw.41",
-      "4.1.1-202105261132",
-      "2021-05-26",
-      "Qt Installer Framework 4.1",
+      "qt.tools.ifw.47",
+      "4.7.0-0-202402231255",
+      "2024-02-23",
+      "Qt Installer Framework 4.7",
+      "The Qt Installer Framework provides a set of tools and utilities to create installers for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS."
+    ],
+    [
+      "qt.tools.ifw.48",
+      "4.8.1-0-202409251146",
+      "2024-09-25",
+      "Qt Installer Framework 4.8",
       "The Qt Installer Framework provides a set of tools and utilities to create installers for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS."
     ]
   ]

--- a/tests/data/mac-desktop-tools_ifw-tools_ifw_47-update.xml
+++ b/tests/data/mac-desktop-tools_ifw-tools_ifw_47-update.xml
@@ -3,17 +3,17 @@
  <ApplicationVersion>1.0.0</ApplicationVersion>
  <Checksum>true</Checksum>
  <PackageUpdate>
-  <Name>qt.tools.ifw.41</Name>
-  <DisplayName>Qt Installer Framework 4.1</DisplayName>
+  <Name>qt.tools.ifw.47</Name>
+  <DisplayName>Qt Installer Framework 4.7</DisplayName>
   <Description>The Qt Installer Framework provides a set of tools and utilities to create installers for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS.</Description>
-  <Version>4.1.1-202105261132</Version>
-  <ReleaseDate>2021-05-26</ReleaseDate>
+  <Version>4.7.0-0-202402231255</Version>
+  <ReleaseDate>2024-02-23</ReleaseDate>
   <Default>false</Default>
-  <SortingPriority>410</SortingPriority>
+  <SortingPriority>470</SortingPriority>
   <DownloadableArchives>ifw-mac-x64.7z</DownloadableArchives>
-  <UpdateFile UncompressedSize="129741860" CompressedSize="39605245" OS="Any"/>
-  <SHA1>ac812bbcade385c605bc1dc200be8a23ac839cbf</SHA1>
+  <UpdateFile CompressedSize="50110689" OS="Any" UncompressedSize="181714379"/>
+  <SHA1>70040c1892fb389bfbb8321ce65d9e3bd75ede87</SHA1>
  </PackageUpdate>
- <SHA1>ac812bbcade385c605bc1dc200be8a23ac839cbf</SHA1>
- <MetadataName>2021-05-26-1132_meta.7z</MetadataName>
+ <SHA1>70040c1892fb389bfbb8321ce65d9e3bd75ede87</SHA1>
+ <MetadataName>2024-02-23-1259_meta.7z</MetadataName>
 </Updates>

--- a/tests/data/mac-desktop-tools_ifw-tools_ifw_48-update.xml
+++ b/tests/data/mac-desktop-tools_ifw-tools_ifw_48-update.xml
@@ -1,0 +1,19 @@
+<Updates>
+ <ApplicationName>{AnyApplication}</ApplicationName>
+ <ApplicationVersion>1.0.0</ApplicationVersion>
+ <Checksum>true</Checksum>
+ <PackageUpdate>
+  <Name>qt.tools.ifw.48</Name>
+  <DisplayName>Qt Installer Framework 4.8</DisplayName>
+  <Description>The Qt Installer Framework provides a set of tools and utilities to create installers for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS.</Description>
+  <Version>4.8.1-0-202409251146</Version>
+  <ReleaseDate>2024-09-25</ReleaseDate>
+  <Default>false</Default>
+  <SortingPriority>481</SortingPriority>
+  <DownloadableArchives>ifw-mac-x64.7z</DownloadableArchives>
+  <UpdateFile CompressedSize="49899056" OS="Any" UncompressedSize="177656231"/>
+  <SHA1>a5b0c91e847645d9538b7a33b121e7932d278eb6</SHA1>
+ </PackageUpdate>
+ <SHA1>141b42fa308a9e97845e0f5abb9d6e40fe2d9edf</SHA1>
+ <MetadataName>2024-09-25-1153_meta.7z</MetadataName>
+</Updates>

--- a/tests/data/mac-desktop-tools_ifw.html
+++ b/tests/data/mac-desktop-tools_ifw.html
@@ -1,0 +1,20 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>Index of /online/qtsdkrepository/mac_x64/ifw</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" type="text/css" href="/static/normalize.css"><link rel="stylesheet" type="text/css" href="/static/style.css"><link rel="stylesheet" href="/static/bootstrap.css" type="text/css"><link rel="stylesheet" href="/static/bootstrap-download-index.css" type="text/css"><script type="text/javascript" src="/static/jquery.js"></script> <script type="text/javascript" src="/static/javascript-index.js"></script> <script type="text/javascript" src="/static/javascript-mirrorlist.js"></script> </head>
+ <body>
+<h1>Index of /online/qtsdkrepository/mac_x64/ifw</h1>
+<table><tr><th>&nbsp;</th><th><a href="?C=N;O=A">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th>Metadata</th></tr><tr><th colspan="5"><hr /></th></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="/online/qtsdkrepository/mac_x64/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<!-- <tr><td valign="top">&nbsp;</td><td><a href="tools_ifw_411/">tools_ifw_411/</a></td><td align="right">25-Mar-2026 07:51  </td><td align="right">  - </td><td>&nbsp;</td></tr> -->
+<!-- <tr><td valign="top">&nbsp;</td><td><a href="tools_ifw_410/">tools_ifw_410/</a></td><td align="right">09-Jun-2025 09:26  </td><td align="right">  - </td><td>&nbsp;</td></tr> -->
+<!-- <tr><td valign="top">&nbsp;</td><td><a href="tools_ifw_49/">tools_ifw_49/</a></td><td align="right">18-Mar-2025 11:05  </td><td align="right">  - </td><td>&nbsp;</td></tr> -->
+<tr><td valign="top">&nbsp;</td><td><a href="tools_ifw_48/">tools_ifw_48/</a></td><td align="right">25-Sep-2024 15:08  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="tools_ifw_47/">tools_ifw_47/</a></td><td align="right">06-May-2024 11:57  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><th colspan="5"><hr /></th></tr>
+</table>
+<br/><address><a href="http://mirrorbrain.org/">MirrorBrain</a> powered by <a href="http://httpd.apache.org/">Apache</a></address>
+</body></html>

--- a/tests/data/mac-desktop-tools_qtdesignstudio.html
+++ b/tests/data/mac-desktop-tools_qtdesignstudio.html
@@ -1,0 +1,18 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>Index of /online/qtsdkrepository/mac_x64/desktop/tools_qtdesignstudio</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" type="text/css" href="/static/normalize.css"><link rel="stylesheet" type="text/css" href="/static/style.css"><link rel="stylesheet" href="/static/bootstrap.css" type="text/css"><link rel="stylesheet" href="/static/bootstrap-download-index.css" type="text/css"><script type="text/javascript" src="/static/jquery.js"></script> <script type="text/javascript" src="/static/javascript-index.js"></script> <script type="text/javascript" src="/static/javascript-mirrorlist.js"></script> </head>
+ <body>
+<h1>Index of /online/qtsdkrepository/mac_x64/desktop/tools_qtdesignstudio</h1>
+<table><tr><th>&nbsp;</th><th><a href="?C=N;O=A">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th>Metadata</th></tr><tr><th colspan="5"><hr /></th></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="/online/qtsdkrepository/mac_x64/desktop/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="qt.tools.qtdesignstudio/">qt.tools.qtdesignstudio/</a></td><td align="right">17-Dec-2021 13:18  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="Updates.xml">Updates.xml</a></td><td align="right">26-Feb-2026 12:59  </td><td align="right">1.5K </td><td><a href="Updates.xml.mirrorlist">Details</a></td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="2021-12-17-0947_meta.7z">2021-12-17-0947_meta.7z</a></td><td align="right">17-Dec-2021 13:17  </td><td align="right">5.6K </td><td><a href="2021-12-17-0947_meta.7z.mirrorlist">Details</a></td></tr>
+<tr><th colspan="5"><hr /></th></tr>
+</table>
+<br/><address><a href="http://mirrorbrain.org/">MirrorBrain</a> powered by <a href="http://httpd.apache.org/">Apache</a></address>
+</body></html>

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -249,22 +249,6 @@ def to_xml(package_updates: Iterable[Dict]) -> str:
     )
 
 
-@pytest.mark.parametrize(
-    "tool_name, variant_name, version, actual_version",
-    (("tools_qtcreator", "qt.tools.qtcreator", "1.2.3", "3.2.1"),),
-)
-def test_tool_archive_wrong_version(monkeypatch, tool_name, variant_name, version, actual_version):
-    def _mock(self, *args):
-        return to_xml([dict(Name=variant_name, Version=actual_version)])
-
-    monkeypatch.setattr(QtArchives, "_download_update_xml", _mock)
-
-    host, target, base = "mac", "desktop", "https://example.com"
-    with pytest.raises(NoPackageFound) as e:
-        ToolArchives(host, target, tool_name, base, version_str=version, arch=variant_name)
-    assert e.type == NoPackageFound
-
-
 # Test the helper class
 def test_module_to_package():
     qt_base_names = ["qt.999.clang", "qt9.999.clang", "qt9.999.addon.clang"]

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -446,7 +446,8 @@ def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
     if tool_name != "tools_ifw":
         in_file = "{}-{}-{}-update.xml".format(host, target, tool_name)
         _xml = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
-        _mock_fetch_http = lambda self, _: _xml
+        def _mock_fetch_http(self, _, *args, **kwargs):
+            return _xml
     else:
 
         def _mock_fetch_http(self, rest_of_url, *args, **kwargs):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -460,6 +460,8 @@ def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
             _html = (Path(__file__).parent / "data" / "mac-desktop-tools_ifw.html").read_text("utf-8")
             if tail == "":
                 return _html
+            if not tail.endswith("/Updates.xml"):
+                assert False, f"Fetched an unexpected file at '{rest_of_url}'"
 
             variant = tail.removesuffix("/Updates.xml")
             in_file = "{}-{}-{}-{}-update.xml".format(host, target, tool_name, variant)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -999,9 +999,9 @@ def test_show_list_tools_long_qtdesignstudio(capsys, monkeypatch, columns, expec
     update_xml = (Path(__file__).parent / "data" / "mac-desktop-tools_qtdesignstudio-update.xml").read_text("utf-8")
 
     def _mock_fetch_http(self, rest_of_url, *args, **kwargs):
-        if rest_of_url.endswith("/"):
+        if rest_of_url.endswith("/tools_qtdesignstudio/"):
             return _html
-        if rest_of_url.endswith("/Updates.xml"):
+        if rest_of_url.endswith("/tools_qtdesignstudio/Updates.xml"):
             return update_xml
         else:
             assert False, f"Fetched an unexpected file at '{rest_of_url}'"

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -446,6 +446,7 @@ def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
     if tool_name != "tools_ifw":
         in_file = "{}-{}-{}-update.xml".format(host, target, tool_name)
         _xml = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
+
         def _mock_fetch_http(self, _, *args, **kwargs):
             return _xml
     else:

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -966,20 +966,20 @@ def test_list_fetch_tool_by_simple_spec(monkeypatch):
     (
         (
             120,
-            "   Tool Variant Name            Version          Release Date          Display Name                  Description        \n"
-            "========================================================================================================================\n"
-            "qt.tools.qtdesignstudio   2.3.1-0-202112170945   2021-12-17     Qt Design Studio              Qt Design Studio is a UI  \n"
-            "                                                                2.3.1-community               design and development    \n"
-            "                                                                                              environment for creating  \n"
-            "                                                                                              animated UIs and          \n"
-            "                                                                                              previewing them on the    \n"
-            "                                                                                              desktop or on Android and \n"
-            "                                                                                              embedded Linux devices. It\n"
-            "                                                                                              provides you with tools   \n"
-            "                                                                                              for accomplishing your    \n"
-            "                                                                                              tasks throughout the whole\n"
-            "                                                                                              process, from design to   \n"
-            "                                                                                              production.               \n",
+            "   Tool Variant Name            Version          Release Date          Display Name                  Description        \n"  # noqa: E501
+            "========================================================================================================================\n"  # noqa: E501
+            "qt.tools.qtdesignstudio   2.3.1-0-202112170945   2021-12-17     Qt Design Studio              Qt Design Studio is a UI  \n"  # noqa: E501
+            "                                                                2.3.1-community               design and development    \n"  # noqa: E501
+            "                                                                                              environment for creating  \n"  # noqa: E501
+            "                                                                                              animated UIs and          \n"  # noqa: E501
+            "                                                                                              previewing them on the    \n"  # noqa: E501
+            "                                                                                              desktop or on Android and \n"  # noqa: E501
+            "                                                                                              embedded Linux devices. It\n"  # noqa: E501
+            "                                                                                              provides you with tools   \n"  # noqa: E501
+            "                                                                                              for accomplishing your    \n"  # noqa: E501
+            "                                                                                              tasks throughout the whole\n"  # noqa: E501
+            "                                                                                              process, from design to   \n"  # noqa: E501
+            "                                                                                              production.               \n",  # noqa: E501
         ),
         (
             80,
@@ -989,9 +989,9 @@ def test_list_fetch_tool_by_simple_spec(monkeypatch):
         ),
         (
             0,
-            "   Tool Variant Name            Version          Release Date             Display Name                                                                                                                                                 Description                                                                                                                                    \n"
-            "======================================================================================================================================================================================================================================================================================================================================================================================\n"
-            "qt.tools.qtdesignstudio   2.3.1-0-202112170945   2021-12-17     Qt Design Studio 2.3.1-community   Qt Design Studio is a UI design and development environment for creating animated UIs and previewing them on the desktop or on Android and embedded Linux devices. It provides you with tools for accomplishing your tasks throughout the whole process, from design to production.\n",
+            "   Tool Variant Name            Version          Release Date             Display Name                                                                                                                                                 Description                                                                                                                                    \n"  # noqa: E501
+            "======================================================================================================================================================================================================================================================================================================================================================================================\n"  # noqa: E501
+            "qt.tools.qtdesignstudio   2.3.1-0-202112170945   2021-12-17     Qt Design Studio 2.3.1-community   Qt Design Studio is a UI design and development environment for creating animated UIs and previewing them on the desktop or on Android and embedded Linux devices. It provides you with tools for accomplishing your tasks throughout the whole process, from design to production.\n",  # noqa: E501
         ),
     ),
 )

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -440,12 +440,30 @@ def test_list_archives_bad_xml(monkeypatch, xml_content: str):
 )
 def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
     archive_id = ArchiveId("tools", host, target)
-    in_file = "{}-{}-{}-update.xml".format(host, target, tool_name)
     expect_out_file = "{}-{}-{}-expect.json".format(host, target, tool_name)
-    _xml = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
     expect = json.loads((Path(__file__).parent / "data" / expect_out_file).read_text("utf-8"))
 
-    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: _xml)
+    if tool_name != "tools_ifw":
+        in_file = "{}-{}-{}-update.xml".format(host, target, tool_name)
+        _xml = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
+        _mock_fetch_http = lambda self, _: _xml
+    else:
+
+        def _mock_fetch_http(self, rest_of_url, *args, **kwargs):
+            if not rest_of_url.startswith("online/qtsdkrepository/mac_x64/ifw/"):
+                raise ArchiveDownloadError(f"No such file at {rest_of_url}")
+
+            tail = rest_of_url.removeprefix("online/qtsdkrepository/mac_x64/ifw/")
+            _html = (Path(__file__).parent / "data" / "mac-desktop-tools_ifw.html").read_text("utf-8")
+            if tail == "":
+                return _html
+
+            variant = tail.removesuffix("/Updates.xml")
+            in_file = "{}-{}-{}-{}-update.xml".format(host, target, tool_name, variant)
+            _xml = (Path(__file__).parent / "data" / in_file).read_text("utf-8")
+            return _xml
+
+    monkeypatch.setattr(MetadataFactory, "fetch_http", _mock_fetch_http)
 
     modules = MetadataFactory(archive_id, tool_name=tool_name).getList()
     assert modules == expect["modules"]
@@ -820,18 +838,6 @@ wrong_arch_msg = "Please use 'aqt list-qt mac desktop --arch <QT_VERSION>' to li
             MetadataFactory(mac_qt, spec=SimpleSpec("<5.9")),
             ["Please use 'aqt list-qt mac desktop' to check that versions of qt exist within the spec '<5.9'."],
         ),
-        (
-            MetadataFactory(ArchiveId("tools", "mac", "desktop"), tool_name="ifw"),
-            [wrong_tool_name_msg],
-        ),
-        (
-            MetadataFactory(mac_qt, architectures_ver="1.2.3"),
-            [wrong_qt_version_msg],
-        ),
-        (
-            MetadataFactory(mac_qt, modules_query=ModulesQuery("1.2.3", "clang_64")),
-            [wrong_qt_version_msg, wrong_arch_msg],
-        ),
     ),
 )
 def test_suggested_follow_up(meta: MetadataFactory, expected_message: str):
@@ -958,52 +964,54 @@ def test_list_fetch_tool_by_simple_spec(monkeypatch):
     (
         (
             120,
-            (
-                "Tool Variant Name        Version         Release Date          Display Name          "
-                "            Description            \n"
-                "====================================================================================="
-                "===================================\n"
-                "qt.tools.ifw.41     4.1.1-202105261132   2021-05-26     Qt Installer Framework 4.1   "
-                "The Qt Installer Framework provides\n"
-                "                                                                                     "
-                "a set of tools and utilities to    \n"
-                "                                                                                     "
-                "create installers for the supported\n"
-                "                                                                                     "
-                "desktop Qt platforms: Linux,       \n"
-                "                                                                                     "
-                "Microsoft Windows, and macOS.      \n"
-            ),
+            "   Tool Variant Name            Version          Release Date          Display Name                  Description        \n"
+            "========================================================================================================================\n"
+            "qt.tools.qtdesignstudio   2.3.1-0-202112170945   2021-12-17     Qt Design Studio              Qt Design Studio is a UI  \n"
+            "                                                                2.3.1-community               design and development    \n"
+            "                                                                                              environment for creating  \n"
+            "                                                                                              animated UIs and          \n"
+            "                                                                                              previewing them on the    \n"
+            "                                                                                              desktop or on Android and \n"
+            "                                                                                              embedded Linux devices. It\n"
+            "                                                                                              provides you with tools   \n"
+            "                                                                                              for accomplishing your    \n"
+            "                                                                                              tasks throughout the whole\n"
+            "                                                                                              process, from design to   \n"
+            "                                                                                              production.               \n",
         ),
         (
             80,
-            "Tool Variant Name        Version         Release Date\n"
-            "=====================================================\n"
-            "qt.tools.ifw.41     4.1.1-202105261132   2021-05-26  \n",
+            "   Tool Variant Name            Version          Release Date\n"
+            "=============================================================\n"
+            "qt.tools.qtdesignstudio   2.3.1-0-202112170945   2021-12-17  \n",
         ),
         (
             0,
-            "Tool Variant Name        Version         Release Date          Display Name          "
-            "                                                                           Descriptio"
-            "n                                                                            \n"
-            "====================================================================================="
-            "====================================================================================="
-            "=============================================================================\n"
-            "qt.tools.ifw.41     4.1.1-202105261132   2021-05-26     Qt Installer Framework 4.1   "
-            "The Qt Installer Framework provides a set of tools and utilities to create installers"
-            " for the supported desktop Qt platforms: Linux, Microsoft Windows, and macOS.\n",
+            "   Tool Variant Name            Version          Release Date             Display Name                                                                                                                                                 Description                                                                                                                                    \n"
+            "======================================================================================================================================================================================================================================================================================================================================================================================\n"
+            "qt.tools.qtdesignstudio   2.3.1-0-202112170945   2021-12-17     Qt Design Studio 2.3.1-community   Qt Design Studio is a UI design and development environment for creating animated UIs and previewing them on the desktop or on Android and embedded Linux devices. It provides you with tools for accomplishing your tasks throughout the whole process, from design to production.\n",
         ),
     ),
 )
-def test_show_list_tools_long_ifw(capsys, monkeypatch, columns, expect):
-    update_xml = (Path(__file__).parent / "data" / "mac-desktop-tools_ifw-update.xml").read_text("utf-8")
-    monkeypatch.setattr(MetadataFactory, "fetch_http", lambda self, _: update_xml)
+def test_show_list_tools_long_qtdesignstudio(capsys, monkeypatch, columns, expect):
+    _html = (Path(__file__).parent / "data" / "mac-desktop-tools_qtdesignstudio.html").read_text("utf-8")
+    update_xml = (Path(__file__).parent / "data" / "mac-desktop-tools_qtdesignstudio-update.xml").read_text("utf-8")
+
+    def _mock_fetch_http(self, rest_of_url, *args, **kwargs):
+        if rest_of_url.endswith("/"):
+            return _html
+        if rest_of_url.endswith("/Updates.xml"):
+            return update_xml
+        else:
+            assert False, f"Fetched an unexpected file at '{rest_of_url}'"
+
+    monkeypatch.setattr(MetadataFactory, "fetch_http", _mock_fetch_http)
 
     monkeypatch.setattr(shutil, "get_terminal_size", lambda fallback: os.terminal_size((columns, 24)))
 
     meta = MetadataFactory(
         ArchiveId("tools", "mac", "desktop"),
-        tool_name="tools_ifw",
+        tool_name="tools_qtdesignstudio",
         is_long_listing=True,
     )
     show_list(meta)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -449,6 +449,7 @@ def test_tool_modules(monkeypatch, host: str, target: str, tool_name: str):
 
         def _mock_fetch_http(self, _, *args, **kwargs):
             return _xml
+
     else:
 
         def _mock_fetch_http(self, rest_of_url, *args, **kwargs):

--- a/tests/test_tools_archives.py
+++ b/tests/test_tools_archives.py
@@ -18,7 +18,7 @@ def _stub_download_xml(self, *args, **kwargs):
 
 
 @pytest.mark.parametrize(
-    "os_name,target,tool_name,tool_version,expected_path",
+    "os_name,target,tool_name,arch,expected_path",
     [
         (
             "linux",
@@ -27,33 +27,23 @@ def _stub_download_xml(self, *args, **kwargs):
             None,
             "online/qtsdkrepository/linux_x64/desktop/tools_ninja",
         ),
-        # tools_ifw without specifying a variant should use the legacy path
-        (
-            "mac",
-            "desktop",
-            "tools_ifw",
-            None,
-            "online/qtsdkrepository/mac_x64/desktop/tools_ifw",
-        ),
-        # new locations: tools_ifw48 tools_ifw49 tools_ifw410
         (
             "linux",
             "desktop",
             "tools_ifw",
-            "tools_ifw410",
-            "online/qtsdkrepository/linux_x64/ifw/tools_ifw410",
+            "qt.tools.ifw.48",
+            "online/qtsdkrepository/linux_x64/ifw/tools_ifw_48",
         ),
-        # legacy locations: tools_ifw47
         (
             "linux",
             "desktop",
             "tools_ifw",
-            "tools_ifw47",
-            "online/qtsdkrepository/linux_x64/desktop/tools_ifw",
+            "qt.tools.ifw.47",
+            "online/qtsdkrepository/linux_x64/ifw/tools_ifw_47",
         ),
     ],
 )
-def test_tool_archives_repo_folder(monkeypatch, os_name, target, tool_name, tool_version, expected_path):
+def test_tool_archives_repo_folder(monkeypatch, os_name, target, tool_name, arch, expected_path):
     # Capture the target folder passed to _parse_update_xml
     captured = {}
 
@@ -66,7 +56,7 @@ def test_tool_archives_repo_folder(monkeypatch, os_name, target, tool_name, tool
     monkeypatch.setattr(ToolArchives, "_parse_update_xml", _capture_parse)
 
     # Create the ToolArchives instance; __init__ triggers _get_archives()
-    ToolArchives(os_name=os_name, target=target, tool_name=tool_name, base=Settings.baseurl, version_str=tool_version)
+    ToolArchives(os_name=os_name, target=target, tool_name=tool_name, base=Settings.baseurl, arch=arch)
 
     assert captured["folder"] == expected_path
 


### PR DESCRIPTION
Based on #963, let's continue fixing #792 by dropping old stuff. Please read the commit message for details.

Test:

```console
# aqt list-tool linux desktop tools_ifw
qt.tools.ifw.411
qt.tools.ifw.410
qt.tools.ifw.49
qt.tools.ifw.48
qt.tools.ifw.47

```

```console
# aqt install-tool linux desktop tools_ifw 'qt.tools.ifw.411'
INFO    : aqtinstall(aqt) v0.1.dev2 on Python 3.12.12 [CPython GCC 14.2.0]
INFO    : Downloading qt.tools.ifw.411...
INFO    : Finished installation of ifw-linux-x64.7z in 10.17739469
INFO    : Finished installation
INFO    : Time elapsed: 13.03673958 second

# find ./ | head -n 10
./
./Tools
./Tools/QtInstallerFramework
./Tools/QtInstallerFramework/4.11
./Tools/QtInstallerFramework/4.11/examples
./Tools/QtInstallerFramework/4.11/examples/productimage
./Tools/QtInstallerFramework/4.11/examples/productimage/config
./Tools/QtInstallerFramework/4.11/examples/productimage/config/Built_with_Qt.png
./Tools/QtInstallerFramework/4.11/examples/productimage/config/Built_with_Qt_logo.png
./Tools/QtInstallerFramework/4.11/examples/productimage/config/config.xml

```

```console
# aqt install-tool linux desktop tools_ifw
INFO    : aqtinstall(aqt) v0.1.dev2 on Python 3.12.12 [CPython GCC 14.2.0]
INFO    : Downloading qt.tools.ifw.411...
INFO    : Finished installation of ifw-linux-x64.7z in 9.98366568
INFO    : Downloading qt.tools.ifw.410...
INFO    : Finished installation of ifw-linux-x64.7z in 9.52332566
INFO    : Downloading qt.tools.ifw.49...
INFO    : Finished installation of ifw-linux-x64.7z in 9.66283446
INFO    : Downloading qt.tools.ifw.48...
INFO    : Finished installation of ifw-linux-x64.7z in 9.25116976
INFO    : Downloading qt.tools.ifw.47...
INFO    : Finished installation of ifw-linux-x64.7z in 11.31012378
INFO    : Finished installation
INFO    : Time elapsed: 75.03670587 second

# find ./ -maxdepth 3
./
./Tools
./Tools/QtInstallerFramework
./Tools/QtInstallerFramework/4.9
./Tools/QtInstallerFramework/4.10
./Tools/QtInstallerFramework/4.7
./Tools/QtInstallerFramework/4.11
./Tools/QtInstallerFramework/4.8
./aqtinstall.log

```

To me, aqt is now full of if-else blocks and workarounds. We really need a new design.