### PR TITLE
docs(readme): replace dead snyk.io badge with customized one

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Another Qt installer(aqt)
    :target: https://github.com/miurahr/aqtinstall/actions?query=workflow%3A%22Test+on+GH+actions+environment%22
 .. |coveralls| image:: https://coveralls.io/repos/github/miurahr/aqtinstall/badge.svg?branch=master
    :target: https://coveralls.io/github/miurahr/aqtinstall?branch=master
-.. |Package health| image:: https://snyk.io/advisor/python/aqtinstall/badge.svg
+.. |Package health| image:: https://img.shields.io/badge/visit-snyk.io-azure
   :target: https://snyk.io/advisor/python/aqtinstall
   :alt: aqtinstall
 


### PR DESCRIPTION
The badge service has been dead.

Ref: How to fix invalid GitHub badge link containing 404s, and paywall links https://support.snyk.io/s/question/0D5PU00001CHAvw0AH/how-to-fix-invalid-github-badge-link-containing-404s-and-paywall-links

Comparison:

| Before | After |
| - | - |
| ![aqtinstall](https://snyk.io/advisor/python/aqtinstall/badge.svg), should be 404 | ![aqtinstall](https://img.shields.io/badge/visit-snyk.io-azure), should be OK |

.