### PR TITLE
correct  documentation: rst syntax, spelling.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -166,18 +166,18 @@ trusted_mirrors:
     ``aqtinstall`` uses the SHA-256 algorithm to perform this check.
 
     Alternatively, you can set ``AQT_MIRRORS_TRUSTED_MIRRORS`` as an environment
-    variable, which will override any value in ``settings.iniˇ.
+    variable, which will override any value in ``settings.ini``.
 
 blacklist:
     It is a list of URL where is a problematic mirror site.
-    Some mirror sites ignore a connection from IP addresses out of their preffered one.
+    Some mirror sites ignore a connection from IP addresses outside of their preferred range.
     It will cause connection error or connection timeout.
     There are some known mirror sites in default.
     If you are not happy with the default sites,
     you can override them with custom settings.
 
     Alternatively, you can set ``AQT_MIRRORS_BLACKLIST`` as an environment
-    variable, which will override any value in ``settings.iniˇ.
+    variable, which will override any value in ``settings.ini``.
 
 fallbacks:
     It is a list of URL where is a good for access.
@@ -185,4 +185,4 @@ fallbacks:
     You can find a list of mirrors at: https://download.qt.io/static/mirrorlist/
 
     Alternatively, you can set ``AQT_MIRRORS_FALLBACKS`` as an environment
-    variable, which will override any value in ``settings.iniˇ.
+    variable, which will override any value in ``settings.ini``.


### PR DESCRIPTION
This fixes the following warnings when running tox:
.../aqtinstall/docs/configuration.rst:168: WARNING: Inline literal start-string without end-string. [docutils]
.../aqtinstall/docs/configuration.rst:179: WARNING: Inline literal start-string without end-string. [docutils]
.../aqtinstall/docs/configuration.rst:187: WARNING: Inline literal start-string without end-string. [docutils]