### PR TITLE
chore: Update `py7zr` dependency to `>=1.1.3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "defusedxml",
     "humanize",
     "patch-ng",
-    "py7zr>=0.22.0",
+    "py7zr>=1.1.3",
     "requests>=2.31.0",
     "semantic-version",
     "texttable",


### PR DESCRIPTION
There are the fixes for multiple vulnerabilities in py7zr@1.1.3
