### PR TITLE
Correct `min_module_size` in settings example

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -22,7 +22,7 @@ A file is like as follows:
     print_stacktrace_on_error: False
     always_keep_archives: False
     archive_download_location: .
-    min_archive_size: 41
+    min_module_size: 41
 
     [requests]
     connection_timeout: 3.5


### PR DESCRIPTION
Just a tiny documentation tweak: it appears that the `min_module_size` setting was accidentally added as `min_archive_size` in the example settings, when the feature was first added in commit d6a6f797407183d83863cd4d53cbdc0d1e201062.