### PR TITLE
feat: log commands of each "safely_run" and "safely_run_save_output"

### DIFF
--- a/aqt/commercial.py
+++ b/aqt/commercial.py
@@ -36,19 +36,11 @@ from aqt.helper import (
     get_qt_account_path,
     get_qt_installer_name,
     prepare_installer,
+    redact_credentials,
     safely_run,
     safely_run_save_output,
 )
 from aqt.metadata import Version
-
-
-def _redact_credentials(cmd: List[str]) -> List[str]:
-    """Return a copy of cmd with values following --email/--pw replaced by '***'."""
-    redacted = cmd.copy()
-    for i in range(len(redacted) - 1):
-        if redacted[i] in ("--email", "--pw"):
-            redacted[i + 1] = "***"
-    return redacted
 
 
 @dataclass
@@ -151,7 +143,7 @@ class QtPackageManager:
         cmd.append(base_package)
 
         try:
-            self.logger.info(f"Running: {_redact_credentials(cmd)}")
+            self.logger.info(f"Running: {redact_credentials(cmd)}")
             output = safely_run_save_output(cmd, Settings.qt_installer_timeout)
 
             # Handle both string and CompletedProcess outputs
@@ -383,10 +375,10 @@ class CommercialInstaller:
                 cmd = [*base_cmd, *install_cmd]
 
             if not self.dry_run:
-                self.logger.info(f"Running: {_redact_credentials(cmd)}")
+                self.logger.info(f"Running: {redact_credentials(cmd)}")
                 safely_run(cmd, Settings.qt_installer_timeout)
             else:
-                self.logger.info(f"Would run: {_redact_credentials(cmd)}")
+                self.logger.info(f"Would run: {redact_credentials(cmd)}")
 
         except Exception as e:
             self.logger.error(f"Installation failed: {str(e)}")

--- a/aqt/helper.py
+++ b/aqt/helper.py
@@ -804,3 +804,12 @@ def prepare_installer(installer_path: Path, os_name: str) -> Path:
         return dst_app_path / "Contents" / "MacOS" / Path(src_app_name).stem
     else:
         return installer_path
+
+
+def redact_credentials(cmd: List[str]) -> List[str]:
+    """Return a copy of cmd with values following --email/--pw replaced by '***'."""
+    redacted = cmd.copy()
+    for i in range(len(redacted) - 1):
+        if redacted[i] in ("--email", "--pw"):
+            redacted[i + 1] = "***"
+    return redacted

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -66,6 +66,7 @@ from aqt.helper import (
     get_os_name,
     get_qt_installer_name,
     prepare_installer,
+    redact_credentials,
     retry_on_bad_connection,
     retry_on_errors,
     safely_run_save_output,
@@ -1053,7 +1054,7 @@ class Cli:
                 cmd.extend(args.search_terms)
 
             # Run search
-            self.logger.info(f"Running: {cmd}")
+            self.logger.info(f"Running: {redact_credentials(cmd)}")
             output = safely_run_save_output(cmd, Settings.qt_installer_timeout)
 
             if output.stdout:

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -1053,6 +1053,7 @@ class Cli:
                 cmd.extend(args.search_terms)
 
             # Run search
+            self.logger.info(f"Running: {cmd}")
             output = safely_run_save_output(cmd, Settings.qt_installer_timeout)
 
             if output.stdout:


### PR DESCRIPTION
For better debugging! This is for "list-qt-official".

Existing log lines:

- https://github.com/miurahr/aqtinstall/blob/8d961e61720b3c06583517fbc68d57ec0a4e9f95/aqt/commercial.py#L154-L155
- https://github.com/miurahr/aqtinstall/blob/8d961e61720b3c06583517fbc68d57ec0a4e9f95/aqt/commercial.py#L386-L387

.