### PR TITLE
chore (ci): Add appropriate naming to `publish-to-pypi` workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,3 +1,4 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   push:


### PR DESCRIPTION
### How it was displayed:

![Screenshot 2026-04-11 164952](https://github.com/user-attachments/assets/cc46ea8a-2d56-413b-870c-e4941c82d244)
____

### How it is displayed now:
_To be added, when workflow is run/approved._

(Will be similar to https://github.com/miurahr/py7zr/actions)
![Screenshot 2026-04-12 155145](https://github.com/user-attachments/assets/c490475a-fb4c-4410-ba12-d7bfac1e185b)
