### PR TITLE
Fix list-qt-official, install-qt-official and test_commercial on macOS

### DIFF
--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -127,18 +127,10 @@ def get_qt_installers() -> dict[str, str]:
                         installers[f"{os_type}-arm64"] = filename
                     elif "x64" in filename.lower():
                         installers[f"{os_type}-x64"] = filename
-                        # Also add generic OS entry for x64 variants of Windows and Linux
-                        if os_type in ["windows", "linux"]:
-                            installers[os_type] = filename
-                    else:
-                        # Handle case with no explicit architecture
-                        # Most likely for macOS which might just say "mac" without arch
-                        installers[os_type] = filename
-
-            # macOS arm64 special case, as no official arm64 installer exists
-            # it should not override the arm64 installer if it appears later
-            if installers.get("mac-x64") and not installers.get("mac-arm64"):
-                installers["mac-arm64"] = installers["mac-x64"]
+                    elif "universal" in filename.lower():
+                        # Most likely for macOS which was using qt-online-installer-macOS-universal.dmg 25-Mar-2026.
+                        installers[f"{os_type}-arm64"] = filename
+                        installers[f"{os_type}-x64"] = filename
 
         return installers
 

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -182,13 +182,12 @@ def test_build_command(
 @pytest.mark.parametrize(
     "os, osarch, expected_suffix",
     [
-        pytest.param("windows", "windows", ".exe"),
         pytest.param("windows", "windows-x64", ".exe"),
         pytest.param("windows", "windows-arm64", ".exe"),
-        pytest.param("linux", "linux", ".run"),
         pytest.param("linux", "linux-x64", ".run"),
         pytest.param("linux", "linux-arm64", ".run"),
         pytest.param("mac", "mac-x64", ".dmg"),
+        pytest.param("mac", "mac-arm64", ".dmg"),
     ],
 )
 def test_commercial_installer_names(monkeypatch, os, osarch, expected_suffix):
@@ -200,7 +199,7 @@ def test_commercial_installer_names(monkeypatch, os, osarch, expected_suffix):
 
     assert installer_name.endswith(expected_suffix)
 
-    if os == get_os_name() and osarch in ["windows", "linux", "mac-x64"]:
+    if os == get_os_name() and osarch in ["windows-x64", "linux-x64", "mac-arm64"]:
         target_path = Settings.qt_installer_temp_path / Path(installer_name)
         base_url = Settings.baseurl
         timeout = (Settings.connection_timeout, Settings.response_timeout)

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -199,12 +199,12 @@ def test_commercial_installer_names(monkeypatch, os, osarch, expected_suffix):
 
     assert installer_name.endswith(expected_suffix)
 
-    if os == get_os_name() and osarch in ["windows-x64", "linux-x64", "mac-arm64"]:
-        target_path = Settings.qt_installer_temp_path / Path(installer_name)
-        base_url = Settings.baseurl
-        timeout = (Settings.connection_timeout, Settings.response_timeout)
-        download_installer(base_url, installer_name, target_path, timeout)
-        assert True
+    # make sure the installer can be downloaded for all os's and arch's.
+    target_path = Settings.qt_installer_temp_path / Path(installer_name)
+    base_url = Settings.baseurl
+    timeout = (Settings.connection_timeout, Settings.response_timeout)
+    download_installer(base_url, installer_name, target_path, timeout)
+    assert True
 
 
 @pytest.mark.parametrize(
@@ -347,7 +347,7 @@ def test_install_qt_commercial(
 
             modified.append(line)
 
-        return "\n".join(modified)
+        return "\n".join(modified) + "\n"
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     config_path = os.path.join(script_dir, "../aqt/settings.ini")

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -177,9 +177,18 @@ def test_build_command(
     )
     assert cmd == expected_cmd
 
+
 @pytest.fixture(scope="module")
-def get_qt_installers_once() -> dict[str, str]:
-    return get_qt_installers()
+def get_qt_installers_once():
+    cache = {}
+
+    def _get():
+        if "data" not in cache:
+            cache["data"] = get_qt_installers()
+        return cache["data"]
+
+    return _get
+
 
 @pytest.mark.enable_socket
 @pytest.mark.parametrize(
@@ -197,11 +206,12 @@ def test_commercial_installer_names(monkeypatch, get_qt_installers_once, osarch,
     """Test installer names finder"""
 
     monkeypatch.setattr("aqt.helper.get_os_arch", lambda: osarch)
-    monkeypatch.setattr("aqt.helper.get_qt_installers", lambda: get_qt_installers_once)
+    monkeypatch.setattr("aqt.helper.get_qt_installers", lambda: get_qt_installers_once())
 
     installer_name = get_qt_installer_name()
 
     assert installer_name.endswith(expected_suffix)
+
 
 @pytest.mark.parametrize(
     "modules, expected_command",

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -8,7 +8,7 @@ import pytest
 
 from aqt.commercial import CommercialInstaller, QtPackageInfo, QtPackageManager
 from aqt.exceptions import DiskAccessNotPermitted
-from aqt.helper import Settings, download_installer, get_qt_account_path, get_qt_installer_name
+from aqt.helper import Settings, get_qt_account_path, get_qt_installer_name, get_qt_installers
 from aqt.installer import Cli
 from aqt.metadata import Version
 
@@ -177,35 +177,31 @@ def test_build_command(
     )
     assert cmd == expected_cmd
 
+@pytest.fixture(scope="module")
+def get_qt_installers_once() -> dict[str, str]:
+    return get_qt_installers()
 
 @pytest.mark.enable_socket
 @pytest.mark.parametrize(
-    "os, osarch, expected_suffix",
+    "osarch, expected_suffix",
     [
-        pytest.param("windows", "windows-x64", ".exe"),
-        pytest.param("windows", "windows-arm64", ".exe"),
-        pytest.param("linux", "linux-x64", ".run"),
-        pytest.param("linux", "linux-arm64", ".run"),
-        pytest.param("mac", "mac-x64", ".dmg"),
-        pytest.param("mac", "mac-arm64", ".dmg"),
+        pytest.param("windows-x64", ".exe"),
+        pytest.param("windows-arm64", ".exe"),
+        pytest.param("linux-x64", ".run"),
+        pytest.param("linux-arm64", ".run"),
+        pytest.param("mac-x64", ".dmg"),
+        pytest.param("mac-arm64", ".dmg"),
     ],
 )
-def test_commercial_installer_names(monkeypatch, os, osarch, expected_suffix):
+def test_commercial_installer_names(monkeypatch, get_qt_installers_once, osarch, expected_suffix):
     """Test installer names finder"""
 
     monkeypatch.setattr("aqt.helper.get_os_arch", lambda: osarch)
+    monkeypatch.setattr("aqt.helper.get_qt_installers", lambda: get_qt_installers_once)
 
     installer_name = get_qt_installer_name()
 
     assert installer_name.endswith(expected_suffix)
-
-    # make sure the installer can be downloaded for all os's and arch's.
-    target_path = Settings.qt_installer_temp_path / Path(installer_name)
-    base_url = Settings.baseurl
-    timeout = (Settings.connection_timeout, Settings.response_timeout)
-    download_installer(base_url, installer_name, target_path, timeout)
-    assert True
-
 
 @pytest.mark.parametrize(
     "modules, expected_command",

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -8,7 +8,7 @@ import pytest
 
 from aqt.commercial import CommercialInstaller, QtPackageInfo, QtPackageManager
 from aqt.exceptions import DiskAccessNotPermitted
-from aqt.helper import Settings, download_installer, get_os_name, get_qt_account_path, get_qt_installer_name
+from aqt.helper import Settings, download_installer, get_qt_account_path, get_qt_installer_name
 from aqt.installer import Cli
 from aqt.metadata import Version
 


### PR DESCRIPTION
list-qt-official, install-qt-official and pytest test_commercial.py all have been failing.  This resolves those issues.  
The dictionary of installers is keyed by os and arch (helper.py, get_os_arch(), no change).  However Qt now provides one install for macOS qt-online-installer-macOS-universal.dmg.  It is a universal binary which works on amd64 and arm64.  This PR registers that universal installer for both mac-amd64 and mac-arm64 keys.  generic os entries, fallback entries that used rosetta, and our guess that they would name the universal installer online-installer-macOS.dmg are all removed.   These entries were not used by aqt but some of them were used by test.

This also modifies the test to download the installer for all 6 keys, proving we can find the installer for all combinations of OS and architecture.

This also adds a newline on to the end of settings.ini when test_commercial modifies it.  Previously running test_commercial would leave settings.ini modified as it deleted the traililng newline.

Note open PR #913 tried to fix a related issue about 1 year ago.  In the mean time Qt has changed the installer names again.  If this PR is accepted I would recommend PR #913 be closed without merging.