### PR TITLE
avoid py7zr.SevenZipFile.writestr()

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,7 +11,7 @@ import textwrap
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import py7zr
@@ -1512,7 +1512,7 @@ def test_install(
         ("6.10.1", "6101", "wasm_singlethread", True),
     ],
 )
-def test_install_qt6_wasm_autodesktop(monkeypatch, capsys, version, str_version, wasm_arch, extract_target):
+def test_install_qt6_wasm_autodesktop(monkeypatch, capsys, tmp_path, version, str_version, wasm_arch, extract_target):
     """Test installing Qt 6.8 WASM with autodesktop, which requires special handling for addons"""
 
     if sys.platform.startswith("linux"):
@@ -1596,14 +1596,9 @@ def test_install_qt6_wasm_autodesktop(monkeypatch, capsys, version, str_version,
                     )
 
                 for filepath, content in basic_files.items():
-                    # use delete_on_close=False instead of delete=False, and context manager when python >= 3.12.
-                    mockfile = NamedTemporaryFile(delete=False)
-                    try:
-                        mockfile.write(content.encode("utf-8"))
-                        mockfile.close()
-                        archive.write(mockfile.name, filepath)
-                    finally:
-                        os.unlink(mockfile.name)
+                    mockfile = tmp_path / Path(filepath).name
+                    mockfile.write_text(content, encoding="utf-8")
+                    archive.write(mockfile, filepath)
 
     # Setup mocks
     monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,7 +11,7 @@ import textwrap
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from tempfile import TemporaryDirectory, NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import py7zr
@@ -1596,10 +1596,14 @@ def test_install_qt6_wasm_autodesktop(monkeypatch, capsys, version, str_version,
                     )
 
                 for filepath, content in basic_files.items():
-                    with NamedTemporaryFile(delete_on_close=False) as mockfile:
+                    # use delete_on_close=False instead of delete=False, and context manager when python >= 3.12.
+                    mockfile = NamedTemporaryFile(delete=False)
+                    try:
                         mockfile.write(content.encode("utf-8"))
                         mockfile.close()
                         archive.write(mockfile.name, filepath)
+                    finally:
+                        os.unlink(mockfile.name)
 
     # Setup mocks
     monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,7 +11,7 @@ import textwrap
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import py7zr
@@ -1582,10 +1582,10 @@ def test_install_qt6_wasm_autodesktop(monkeypatch, capsys, version, str_version,
                     basic_files.update(
                         {
                             f"{prefix}bin/target_qt.conf": "Prefix=...\n",  # Basic config
-                            f"{prefix}bin/qmake{extension}": "echo Mock qmake{extension}\n",
-                            f"{prefix}bin/qmake6{extension}": "echo Mock qmake6{extension}\n",
-                            f"{prefix}bin/qtpaths{extension}": "echo Mock qtpaths{extension}\n",
-                            f"{prefix}bin/qtpaths6{extension}": "echo Mock qtpaths6{extension}\n",
+                            f"{prefix}bin/qmake{extension}": f"echo Mock qmake{extension}\n",
+                            f"{prefix}bin/qmake6{extension}": f"echo Mock qmake6{extension}\n",
+                            f"{prefix}bin/qtpaths{extension}": f"echo Mock qtpaths{extension}\n",
+                            f"{prefix}bin/qtpaths6{extension}": f"echo Mock qtpaths6{extension}\n",
                         }
                     )
                 else:
@@ -1596,7 +1596,10 @@ def test_install_qt6_wasm_autodesktop(monkeypatch, capsys, version, str_version,
                     )
 
                 for filepath, content in basic_files.items():
-                    archive.writestr(content.encode("utf-8"), filepath)
+                    with NamedTemporaryFile(delete_on_close=False) as mockfile:
+                        mockfile.write(content.encode("utf-8"))
+                        mockfile.close()
+                        archive.write(mockfile.name, filepath)
 
     # Setup mocks
     monkeypatch.setattr("aqt.archives.getUrl", mock_get_url)


### PR DESCRIPTION
we have had a history of permission problems with writestr().  This avoids them by using the presumably better tested write() function.

This resolves #1016.

We worked fine with py7zr 0.22.0, but not 1.1.0.  The exact py7zr commit that broke us is listed in #1016.