### PR TITLE
fix: remove last remnant of `codacy` reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,6 @@ Another Qt installer(aqt)
 - Release: |pypi|
 - Documentation: |docs|
 - Test status: |gha| and Coverage: |coveralls|
-- Code Quality: |codacy|
 - Project maturity |Package health|
 
 .. |pypi| image:: https://badge.fury.io/py/aqtinstall.svg


### PR DESCRIPTION
PR https://github.com/miurahr/aqtinstall/pull/994 removed `codacy` badge but left the reference, this fixes: `line 7: Error: Undefined substitution referenced: "codacy"`