### PR TITLE
refactor: migrate from Flake8 to Ruff for linting and enforce modern code formatting standards

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 125
-exclude = .git,__pycache__,docs/conf.py,build,dist,tmp,venv
-extend-ignore = E203, W50

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -65,9 +65,7 @@ class QtPackage:
     def __str__(self):
         v_info = f", version={self.version}" if self.version else ""
         return (
-            f"QtPackage(name={self.name}, url={self.archive_path}, "
-            f"archive={self.archive}, desc={self.package_desc}"
-            f"{v_info})"
+            f"QtPackage(name={self.name}, url={self.archive_path}, archive={self.archive}, desc={self.package_desc}{v_info})"
         )
 
 

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -376,7 +376,6 @@ class Cli:
             arch = self._set_arch(args.arch, os_name, target, qt_version)
 
         if hasattr(args, "use_official_installer") and args.use_official_installer is not None:
-
             if len(args.use_official_installer) not in [0, 2]:
                 raise CliInputError(
                     "When providing arguments to --use-official-installer, exactly 2 arguments are required: "
@@ -666,7 +665,6 @@ class Cli:
         """Print versions of Qt, extensions, modules, architectures"""
 
         if hasattr(args, "use_official_installer") and args.use_official_installer is not None:
-
             if len(args.use_official_installer) not in [0, 2]:
                 raise CliInputError(
                     "When providing arguments to --use-official-installer, exactly 2 arguments are required: "
@@ -1311,7 +1309,7 @@ class Cli:
             "-b",
             "--base",
             nargs="?",
-            help="Specify mirror base url such as http://mirrors.ocf.berkeley.edu/qt/, " "where 'online' folder exist.",
+            help="Specify mirror base url such as http://mirrors.ocf.berkeley.edu/qt/, where 'online' folder exist.",
         )
         subparser.add_argument(
             "--timeout",

--- a/ci/generate_azure_pipelines_matrices.py
+++ b/ci/generate_azure_pipelines_matrices.py
@@ -1,6 +1,7 @@
 """
 This sets variables for a matrix of QT versions to test downloading against with Azure Pipelines
 """
+
 import collections
 import json
 import re
@@ -15,7 +16,6 @@ MIRRORS = [
 
 
 class BuildJob:
-
     EMSDK_FOR_QT = {
         "6.2": "2.0.14",
         "6.3": "3.0.0",
@@ -69,21 +69,21 @@ class BuildJob:
         self.emsdk_version = emsdk_version
         self.autodesk_arch_folder = autodesk_arch_folder
 
-    def qt_bindir(self, *, sep='/') -> str:
+    def qt_bindir(self, *, sep="/") -> str:
         out_dir = f"$(Build.BinariesDirectory){sep}Qt" if not self.output_dir else self.output_dir
         version_dir = self.qt_version
         return f"{out_dir}{sep}{version_dir}{sep}{self.archdir}{sep}bin"
 
     def win_qt_bindir(self) -> str:
-        return self.qt_bindir(sep='\\')
+        return self.qt_bindir(sep="\\")
 
-    def autodesk_qt_bindir(self, *, sep='/') -> str:
+    def autodesk_qt_bindir(self, *, sep="/") -> str:
         out_dir = f"$(Build.BinariesDirectory){sep}Qt" if not self.output_dir else self.output_dir
         version_dir = self.qt_version
         return f"{out_dir}{sep}{version_dir}{sep}{self.autodesk_arch_folder or self.archdir}{sep}bin"
 
     def win_autodesk_qt_bindir(self) -> str:
-        return self.autodesk_qt_bindir(sep='\\')
+        return self.autodesk_qt_bindir(sep="\\")
 
     def mingw_folder(self) -> str:
         """
@@ -97,9 +97,9 @@ class BuildJob:
         if not self.mingw_variant:
             return ""
         match = re.match(r"^win(?P<bits>\d+)_(?P<llvm>llvm_)?(?P<mingw>mingw\d+)$", self.mingw_variant)
-        if match.group('llvm'):
+        if match.group("llvm"):
             return f"llvm-{match.group('mingw')}_{match.group('bits')}"
-        if match.group('mingw') == "mingw900":  # tool contains mingw 11.2.0, not 9.0.0
+        if match.group("mingw") == "mingw900":  # tool contains mingw 11.2.0, not 9.0.0
             return f"mingw1120_{match.group('bits')}"
         return f"{match.group('mingw')}_{match.group('bits')}"
 
@@ -156,24 +156,23 @@ all_platform_build_jobs = [
 
 # Linux Desktop
 for qt_version in qt_versions:
-    linux_build_jobs.append(
-        BuildJob("install-qt", qt_version, "linux", "desktop", "linux_gcc_64", "gcc_64")
-    )
+    linux_build_jobs.append(BuildJob("install-qt", qt_version, "linux", "desktop", "linux_gcc_64", "gcc_64"))
 linux_arm64_build_jobs.append(BuildJob("install-qt", "6.7.0", "linux_arm64", "desktop", "linux_gcc_arm64", "gcc_arm64"))
 
 # Mac Desktop
 for qt_version in qt_versions:
-    mac_build_jobs.append(
-        BuildJob("install-qt", qt_version, "mac", "desktop", "clang_64", "macos")
+    mac_build_jobs.append(BuildJob("install-qt", qt_version, "mac", "desktop", "clang_64", "macos"))
+mac_build_jobs.append(
+    BuildJob(
+        "install-qt",
+        "6.2.0",
+        "mac",
+        "desktop",
+        "clang_64",
+        "macos",
+        module="qtcharts qtnetworkauth",
     )
-mac_build_jobs.append(BuildJob(
-    "install-qt",
-    "6.2.0",
-    "mac",
-    "desktop",
-    "clang_64",
-    "macos",
-    module="qtcharts qtnetworkauth", ))
+)
 
 # Windows Desktop
 for qt_version in qt_versions:
@@ -201,7 +200,13 @@ windows_build_jobs.extend(
         ),
         BuildJob(
             # Archives stored as .zip
-            "install-src", "6.4.3", "windows", "desktop", "gcc_64", "gcc_64", subarchives="qtlottie",
+            "install-src",
+            "6.4.3",
+            "windows",
+            "desktop",
+            "gcc_64",
+            "gcc_64",
+            subarchives="qtlottie",
             # Fail the job if this path does not exist:
             check_output_cmd="ls -lh ./6.4.3/Src/qtlottie/",
         ),
@@ -213,42 +218,75 @@ linux_build_jobs.extend(
     [
         BuildJob(
             # Archives stored as .7z
-            "install-src", "6.1.0", "linux", "desktop", "gcc_64", "gcc_64", subarchives="qtlottie",
+            "install-src",
+            "6.1.0",
+            "linux",
+            "desktop",
+            "gcc_64",
+            "gcc_64",
+            subarchives="qtlottie",
             # Fail the job if this path does not exist:
             check_output_cmd="ls -lh ./6.1.0/Src/qtlottie/",
         ),
         BuildJob(
             # Archives stored as .tar.gz
-            "install-src", "6.4.3", "linux", "desktop", "gcc_64", "gcc_64", subarchives="qtlottie",
+            "install-src",
+            "6.4.3",
+            "linux",
+            "desktop",
+            "gcc_64",
+            "gcc_64",
+            subarchives="qtlottie",
             # Fail the job if this path does not exist:
             check_output_cmd="ls -lh ./6.4.3/Src/qtlottie/",
         ),
         # Should install the `qtlottie` module, even though the archive `qtlottieanimation` is not specified:
         BuildJob(
-            "install-doc", "6.1.3", "linux", "desktop", "gcc_64", "gcc_64",
-            subarchives="qtdoc", module="qtlottie",
+            "install-doc",
+            "6.1.3",
+            "linux",
+            "desktop",
+            "gcc_64",
+            "gcc_64",
+            subarchives="qtdoc",
+            module="qtlottie",
             # Fail the job if these paths do not exist:
             check_output_cmd="ls -lh ./Docs/Qt-6.1.3/qtdoc/ ./Docs/Qt-6.1.3/qtlottieanimation/",
         ),
         # Should install the `qtcharts` module, even though the archive `qtcharts` is not specified:
         BuildJob(
-            "install-example", "6.1.3", "linux", "desktop", "gcc_64", "gcc_64",
-            subarchives="qtdoc", module="qtcharts",
+            "install-example",
+            "6.1.3",
+            "linux",
+            "desktop",
+            "gcc_64",
+            "gcc_64",
+            subarchives="qtdoc",
+            module="qtcharts",
             # Fail the job if these paths do not exist:
-            check_output_cmd="ls -lh ./Examples/Qt-6.1.3/charts/ ./Examples/Qt-6.1.3/demos/ "
-                             "./Examples/Qt-6.1.3/tutorials/",
+            check_output_cmd="ls -lh ./Examples/Qt-6.1.3/charts/ ./Examples/Qt-6.1.3/demos/ ./Examples/Qt-6.1.3/tutorials/",
         ),
         # test for list commands
-        BuildJob('list-qt', '6.1.0', 'linux', 'desktop', 'gcc_64', '', spec=">6.0,<6.1.1",
-                 list_options={'HAS_WASM': "False"}),
-        BuildJob('list-qt', '6.1.0', 'linux', 'android', 'android_armv7', '', spec=">6.0,<6.1.1", list_options={}),
+        BuildJob(
+            "list-qt", "6.1.0", "linux", "desktop", "gcc_64", "", spec=">6.0,<6.1.1", list_options={"HAS_WASM": "False"}
+        ),
+        BuildJob("list-qt", "6.1.0", "linux", "android", "android_armv7", "", spec=">6.0,<6.1.1", list_options={}),
     ]
 )
 
 # WASM
 linux_build_jobs.append(
-    BuildJob("install-qt", "6.4.0", "linux", "desktop", "wasm_32", "wasm_32",
-             is_autodesktop=True, emsdk_version="sdk-3.1.14-64bit", autodesk_arch_folder="gcc_64")
+    BuildJob(
+        "install-qt",
+        "6.4.0",
+        "linux",
+        "desktop",
+        "wasm_32",
+        "wasm_32",
+        is_autodesktop=True,
+        emsdk_version="sdk-3.1.14-64bit",
+        autodesk_arch_folder="gcc_64",
+    )
 )
 for job_queue, host, desk_arch in (
     (linux_build_jobs, "linux", "gcc_64"),
@@ -257,24 +295,59 @@ for job_queue, host, desk_arch in (
 ):
     for wasm_arch in ("wasm_singlethread", "wasm_multithread"):
         job_queue.append(
-            BuildJob("install-qt", "6.5.0", host, "desktop", wasm_arch, wasm_arch,
-                     is_autodesktop=True, emsdk_version="sdk-3.1.25-64bit", autodesk_arch_folder=desk_arch)
+            BuildJob(
+                "install-qt",
+                "6.5.0",
+                host,
+                "desktop",
+                wasm_arch,
+                wasm_arch,
+                is_autodesktop=True,
+                emsdk_version="sdk-3.1.25-64bit",
+                autodesk_arch_folder=desk_arch,
+            )
         )
 mac_build_jobs.append(
-    BuildJob("install-qt", "6.4.3", "mac", "desktop", "wasm_32", "wasm_32",
-             is_autodesktop=True, emsdk_version="sdk-3.1.14-64bit", autodesk_arch_folder="clang_64")
+    BuildJob(
+        "install-qt",
+        "6.4.3",
+        "mac",
+        "desktop",
+        "wasm_32",
+        "wasm_32",
+        is_autodesktop=True,
+        emsdk_version="sdk-3.1.14-64bit",
+        autodesk_arch_folder="clang_64",
+    )
 )
 windows_build_jobs.append(
-    BuildJob("install-qt", "6.4.3", "windows", "desktop", "wasm_32", "wasm_32",
-             is_autodesktop=True, emsdk_version="sdk-3.1.14-64bit", autodesk_arch_folder="mingw_64",
-             mingw_variant="win64_mingw900")
+    BuildJob(
+        "install-qt",
+        "6.4.3",
+        "windows",
+        "desktop",
+        "wasm_32",
+        "wasm_32",
+        is_autodesktop=True,
+        emsdk_version="sdk-3.1.14-64bit",
+        autodesk_arch_folder="mingw_64",
+        mingw_variant="win64_mingw900",
+    )
 )
 
 # WASM post 6.7.x
 linux_build_jobs.append(
-    BuildJob("install-qt", "6.7.3", "all_os", "wasm", "wasm_multithread", "wasm_multithread",
-             is_autodesktop=True, emsdk_version=f"sdk-{BuildJob.emsdk_version_for_qt("6.7.3")}-64bit",
-             autodesk_arch_folder="gcc_64")
+    BuildJob(
+        "install-qt",
+        "6.7.3",
+        "all_os",
+        "wasm",
+        "wasm_multithread",
+        "wasm_multithread",
+        is_autodesktop=True,
+        emsdk_version=f"sdk-{BuildJob.emsdk_version_for_qt('6.7.3')}-64bit",
+        autodesk_arch_folder="gcc_64",
+    )
 )
 for job_queue, host, desk_arch, target, qt_version in (
     (linux_build_jobs, "all_os", "linux_gcc_64", "wasm", qt_versions[0]),
@@ -283,9 +356,17 @@ for job_queue, host, desk_arch, target, qt_version in (
 ):
     for wasm_arch in ("wasm_singlethread", "wasm_multithread"):
         job_queue.append(
-            BuildJob("install-qt", qt_version, host, target, wasm_arch, wasm_arch,
-                     is_autodesktop=True, emsdk_version=f"sdk-{BuildJob.emsdk_version_for_qt(qt_version)}-64bit",
-                     autodesk_arch_folder=desk_arch)
+            BuildJob(
+                "install-qt",
+                qt_version,
+                host,
+                target,
+                wasm_arch,
+                wasm_arch,
+                is_autodesktop=True,
+                emsdk_version=f"sdk-{BuildJob.emsdk_version_for_qt(qt_version)}-64bit",
+                autodesk_arch_folder=desk_arch,
+            )
         )
 
 # mobile SDK
@@ -329,41 +410,28 @@ tool_options_mac = {
     "TEST_TOOL1_CMD": f'"{qt_creator_mac_bin_path}qbs" --version',
     "LIST_TOOL1_CMD": f'ls "{qt_creator_mac_bin_path}"',
 }
-windows_build_jobs.append(
-    BuildJob("install-tool", "", "windows", "desktop", "", "", tool_options=tool_options)
-)
-linux_build_jobs.append(
-    BuildJob("install-tool", "", "linux", "desktop", "", "", tool_options=tool_options)
-)
-mac_build_jobs.append(
-    BuildJob("install-tool", "", "mac", "desktop", "", "", tool_options=tool_options_mac)
-)
+windows_build_jobs.append(BuildJob("install-tool", "", "windows", "desktop", "", "", tool_options=tool_options))
+linux_build_jobs.append(BuildJob("install-tool", "", "linux", "desktop", "", "", tool_options=tool_options))
+mac_build_jobs.append(BuildJob("install-tool", "", "mac", "desktop", "", "", tool_options=tool_options_mac))
 
 # Commercial
 windows_build_jobs.append(
-    BuildJob("install-qt-official", "6.8.1", "windows", "desktop", "win64_msvc2022_64",
-             "win64_msvc2022_64", module="qtquick3d")
+    BuildJob(
+        "install-qt-official", "6.8.1", "windows", "desktop", "win64_msvc2022_64", "win64_msvc2022_64", module="qtquick3d"
+    )
 )
 linux_build_jobs.append(
-    BuildJob("install-qt-official", "6.8.1", "linux", "desktop", "linux_gcc_64",
-             "linux_gcc_64", module="qtquick3d")
+    BuildJob("install-qt-official", "6.8.1", "linux", "desktop", "linux_gcc_64", "linux_gcc_64", module="qtquick3d")
 )
-mac_build_jobs.append(
-    BuildJob("install-qt-official", "6.8.1", "mac", "desktop", "clang_64", "clang_64",
-             module="qtquick3d")
-)
+mac_build_jobs.append(BuildJob("install-qt-official", "6.8.1", "mac", "desktop", "clang_64", "clang_64", module="qtquick3d"))
 
 matrices = {}
 
 for platform_build_job in all_platform_build_jobs:
     matrix_dictionary = collections.OrderedDict()
 
-    for build_job, python_version in product(
-        platform_build_job.build_jobs, python_versions
-    ):
-        key = "{} {} {} for {}".format(
-            build_job.command, build_job.qt_version, build_job.arch, build_job.target
-        )
+    for build_job, python_version in product(platform_build_job.build_jobs, python_versions):
+        key = "{} {} {} for {}".format(build_job.command, build_job.qt_version, build_job.arch, build_job.target)
         if build_job.spec:
             key = '{} (spec="{}")'.format(key, build_job.spec)
         if build_job.module:
@@ -393,8 +461,8 @@ for platform_build_job in all_platform_build_jobs:
                 ("OUTPUT_DIR", build_job.output_dir if build_job.output_dir else ""),
                 ("QT_BINDIR", build_job.qt_bindir()),
                 ("WIN_QT_BINDIR", build_job.win_qt_bindir()),
-                ("EMSDK_VERSION", (build_job.emsdk_version + "@main").split('@')[0]),
-                ("EMSDK_TAG", (build_job.emsdk_version + "@main").split('@')[1]),
+                ("EMSDK_VERSION", (build_job.emsdk_version + "@main").split("@")[0]),
+                ("EMSDK_TAG", (build_job.emsdk_version + "@main").split("@")[1]),
                 ("WIN_AUTODESK_QT_BINDIR", build_job.win_autodesk_qt_bindir()),
                 ("TOOL1_ARGS", build_job.tool_options.get("TOOL1_ARGS", "")),
                 ("LIST_TOOL1_CMD", build_job.tool_options.get("LIST_TOOL1_CMD", "")),
@@ -402,22 +470,14 @@ for platform_build_job in all_platform_build_jobs:
                 ("TOOL2_ARGS", build_job.tool_options.get("TOOL2_ARGS", "")),
                 ("LIST_TOOL2_CMD", build_job.tool_options.get("LIST_TOOL2_CMD", "")),
                 ("TEST_TOOL2_CMD", build_job.tool_options.get("TEST_TOOL2_CMD", "")),
-                ("CHECK_OUTPUT_CMD", build_job.check_output_cmd or "")
+                ("CHECK_OUTPUT_CMD", build_job.check_output_cmd or ""),
             ]
         )
 
     matrices[platform_build_job.platform] = matrix_dictionary
 
 print("Setting Variables below")
-print(
-    f"##vso[task.setVariable variable=linux;isOutput=true]{json.dumps(matrices['linux'])}"
-)
-print(
-    f"##vso[task.setVariable variable=linux_arm64;isOutput=true]{json.dumps(matrices['linux_arm64'])}"
-)
-print(
-    f"##vso[task.setVariable variable=windows;isOutput=true]{json.dumps(matrices['windows'])}"
-)
-print(
-    f"##vso[task.setVariable variable=mac;isOutput=true]{json.dumps(matrices['mac'])}"
-)
+print(f"##vso[task.setVariable variable=linux;isOutput=true]{json.dumps(matrices['linux'])}")
+print(f"##vso[task.setVariable variable=linux_arm64;isOutput=true]{json.dumps(matrices['linux_arm64'])}")
+print(f"##vso[task.setVariable variable=windows;isOutput=true]{json.dumps(matrices['windows'])}")
+print(f"##vso[task.setVariable variable=mac;isOutput=true]{json.dumps(matrices['mac'])}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,8 +203,8 @@ commands = [["python", "-m", "pytest", "-vv"]]
 extras = ["check"]
 commands = [
     ["check-manifest", "{toxinidir}"],
-    ["ruff", "check", "aqt", "tests"],
-    ["ruff", "format", "--check", "aqt", "tests"],
+    ["ruff", "check", "aqt", "tests", "ci", "tools"],
+    ["ruff", "format", "--check", "aqt", "tests", "ci", "tools"],
 ]
 
 [tool.tox.env.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ test = [
 check = [
     "mypy>=1.10.0",
     "ruff>=0.6.0",
-    "black",
     "docutils",
     "check-manifest",
     "readme-renderer",
@@ -108,10 +107,6 @@ exclude_lines = ["if __name__ == .__main__.:", "pragma: no-cover", "@abstract", 
 
 [tool.pylint]
 max-line-length = 125
-
-[tool.black]
-line-length = 125
-target-version = ['py314']
 
 [tool.ruff]
 line-length = 125
@@ -209,7 +204,7 @@ extras = ["check"]
 commands = [
     ["check-manifest", "{toxinidir}"],
     ["ruff", "check", "aqt", "tests"],
-    ["black", "--check", "aqt", "tests"],
+    ["ruff", "format", "--check", "aqt", "tests"],
 ]
 
 [tool.tox.env.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ aqt = "aqt.__main__:main"
 [project.optional-dependencies]
 test = [
     "pytest>=6.0",
-    "pytest-pep8",
     "pytest-cov",
     "pytest-remotedata>=0.4.1",
     "pytest-socket",
@@ -57,12 +56,8 @@ test = [
 ]
 check = [
     "mypy>=1.10.0",
-    "flake8>=6.0.0,<8.0.0",
-    "flake8-black",
-    "flake8-colors",
-    "flake8-isort>=6.0.0,<7.0.0",
-    "flake8-pyi",
-    "flake8-typing-imports",
+    "ruff>=0.6.0",
+    "black",
     "docutils",
     "check-manifest",
     "readme-renderer",
@@ -118,15 +113,20 @@ max-line-length = 125
 line-length = 125
 target-version = ['py314']
 
-[tool.isort]
-line_length = 125
-known_first_party = "aqt"
-known_third_party = ["docutils", "flake8", "pyannotate_runtime", "pytest", "pytz", "requests", "setuptools", "sphinx", "yaml", "packaging"]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
+[tool.ruff]
+line-length = 125
+target-version = "py310"
+extend-exclude = ["docs/conf.py", "build", "dist", "tmp", "venv"]
+
+[tool.ruff.lint]
+# E/W: pycodestyle, F: pyflakes, I: isort, PYI: flake8-pyi
+select = ["E", "W", "F", "I", "PYI"]
+# E203: whitespace before ':' (conflicts with black slice formatting)
+ignore = ["E203"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["aqt"]
+known-third-party = ["docutils", "flake8", "pyannotate_runtime", "pytest", "pytz", "requests", "setuptools", "sphinx", "yaml", "packaging"]
 
 [tool.mypy]
 # Untyped definitions and calls are disable in default
@@ -206,7 +206,11 @@ commands = [["python", "-m", "pytest", "-vv"]]
 
 [tool.tox.env.check]
 extras = ["check"]
-commands = [["check-manifest", "{toxinidir}"], ["flake8", "aqt", "tests"]]
+commands = [
+    ["check-manifest", "{toxinidir}"],
+    ["ruff", "check", "aqt", "tests"],
+    ["black", "--check", "aqt", "tests"],
+]
 
 [tool.tox.env.mypy]
 extras = ["check"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -492,8 +492,8 @@ def test_get_autodesktop_dir_and_arch_non_android(
         if is_installed:
             assert any("Found installed" in line for line in err_lines), "Expected 'Found installed' message."
         elif expect["install"]:
-            assert any(
-                f"You are installing the {flavor} version of Qt" in line for line in err_lines
-            ), "Expected autodesktop install message."
+            assert any(f"You are installing the {flavor} version of Qt" in line for line in err_lines), (
+                "Expected autodesktop install message."
+            )
         elif expect["instruct"]:
             assert any("You can install" in line for line in err_lines), "Expected install instruction message."

--- a/tests/test_commercial.py
+++ b/tests/test_commercial.py
@@ -237,7 +237,7 @@ def test_get_install_command(monkeypatch, modules: Optional[List[str]], expected
     "cmd, arch_dict, details, expected_command",
     [
         (
-            "install-qt-official desktop {} 6.8.1 " "--outputdir ./install-qt-official --email {} --pw {}",
+            "install-qt-official desktop {} 6.8.1 --outputdir ./install-qt-official --email {} --pw {}",
             {"windows": "win64_msvc2022_64", "linux": "linux_gcc_64", "mac": "clang_64"},
             ["./install-qt-official", "qt6", "681"],
             "qt-unified-{}-x64-online.run --email ******** --pw ******** --root {} "
@@ -314,8 +314,7 @@ def test_install_qt_commercial(
 
     # Create a new command with the temp directory
     new_cmd = (
-        f"install-qt-official desktop {arch} 6.8.{str(details[2])[-1]} --outputdir {abs_out} --email {email} "
-        f"--pw {password}"
+        f"install-qt-official desktop {arch} 6.8.{str(details[2])[-1]} --outputdir {abs_out} --email {email} --pw {password}"
     )
 
     # This should raise DiskAccessNotPermitted only for the first test (680)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -22,7 +22,8 @@ def test_cli_unknown_version(capsys):
     Expected result when no redirect occurs:
 
     INFO    : aqtinstall(aqt) v.* on Python 3.*
-    WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml'. This may happen on unofficial mirrors.
+    WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml'.
+              This may happen on unofficial mirrors.
     ERROR   : Failed to locate XML data for Qt version '5.16.0'.
     ==============================Suggested follow-up:==============================
     * Please use 'aqt list-qt mac desktop' to show versions available.
@@ -31,14 +32,17 @@ def test_cli_unknown_version(capsys):
 
     INFO    : aqtinstall(aqt) v.* on Python 3.*
     WARNING : Connection to 'https://download.qt.io' failed. Retrying with fallback '.*'.
-    WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml'. This may happen on unofficial mirrors.
+    WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/qt5_5160/Updates.xml'.
+              This may happen on unofficial mirrors.
     ERROR   : Failed to locate XML data for Qt version '5.16.0'.
     """
 
     matcher = re.compile(
         r"[^\n]*aqtinstall\(aqt\) v.* on Python 3.*\n"
         r"(?:WARNING : Connection to 'https://download.qt.io' failed. Retrying with fallback '.*'.\n)?"
-        rf"WARNING : Failed to download checksum for the file 'online/qtsdkrepository/mac_x64/desktop/{wrong_version_str}/Updates.xml'. This may happen on unofficial mirrors.\n"
+        rf"WARNING : Failed to download checksum for the file "
+        rf"'online/qtsdkrepository/mac_x64/desktop/{wrong_version_str}/Updates.xml'. "
+        r"This may happen on unofficial mirrors.\n"
         rf".*Failed to locate XML data for Qt version '{re.escape(wrong_version)}'\.\n"
         r"==============================Suggested follow-up:==============================\n"
         r"\* Please use 'aqt list-qt mac desktop' to show versions available\.\n",

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -225,7 +225,7 @@ def test_helper_retry_on_error(num_attempts_before_success, num_retries_allowed)
     if num_attempts_before_success > num_retries_allowed:
         with pytest.raises(RuntimeError) as e:
             retry_on_errors(action, (RuntimeError,), num_retries_allowed, "do something")
-        assert e.type == RuntimeError
+        assert e.type is RuntimeError
     else:
         assert retry_on_errors(action, (RuntimeError,), num_retries_allowed, "do something")
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -204,9 +204,9 @@ def make_mock_geturl_download_archive(
             <PackageUpdate>
              <Name>{archive.update_xml_name}</Name>
              <Version>{archive.version}-0-{archive.date.strftime("%Y%m%d%H%M")}</Version>
-             <Description>{getattr(archive, 'package_desc', 'none')}</Description>
+             <Description>{getattr(archive, "package_desc", "none")}</Description>
              <DownloadableArchives>{archive.filename_7z}</DownloadableArchives>
-             {'<Dependencies>qt.qt6.680.gcc_64</Dependencies>' if is_qt68_addon else ''}
+             {"<Dependencies>qt.qt6.680.gcc_64</Dependencies>" if is_qt68_addon else ""}
             </PackageUpdate>""")
 
     standard_xml = "<Updates>\n{}\n</Updates>".format(
@@ -382,10 +382,7 @@ def plain_qtbase_archive(update_xml_name: str, arch: str, host: str = "windows",
                 "QT_EDITION = Not OpenSource\n"
                 "QT_LICHECK = Not Empty\n"
                 "... blah blah blah ...\n",
-                patched_content="... blah blah blah ...\n"
-                "QT_EDITION = OpenSource\n"
-                "QT_LICHECK =\n"
-                "... blah blah blah ...\n",
+                patched_content="... blah blah blah ...\nQT_EDITION = OpenSource\nQT_LICHECK =\n... blah blah blah ...\n",
             ),
         ),
         should_install=should_install,
@@ -1314,9 +1311,7 @@ def tool_archive(host: str, tool_name: str, variant: str, date: datetime = datet
                             ),
                             PatchedFile(
                                 filename="bin/target_qt.conf",
-                                unpatched_content="... blah blah blah ...\n"
-                                "HostPrefix=../../\n"
-                                "... blah blah blah ...\n",
+                                unpatched_content="... blah blah blah ...\nHostPrefix=../../\n... blah blah blah ...\n",
                                 patched_content="... blah blah blah ...\n"
                                 "HostPrefix=../../msvc2022_64\n"
                                 "... blah blah blah ...\n",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -206,7 +206,7 @@ def make_mock_geturl_download_archive(
              <Version>{archive.version}-0-{archive.date.strftime("%Y%m%d%H%M")}</Version>
              <Description>{getattr(archive, 'package_desc', 'none')}</Description>
              <DownloadableArchives>{archive.filename_7z}</DownloadableArchives>
-             {f'<Dependencies>qt.qt6.680.gcc_64</Dependencies>' if is_qt68_addon else ''}
+             {'<Dependencies>qt.qt6.680.gcc_64</Dependencies>' if is_qt68_addon else ''}
             </PackageUpdate>""")
 
     standard_xml = "<Updates>\n{}\n</Updates>".format(

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -112,7 +112,7 @@ def test_versions(init_data, expect_str, expect_fmt, expect_flat, expect_last, e
 
     with pytest.raises(TypeError) as pytest_wrapped_e:
         format(versions, "x")
-    assert pytest_wrapped_e.type == TypeError
+    assert pytest_wrapped_e.type is TypeError
 
 
 @pytest.fixture
@@ -1305,7 +1305,7 @@ def test_select_default_mingw(monkeypatch, host: str, expected: Union[str, Excep
     if isinstance(expected, Exception):
         with pytest.raises(type(expected)) as e:
             MetadataFactory(ArchiveId("qt", host, "desktop")).fetch_default_desktop_arch(Version("1.2.3"))
-        assert e.type == type(expected)
+        assert e.type is type(expected)
     else:
         actual_arch = MetadataFactory(ArchiveId("qt", host, "desktop")).fetch_default_desktop_arch(Version("1.2.3"))
         assert actual_arch == expected

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -28,9 +28,9 @@ def test_get_semantic_version_valid(input_version, is_preview, expected):
         expected (Version): Expected semantic version output
     """
     result = get_semantic_version(input_version, is_preview)
-    assert (
-        result == expected
-    ), f"Failed for input '{input_version}' with is_preview={is_preview}. Expected '{expected}', but got '{result}'"
+    assert result == expected, (
+        f"Failed for input '{input_version}' with is_preview={is_preview}. Expected '{expected}', but got '{result}'"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tools/build_standalone.py
+++ b/tools/build_standalone.py
@@ -1,7 +1,7 @@
 import argparse
 import os
-import PyInstaller.__main__
 
+import PyInstaller.__main__
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/tools/build_standalone.py
+++ b/tools/build_standalone.py
@@ -12,20 +12,23 @@ if __name__ == "__main__":
     tools_dir = os.path.dirname(__file__)
     name = "aqt" if args.arch is None else "aqt_" + args.arch
     args = [
-        '--noconfirm',
-        '--onefile',
-        '--name', name,
-        '--paths', ".",
-        '--hidden-import', "aqt",
+        "--noconfirm",
+        "--onefile",
+        "--name",
+        name,
+        "--paths",
+        ".",
+        "--hidden-import",
+        "aqt",
     ]
 
     # Add data files
-    if os.name == 'nt':
+    if os.name == "nt":
         adddata_arg = "{src:s};aqt"
     else:
         adddata_arg = "{src:s}:aqt"
     for data in ["aqt/logging.ini", "aqt/settings.ini"]:
-        args.append('--add-data')
+        args.append("--add-data")
         args.append(adddata_arg.format(src=data))
     args.append(os.path.join(tools_dir, "launch_aqt.py"))
 

--- a/tools/launch_aqt.py
+++ b/tools/launch_aqt.py
@@ -1,7 +1,8 @@
 #!python.exe
-import aqt
 import re
 import sys
+
+import aqt
 
 if __name__ == "__main__":
     sys.argv[0] = re.sub(r"(-script\.pyw?|\.exe)?$", "", sys.argv[0])

--- a/tools/launch_aqt.py
+++ b/tools/launch_aqt.py
@@ -3,6 +3,6 @@ import aqt
 import re
 import sys
 
-if __name__ == '__main__':
-    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+if __name__ == "__main__":
+    sys.argv[0] = re.sub(r"(-script\.pyw?|\.exe)?$", "", sys.argv[0])
     sys.exit(aqt.main())


### PR DESCRIPTION

flake8-isort and flake8-pep8 lead linting error on Python 3.14.
This change the linting with modern ruff.