### PR TITLE
chore(ci): Use `latest` vmImages in `azure-pipelines` workflow

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
 - job: MatricesGenerator
   displayName: Matrices Generator
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-latest'
   steps:
     - task: UsePythonVersion@0
       inputs:
@@ -18,7 +18,7 @@ jobs:
 - job: Mac
   dependsOn: MatricesGenerator
   pool:
-    vmImage: 'macOS-14'
+    vmImage: 'macOS-latest'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.mac'] ]
   steps:
@@ -29,7 +29,7 @@ jobs:
 - job: Windows
   dependsOn: MatricesGenerator
   pool:
-    vmImage: 'windows-2022'
+    vmImage: 'windows-latest'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.windows'] ]
   variables:
@@ -42,7 +42,7 @@ jobs:
 - job: Linux
   dependsOn: MatricesGenerator
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-latest'
   strategy:
     matrix: $[ dependencies.MatricesGenerator.outputs['mtrx.linux'] ]
   steps:


### PR DESCRIPTION
* `windows-latest`

https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=windows-images%2Cyaml#software

* `ubuntu-latest`

https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=linux-images%2Cyaml#software

* `macOS-latest`

https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=macos-images%2Cyaml#software
____

This should reduce maintenance burden with regards to **Image Deprecations** for example - upcoming! `macOS-14`

https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted-deprecation-schedule?view=azure-devops&tabs=macos-images#macos-14-sonoma-hosted-image-deprecation-schedule