### PR TITLE
chore: Bump numerous `action` revisions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -47,7 +47,7 @@ jobs:
       - name: twine check
         run: python -m twine check dist/*
       - name: upload dist artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dists
           path: dist/
@@ -61,15 +61,15 @@ jobs:
       id-token: write
     steps:
       - name: download dist artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dists
           path: dist/
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ startsWith(github.event.ref, 'refs/heads/releases') }}
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1.14.0

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -206,7 +206,7 @@ jobs:
             print('QT_INATALL_PREFIX {}\nExpected path {}'.format(result, expected_path))
         shell: python
         working-directory: ${{ github.workspace }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: matrix.artifact == 'binary'
         with:
           name: aqt-${{ matrix.os }}-standalone

--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -66,7 +66,7 @@ jobs:
           ${{ startsWith(matrix.system.os, 'windows-') && 'Remove-Item venv -Recurse -Force' || 'rm -rf venv' }}
 
       - name: Upload to Release
-        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de #v2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/${{ matrix.system.output_file }}
@@ -75,7 +75,7 @@ jobs:
           overwrite: true
         if: matrix.system.primary_artifact!='' && startsWith(github.ref, 'refs/tags/v')
       - name: Upload to Release for all architectures
-        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de #v2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/${{ matrix.system.output_file }}
@@ -84,7 +84,7 @@ jobs:
           overwrite: true
         if: matrix.system.secondary_artifact!='' && startsWith(github.ref, 'refs/tags/v')
       - name: Update continuous build
-        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de #v2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           overwrite: true
@@ -94,7 +94,7 @@ jobs:
           asset_name: ${{ matrix.system.primary_artifact }}
         if: matrix.system.primary_artifact!='' && startsWith(github.ref, 'refs/tags/v')
       - name: Update continuous build for all architectures
-        uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 #v2.11.3
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de #v2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           overwrite: true


### PR DESCRIPTION
* Bump `actions/upload-artifact` to `v7`.
* Bump `actions/download-artifact` to `v8`.
* Bump `pypa/gh-action-pypi-publish` to `v1.14.0`.
* Bump `svenstaro/upload-release-action` to `v2.11.5`.